### PR TITLE
docs: drop pre-1.0 cleanup sequence from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,6 @@ honker ships as a [Rust crate](https://crates.io/crates/honker) (`honker`, plus 
 
 > Experimental. API may change.
 
-## Pre-1.0 cleanup sequence
-
-Current cleanup order: land the green test-gap PR after small review
-cleanup, close the superseded `migrate-to-fcntl` PR, finish the
-`UpdateWatcher` rename across core and bindings, then split the
-remaining follow-ups into binding smoke CI, cross-binding interop,
-Windows fixes, and time-based watcher cadence. Completed roadmap work
-belongs in `CHANGELOG.md`; `ROADMAP.md` should stay future tense.
-
 SQLite is increasingly the database for shipped projects. Those inevitably require pubsub and a task queue. The usual answer is "add Redis + Celery." That works, but it introduces a second datastore with its own backup story, a dual-write problem between your business table and the queue, and the operational overhead of running a broker.
 
 honker takes the approach that if SQLite is the primary datastore, the queue should live in the same file. That means `INSERT INTO orders` and `queue.enqueue(...)` commit in the same transaction. Rollback drops both. The queue is just rows in a table with a partial index.


### PR DESCRIPTION
_Authored by Claude (Anthropic's AI assistant) on @russellromney's behalf._

Removes the "Pre-1.0 cleanup sequence" section that was added to the top of the README. Cleanup planning belongs in a project board (or PR descriptions), not the landing page someone hits when they're trying to figure out what honker *is*.

No other changes — just deletes the heading and its paragraph.