### PR TITLE
refactor: use file-id crate for rust stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +129,7 @@ version = "0.2.1"
 dependencies = [
  "chrono",
  "chrono-tz",
+ "file-id",
  "parking_lot",
  "rusqlite",
  "thiserror",
@@ -513,3 +523,77 @@ checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"

--- a/honker-core/Cargo.toml
+++ b/honker-core/Cargo.toml
@@ -17,6 +17,7 @@ name = "honker_core"
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+file-id = "0.2.3"
 parking_lot = "0.12.5"
 rusqlite = { version = "0.39.0", features = ["functions", "hooks"] }
 thiserror = "2.0.18"

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -374,27 +374,27 @@ impl Readers {
 /// `(volume_serial, file_index)` on Windows. Used to detect when the
 /// database file has been replaced underneath us (atomic rename,
 /// litestream restore, volume remount).
-#[cfg(unix)]
+///
+/// Uses the `file-id` crate for stable cross-platform implementation.
 fn stat_identity(path: &Path) -> std::io::Result<(u64, u64)> {
-    use std::os::unix::fs::MetadataExt;
-    let m = std::fs::metadata(path)?;
-    Ok((m.dev(), m.ino()))
-}
-
-#[cfg(windows)]
-fn stat_identity(path: &Path) -> std::io::Result<(u64, u64)> {
-    use std::os::windows::fs::MetadataExt;
-    let m = std::fs::metadata(path)?;
-    Ok((
-        m.volume_serial_number().unwrap_or(0) as u64,
-        m.file_index().unwrap_or(0),
-    ))
-}
-
-#[cfg(not(any(unix, windows)))]
-fn stat_identity(path: &Path) -> std::io::Result<(u64, u64)> {
-    let _ = path;
-    Ok((0, 0))
+    let id = file_id::get_file_id(path)?;
+    match id {
+        file_id::FileId::Inode {
+            device_id,
+            inode_number,
+        } => Ok((device_id, inode_number)),
+        file_id::FileId::LowRes {
+            volume_serial_number,
+            file_index,
+        } => Ok((volume_serial_number as u64, file_index)),
+        file_id::FileId::HighRes {
+            volume_serial_number,
+            file_id,
+        } => {
+            let file_index = (file_id & 0xFFFFFFFFFFFFFFFF) as u64;
+            Ok((volume_serial_number, file_index))
+        }
+    }
 }
 
 /// Read the pager's `data_version` counter via `PRAGMA data_version`.


### PR DESCRIPTION
Currently, under Windows, project can be complied using rust nightly version.

Use file-id can resolve this problem.