### PR TITLE
[codex] grug bring honker-dotnet

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,9 +90,74 @@ Tracked by issue #11:
 - Re-enable Windows for Node after the same close-path fix and after
   `cross_lang.js` stops hard-coding Unix venv paths.
 
+## Phase Ballmer — .NET C# Binding
+
+> After: Phase Submodule · Before: Phase Wake Parity
+
+Track issue #28 by adding an idiomatic .NET binding as a thin wrapper
+around the SQLite loadable extension. The intent is to let LLM-assisted
+porting do most of the mechanical work from the existing Go, Ruby,
+Node, and Rust binding patterns, while keeping human review focused on
+native packaging, cancellation semantics, and cross-platform behavior.
+
+### Shape
+
+- Create a standalone `honker-dotnet` / `Honker` package repo and pin it
+  here as a submodule once the first parity slice is usable.
+- Target modern .NET first, using `Microsoft.Data.Sqlite` as the default
+  managed SQLite layer.
+- Load `honker-extension` on each opened connection and call
+  `honker_bootstrap()` during `Honker.Database.Open(...)`.
+- Package native `honker-extension` binaries under NuGet
+  `runtimes/<rid>/native/` paths, with explicit resolver tests for
+  Linux, macOS, and Windows.
+- Prefer typed wrappers over a Rust/C ABI: `Database`, `Transaction`,
+  `Queue`, `Job`, `Stream`, `Scheduler`, `Lock`, and result helpers all
+  call `SELECT honker_*(...)`.
+
+### First parity slice
+
+- Queue enqueue / claim / ack / retry / fail / heartbeat.
+- `IAsyncEnumerable<Job>` claim loop with `CancellationToken`.
+- Deadline-aware worker sleep using `honker_queue_next_claim_at(queue)`.
+- Scheduler add / remove / tick / soonest / run.
+- Canonical `schedule` naming with `cron` kept as a compatibility alias.
+- `@every <n><unit>`, 6-field cron, and delayed `run_at` tests matching
+  PR #29 binding parity.
+
+### Follow-up parity
+
+- Durable streams with per-consumer offsets.
+- Ephemeral listen / notify once an update-event bridge exists.
+- Rate limits, locks, task results, and batch helpers.
+- EF Core recipe showing how to load the extension on an application
+  connection and enqueue inside an existing transaction.
+
+### Non-goals
+
+- Do not reimplement Honker queue or scheduler logic in C#.
+- Do not make .NET the source of truth for schema or SQL behavior.
+- Do not block the first package on full EF Core integration, AOT,
+  Unity, Xamarin, or mobile support.
+- Do not promise every binding surface in the first release; mark any
+  missing wrappers clearly and keep raw SQL access available.
+
+### Verification
+
+- .NET unit tests cover the same six must-pass queue cases as the other
+  bindings.
+- Cross-process delayed `run_at` and reclaim-deadline tests prove the
+  async worker does not wait for a fallback poll.
+- Scheduler tests prove `@every 1s`, 6-field cron, `schedule`, and
+  legacy `cron` alias behavior.
+- Cross-language interop test proves Python writes can be claimed by C#
+  and C# writes can be claimed by Python.
+- CI builds and tests on Linux, macOS, and Windows for the supported RIDs
+  included in the NuGet package.
+
 ## Phase Wake Parity — Binding Update Events
 
-> After: Phase Submodule · Before: Phase Cadence
+> After: Phase Ballmer · Before: Phase Cadence
 
 Make every maintained binding explicit about its wake/listen behavior,
 then converge them on the shared update-event semantics where the host


### PR DESCRIPTION
see #28

## why grug do this

github issue make c sharp noise.
grug first make plan.
then grug keep bonking rock until dotnet thing become real thing.

## what grug add

- Phase Ballmer in roadmap so tribe know c sharp path
- `honker-dotnet` package as thin wrapper over honker sqlite extension
- queue, listen, notify, stream, results, scheduler, locks, outbox, rate limit
- python-parity tests for wake race, stream replay/live, outbox retry/dead path, packaged native load
- dotnet CI on linux, mac, windows
- NuGet release workflow
- packaged-consumer smoke test so grug know restored app can really open db and run

## grug proof

- `cargo build --release -p honker-extension`
- `dotnet test packages/honker-dotnet/tests/Honker.Tests/Honker.Tests.csproj`
- `70` tests pass on `net8.0`
- `dotnet pack packages/honker-dotnet/src/Honker/Honker.csproj`
- restore packaged consumer and run `Database.Open()` with bundled native extension

## cave still dark in small corner

- first release workflow covers `linux-x64`, `osx-x64`, `osx-arm64`, `win-x64`
- `linux-arm64` and `win-arm64` still wait for future grug
