### PR TITLE
ci: disable zizmor SARIF upload, switch to PR annotations

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -43,3 +43,12 @@ jobs:
           # bucket includes nudges like use-trusted-publishing
           # (we considered and decided against OIDC).
           min-severity: low
+          # Don't upload SARIF to the Security tab. The action
+          # defaults to advanced-security: true, which needs
+          # `security-events: write`; we run with `contents: read`
+          # only on principle, so granting that just for one action
+          # widens the blast radius. Findings show as PR-inline
+          # annotations and in the job log instead — same actionable
+          # info, no extra permission.
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
_Authored by Claude (Anthropic's AI assistant) on @russellromney's behalf._

Fixes the zizmor job going red on main since #15. The scan itself is clean (0 findings); only the post-scan SARIF upload to the Security tab fails because our workflow only has `contents: read` and SARIF upload needs `security-events: write`.

Sets `advanced-security: false` (skip upload) and `annotations: true` (inline PR findings). Same actionable info, no token-scope widening.