### PR TITLE
fix(test): strip trailing CR in createLineReader for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ permissions:
 jobs:
   rust-core:
     name: rust · honker-core (lib tests)
-    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     timeout-minutes: 5
     runs-on: ${{ matrix.os }}
     strategy:
@@ -62,7 +61,6 @@ jobs:
           fi
 
   rust-core-debug:
-    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     # Release builds catch most regressions; debug builds catch a
     # different class — slightly different timing exposes races, and
     # debug-assertions catch arithmetic and bounds problems that
@@ -97,7 +95,6 @@ jobs:
           fi
 
   perf-regression:
-    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     # Run bench/wal_index_methods and assert mmap-shm is meaningfully
     # faster than PRAGMA. The threshold is intentionally loose (50×)
     # — observed delta is ~3000× on real hardware, so anything
@@ -139,7 +136,6 @@ jobs:
           "
 
   rust-extension:
-    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     name: rust · honker-extension (build)
     timeout-minutes: 5
     runs-on: ${{ matrix.os }}
@@ -208,7 +204,6 @@ jobs:
 
   python:
     name: python · honker
-    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     timeout-minutes: 5
     runs-on: ${{ matrix.os }}
     strategy:
@@ -283,12 +278,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # On the diag branch, only the failing windows × node-22 cell
-        # is interesting; everything else has been validated already
-        # (see PR #22 / phase 002). Restore the full matrix when the
-        # branch is deleted by reverting this commit.
-        os: ${{ (github.head_ref == 'claude/diag-windows-listener' || github.ref == 'refs/heads/claude/diag-windows-listener') && fromJSON('["windows-latest"]') || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
-        node-version: ${{ (github.head_ref == 'claude/diag-windows-listener' || github.ref == 'refs/heads/claude/diag-windows-listener') && fromJSON('["22"]') || fromJSON('["20", "22"]') }}
+        # Windows: enabled in #18, which adds Database.close() to the
+        # napi-rs binding so the writer/reader pools and watcher poll
+        # thread release their SQLite handles synchronously. Without
+        # it, basic.js cleanup hits "EBUSY: resource busy or locked,
+        # unlink" on the temp .db file — Windows mandatory locking
+        # rejects unlink while any handle is open. The cross-language
+        # Node tests spawn the repo venv's Python, so we branch on
+        # runner.os below for the venv path.
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: ["20", "22"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -350,7 +349,6 @@ jobs:
         run: node --test test/cross_lang_supporting.js
 
   binding-smoke:
-    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     name: binding smoke · ${{ matrix.name }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
@@ -435,7 +433,6 @@ jobs:
           mix test
 
   ruby-python-interop:
-    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     name: interop · ruby ↔ python
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   rust-core:
     name: rust · honker-core (lib tests)
+    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     timeout-minutes: 5
     runs-on: ${{ matrix.os }}
     strategy:
@@ -61,6 +62,7 @@ jobs:
           fi
 
   rust-core-debug:
+    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     # Release builds catch most regressions; debug builds catch a
     # different class — slightly different timing exposes races, and
     # debug-assertions catch arithmetic and bounds problems that
@@ -95,6 +97,7 @@ jobs:
           fi
 
   perf-regression:
+    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     # Run bench/wal_index_methods and assert mmap-shm is meaningfully
     # faster than PRAGMA. The threshold is intentionally loose (50×)
     # — observed delta is ~3000× on real hardware, so anything
@@ -136,6 +139,7 @@ jobs:
           "
 
   rust-extension:
+    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     name: rust · honker-extension (build)
     timeout-minutes: 5
     runs-on: ${{ matrix.os }}
@@ -204,6 +208,7 @@ jobs:
 
   python:
     name: python · honker
+    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     timeout-minutes: 5
     runs-on: ${{ matrix.os }}
     strategy:
@@ -278,16 +283,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Windows: enabled in #18, which adds Database.close() to the
-        # napi-rs binding so the writer/reader pools and watcher poll
-        # thread release their SQLite handles synchronously. Without
-        # it, basic.js cleanup hits "EBUSY: resource busy or locked,
-        # unlink" on the temp .db file — Windows mandatory locking
-        # rejects unlink while any handle is open. The cross-language
-        # Node tests spawn the repo venv's Python, so we branch on
-        # runner.os below for the venv path.
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: ["20", "22"]
+        # On the diag branch, only the failing windows × node-22 cell
+        # is interesting; everything else has been validated already
+        # (see PR #22 / phase 002). Restore the full matrix when the
+        # branch is deleted by reverting this commit.
+        os: ${{ (github.head_ref == 'claude/diag-windows-listener' || github.ref == 'refs/heads/claude/diag-windows-listener') && fromJSON('["windows-latest"]') || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
+        node-version: ${{ (github.head_ref == 'claude/diag-windows-listener' || github.ref == 'refs/heads/claude/diag-windows-listener') && fromJSON('["22"]') || fromJSON('["20", "22"]') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -349,6 +350,7 @@ jobs:
         run: node --test test/cross_lang_supporting.js
 
   binding-smoke:
+    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     name: binding smoke · ${{ matrix.name }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
@@ -433,6 +435,7 @@ jobs:
           mix test
 
   ruby-python-interop:
+    if: github.head_ref != 'claude/diag-windows-listener' && github.ref != 'refs/heads/claude/diag-windows-listener'
     name: interop · ruby ↔ python
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -549,6 +549,9 @@ impl UpdateWatcher {
         let handle = std::thread::Builder::new()
             .name("honker-update-poll".into())
             .spawn(move || {
+                // DIAG: trace watcher startup so CI tells us whether the
+                // poll thread actually launched on Windows.
+                eprintln!("[honker-diag] watcher thread starting, path={:?}", db_path);
                 let mut conn = match Connection::open_with_flags(
                     &db_path,
                     OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
@@ -563,6 +566,12 @@ impl UpdateWatcher {
                     .as_ref()
                     .and_then(|c| poll_data_version(c).ok())
                     .unwrap_or(0);
+                eprintln!(
+                    "[honker-diag] watcher initial data_version={} (conn={})",
+                    last_version,
+                    conn.is_some()
+                );
+                #[cfg(not(windows))]
                 let initial_identity = match stat_identity(&db_path) {
                     Ok(id) => id,
                     Err(e) => {
@@ -571,6 +580,7 @@ impl UpdateWatcher {
                     }
                 };
                 let mut tick: u64 = 0;
+                let mut diag_tick: u64 = 0;
 
                 while !stop_t.load(Ordering::Acquire) {
                     std::thread::sleep(Duration::from_millis(1));
@@ -580,6 +590,10 @@ impl UpdateWatcher {
                         match poll_data_version(c) {
                             Ok(version) => {
                                 if version != last_version {
+                                    eprintln!(
+                                        "[honker-diag] watcher: data_version {} -> {} (tick={})",
+                                        last_version, version, tick
+                                    );
                                     last_version = version;
                                     on_change();
                                 }
@@ -608,17 +622,20 @@ impl UpdateWatcher {
 
                     // Path 3: stat identity check (dead-man's switch).
                     //
-                    // Triggers on Linux/macOS scenarios that swap the
-                    // db file out from under us — atomic rename
-                    // (litestream restore), volume remount, NFS
-                    // server restart. On Windows the kernel rejects
+                    // Unix-only: catches atomic-rename / volume remount /
+                    // NFS server restart, all of which silently swap
+                    // the inode while existing handles point at the
+                    // orphaned old file. On Windows the kernel rejects
                     // rename-over-open even with `FILE_SHARE_DELETE`,
-                    // so the practical replacement scenarios that
-                    // trigger this on unix don't happen in the same
-                    // way; the dead-man's switch is effectively a
-                    // no-op on Windows. Identity check still runs,
-                    // it just rarely sees a difference.
+                    // so the scenario this defends against essentially
+                    // can't happen — and we've seen file-id flake on
+                    // Windows under unrelated conditions, so a
+                    // false-positive panic here would silently kill
+                    // the watcher thread and leave listeners stuck
+                    // waiting on an mpsc channel nobody sends on.
+                    // Skip the check entirely on Windows.
                     tick += 1;
+                    #[cfg(not(windows))]
                     if tick % 100 == 0 {
                         match stat_identity(&db_path) {
                             Ok(current) => {
@@ -643,7 +660,19 @@ impl UpdateWatcher {
                             }
                         }
                     }
+
+                    // DIAG: heartbeat every ~500ms so CI shows the
+                    // watcher is alive and what it's seeing. Suppress
+                    // initial-zero quiet to avoid log spam.
+                    diag_tick += 1;
+                    if diag_tick % 500 == 0 {
+                        eprintln!(
+                            "[honker-diag] watcher heartbeat: data_version={} tick={}",
+                            last_version, tick
+                        );
+                    }
                 }
+                eprintln!("[honker-diag] watcher thread exiting, last_version={}", last_version);
             })
             .expect("spawn update-poll thread");
         Self {

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -549,9 +549,6 @@ impl UpdateWatcher {
         let handle = std::thread::Builder::new()
             .name("honker-update-poll".into())
             .spawn(move || {
-                // DIAG: trace watcher startup so CI tells us whether the
-                // poll thread actually launched on Windows.
-                eprintln!("[honker-diag] watcher thread starting, path={:?}", db_path);
                 let mut conn = match Connection::open_with_flags(
                     &db_path,
                     OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
@@ -566,12 +563,6 @@ impl UpdateWatcher {
                     .as_ref()
                     .and_then(|c| poll_data_version(c).ok())
                     .unwrap_or(0);
-                eprintln!(
-                    "[honker-diag] watcher initial data_version={} (conn={})",
-                    last_version,
-                    conn.is_some()
-                );
-                #[cfg(not(windows))]
                 let initial_identity = match stat_identity(&db_path) {
                     Ok(id) => id,
                     Err(e) => {
@@ -580,7 +571,6 @@ impl UpdateWatcher {
                     }
                 };
                 let mut tick: u64 = 0;
-                let mut diag_tick: u64 = 0;
 
                 while !stop_t.load(Ordering::Acquire) {
                     std::thread::sleep(Duration::from_millis(1));
@@ -590,10 +580,6 @@ impl UpdateWatcher {
                         match poll_data_version(c) {
                             Ok(version) => {
                                 if version != last_version {
-                                    eprintln!(
-                                        "[honker-diag] watcher: data_version {} -> {} (tick={})",
-                                        last_version, version, tick
-                                    );
                                     last_version = version;
                                     on_change();
                                 }
@@ -622,20 +608,17 @@ impl UpdateWatcher {
 
                     // Path 3: stat identity check (dead-man's switch).
                     //
-                    // Unix-only: catches atomic-rename / volume remount /
-                    // NFS server restart, all of which silently swap
-                    // the inode while existing handles point at the
-                    // orphaned old file. On Windows the kernel rejects
+                    // Triggers on Linux/macOS scenarios that swap the
+                    // db file out from under us — atomic rename
+                    // (litestream restore), volume remount, NFS
+                    // server restart. On Windows the kernel rejects
                     // rename-over-open even with `FILE_SHARE_DELETE`,
-                    // so the scenario this defends against essentially
-                    // can't happen — and we've seen file-id flake on
-                    // Windows under unrelated conditions, so a
-                    // false-positive panic here would silently kill
-                    // the watcher thread and leave listeners stuck
-                    // waiting on an mpsc channel nobody sends on.
-                    // Skip the check entirely on Windows.
+                    // so the practical replacement scenarios that
+                    // trigger this on unix don't happen in the same
+                    // way; the dead-man's switch is effectively a
+                    // no-op on Windows. Identity check still runs,
+                    // it just rarely sees a difference.
                     tick += 1;
-                    #[cfg(not(windows))]
                     if tick % 100 == 0 {
                         match stat_identity(&db_path) {
                             Ok(current) => {
@@ -660,19 +643,7 @@ impl UpdateWatcher {
                             }
                         }
                     }
-
-                    // DIAG: heartbeat every ~500ms so CI shows the
-                    // watcher is alive and what it's seeing. Suppress
-                    // initial-zero quiet to avoid log spam.
-                    diag_tick += 1;
-                    if diag_tick % 500 == 0 {
-                        eprintln!(
-                            "[honker-diag] watcher heartbeat: data_version={} tick={}",
-                            last_version, tick
-                        );
-                    }
                 }
-                eprintln!("[honker-diag] watcher thread exiting, last_version={}", last_version);
             })
             .expect("spawn update-poll thread");
         Self {


### PR DESCRIPTION
## Summary

Closes #23. Closes the `node · honker-node (windows-latest, *)` cells of phase 002.

The Windows reverse-listener parity gap was a one-character bug in the test harness, not a Node-binding or SQLite issue.

`packages/honker-node/test/cross_lang_shared.js`'s `createLineReader` split the Python child's stdout on `\n` and delivered each line *including* the trailing carriage return. On Windows, Python's text-mode stdout writes `\r\n`, so the line came through as `"READY\r"`. The test then did `line === 'READY'` (strict equality), which never matched, so Node never proceeded past `await nextLineMatching('READY', 25000)`.

That meant Node never wrote any notifications. Python's listener was correctly observing nothing — the database really was untouched. The whole "data_version frozen at 2 / count=0 / cross-process WAL visibility broken on Windows" story fell out from there.

The other tests don't hit this:
- `cross_lang_python_to_node.js` uses `'inherit'` for stdout — Node never reads from the line reader.
- `cross_lang_supporting.js` uses `out.split(/\\r?\\n/)` and `startsWith('RESULT ')` — both tolerate CRLF.

## Fix

`cross_lang_shared.js`:
```js
let line = buf.slice(0, nl);
buf = buf.slice(nl + 1);
if (line.endsWith('\\r')) line = line.slice(0, -1);
```

That's the entire change. Net diff over `main`: one file, six lines.

## Diagnosis trail (so the breadcrumbs aren't lost)

The bug was found by instrumenting both sides of the test:
- A 500ms Python `[py-diag]` heartbeat showed Python kept seeing `data_version=2`, `count=0` for the full 20s window.
- A `[honker-diag]` watcher heartbeat in `honker-core` showed the watcher thread was alive and polling, also seeing `data_version=2`.
- Adding `[node-diag]` instrumentation after `await nextLineMatching('READY', ...)` produced **zero** output on Windows — the await never resolved.

That zero-output Node-side told us Node never saw `READY`. Two minutes of staring at `createLineReader` later: trailing CR.

The diagnostic instrumentation has been reverted; only the one-line fix remains.

## Test plan

- [x] `node --test test/cross_lang_node_to_python.js` passes locally on macOS
- [x] CI: `node · honker-node (windows-latest, 22)` ✅ pass (4m6s) — [run](https://github.com/russellromney/honker/actions/runs/25163706921/job/73764340473)
- [ ] Re-run full matrix on the cleaned-up branch to confirm no regressions on ubuntu / macos / py-to-node / supporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)