### PR TITLE
fix: address all file-id follow-ups (#8) — entropy + Windows CI + non-{unix,windows} fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # Windows job verifies the file-id integration on stable Rust
+        # (no nightly-only `windows_by_handle` feature). honker-core's
+        # rusqlite dep enables `bundled` on Windows so no system
+        # SQLite install is required on the runner.
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
+ "cc",
  "pkg-config",
  "prettyplease",
  "quote",

--- a/honker-core/Cargo.toml
+++ b/honker-core/Cargo.toml
@@ -31,8 +31,12 @@ file-id = "0.2.3"
 # build is self-contained. Linux / macOS keep the system-link path
 # they've used since 0.1 — adding `bundled` everywhere would add
 # ~150k lines of C to every fresh compile for no real win.
+#
+# Cargo unions feature sets across `[dependencies]` and target-cfg
+# blocks, so we only list what's added on Windows here. The Windows
+# resolved feature set is `["functions", "hooks", "bundled"]`.
 [target.'cfg(windows)'.dependencies]
-rusqlite = { version = "0.39.0", features = ["functions", "hooks", "bundled"] }
+rusqlite = { version = "0.39.0", features = ["bundled"] }
 
 [dev-dependencies]
 # chrono-tz only in tests — lets us exercise DST edge cases with a

--- a/honker-core/Cargo.toml
+++ b/honker-core/Cargo.toml
@@ -17,10 +17,22 @@ name = "honker_core"
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-file-id = "0.2.3"
 parking_lot = "0.12.5"
 rusqlite = { version = "0.39.0", features = ["functions", "hooks"] }
 thiserror = "2.0.18"
+
+# file-id only supports unix and windows. Other targets (WASI, Redox,
+# illumos, etc.) get the `(0, 0)` fallback in stat_identity.
+[target.'cfg(any(unix, windows))'.dependencies]
+file-id = "0.2.3"
+
+# On Windows, no system libsqlite3 is reliably present at link time
+# (no pkg-config; vcpkg setup varies). Bundle SQLite there so the
+# build is self-contained. Linux / macOS keep the system-link path
+# they've used since 0.1 — adding `bundled` everywhere would add
+# ~150k lines of C to every fresh compile for no real win.
+[target.'cfg(windows)'.dependencies]
+rusqlite = { version = "0.39.0", features = ["functions", "hooks", "bundled"] }
 
 [dev-dependencies]
 # chrono-tz only in tests — lets us exercise DST edge cases with a

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -375,7 +375,14 @@ impl Readers {
 /// database file has been replaced underneath us (atomic rename,
 /// litestream restore, volume remount).
 ///
-/// Uses the `file-id` crate for stable cross-platform implementation.
+/// Uses the `file-id` crate on unix and windows for stable Rust
+/// support without nightly features. Falls back to `(0, 0)` on other
+/// targets (WASI, Redox, illumos, etc.) — same behavior as the
+/// pre-`file-id` `#[cfg(not(any(unix, windows)))]` branch. Identity
+/// collisions disable replacement detection on those platforms but
+/// the watcher still functions; nobody is known to deploy honker
+/// there today.
+#[cfg(any(unix, windows))]
 fn stat_identity(path: &Path) -> std::io::Result<(u64, u64)> {
     let id = file_id::get_file_id(path)?;
     match id {
@@ -398,6 +405,11 @@ fn stat_identity(path: &Path) -> std::io::Result<(u64, u64)> {
             Ok((volume_serial_number, file_index))
         }
     }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn stat_identity(_path: &Path) -> std::io::Result<(u64, u64)> {
+    Ok((0, 0))
 }
 
 /// Read the pager's `data_version` counter via `PRAGMA data_version`.

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -391,7 +391,10 @@ fn stat_identity(path: &Path) -> std::io::Result<(u64, u64)> {
             volume_serial_number,
             file_id,
         } => {
-            let file_index = (file_id & 0xFFFFFFFFFFFFFFFF) as u64;
+            // ReFS file_ids are 128 bits and the upper 64 can be
+            // non-zero (NTFS leaves them at 0). XOR-fold so we keep
+            // entropy from both halves rather than truncating.
+            let file_index = ((file_id >> 64) as u64) ^ (file_id as u64);
             Ok((volume_serial_number, file_index))
         }
     }

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -378,10 +378,11 @@ impl Readers {
 /// Uses the `file-id` crate on unix and windows for stable Rust
 /// support without nightly features. Falls back to `(0, 0)` on other
 /// targets (WASI, Redox, illumos, etc.) — same behavior as the
-/// pre-`file-id` `#[cfg(not(any(unix, windows)))]` branch. Identity
-/// collisions disable replacement detection on those platforms but
-/// the watcher still functions; nobody is known to deploy honker
-/// there today.
+/// pre-`file-id` `#[cfg(not(any(unix, windows)))]` branch. On those
+/// targets the dead-man's switch is a no-op (every `stat_identity`
+/// returns `(0, 0)` so the equality check never trips); replacement
+/// detection is disabled but the watcher still functions. Nobody is
+/// known to deploy honker there today.
 #[cfg(any(unix, windows))]
 fn stat_identity(path: &Path) -> std::io::Result<(u64, u64)> {
     let id = file_id::get_file_id(path)?;
@@ -398,9 +399,13 @@ fn stat_identity(path: &Path) -> std::io::Result<(u64, u64)> {
             volume_serial_number,
             file_id,
         } => {
-            // ReFS file_ids are 128 bits and the upper 64 can be
-            // non-zero (NTFS leaves them at 0). XOR-fold so we keep
-            // entropy from both halves rather than truncating.
+            // ReFS file_ids are 128 bits; NTFS leaves the upper 64
+            // at 0. Either truncation or XOR-fold works in practice
+            // for "did this file get atomically renamed?" since ReFS
+            // file_ids change wholesale on rename. XOR-fold uses
+            // bits from both halves for symmetry; the practical
+            // collision probability is the same as truncation
+            // (~2⁻⁶⁴) and acceptable for this use.
             let file_index = ((file_id >> 64) as u64) ^ (file_id as u64);
             Ok((volume_serial_number, file_index))
         }
@@ -890,6 +895,10 @@ mod tests {
         let _ = std::fs::remove_file(&tmp);
     }
 
+    // Gate to platforms where stat_identity returns real values.
+    // On other targets the function returns (0, 0) for every call,
+    // so the assert_ne! below would fire.
+    #[cfg(any(unix, windows))]
     #[test]
     fn stat_identity_detects_file_replacement() {
         let tmp = std::env::temp_dir().join(format!(


### PR DESCRIPTION
_Authored by Claude (Anthropic's AI assistant) on @russellromney's behalf — addresses all four items from #8._

## Summary

Follow-up to PR #7 ([refactor: use file-id crate for rust stable](https://github.com/russellromney/honker/pull/7)). Closes #8.

**Two code-fix items (commit `d045e5a`):**

1. **`HighRes` arm now XOR-folds the 128-bit `file_id` instead of truncating.** NTFS leaves the upper 64 bits at 0 so truncation was lossless there, but [ReFS can populate the full 128 bits](https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_id_info) — XOR-folding keeps entropy from both halves. Same `(u64, u64)` return type, no API change.
2. **Drops the redundant `& 0xFFFFFFFFFFFFFFFF` mask** — `u128 as u64` already truncates.

**Two scope items (commit `6fd6952`):**

3. **Windows CI added to `rust-core` matrix.** This is the job that exercises `stat_identity_detects_file_replacement` and validates the file-id integration. Other jobs (rust-extension, python, node) involve shell scripts and napi-rs paths that aren't trivially Windows-portable; keeping Windows scope minimal here. To make Windows link without a system SQLite install, `honker-core/Cargo.toml` now enables the `bundled` rusqlite feature *only* on `cfg(windows)` — Linux / macOS keep their existing system-link path so we don't add ~150k lines of C compile to every binding's CI.
4. **`#[cfg(not(any(unix, windows)))]` fallback restored** — pre-PR #7 the code had a `(0, 0)` no-op for targets file-id doesn't cover (WASI, Redox, illumos, etc.). That fallback is back. `file-id` itself is now a target-conditional dep for the same reason.

## What's still not in this PR

Nothing from #8 — all four items are addressed.

## Test plan

- [x] `cargo build -p honker-core` on macOS — clean
- [x] `cargo test -p honker-core --lib` on macOS — all 23 tests pass, including `stat_identity_detects_file_replacement`
- [x] Windows verification — covered by new CI job once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
