### PR TITLE
Add hard queue proof across processes and Go/Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,8 @@ jobs:
         run: cargo test --manifest-path packages/honker-rs/Cargo.toml
       - name: Go
         working-directory: packages/honker-go
+        env:
+          HONKER_INTEROP_PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: go test -tags sqlite_load_extension ./...
       - name: C++
         working-directory: packages/honker-cpp

--- a/packages/honker-go/python_interop_test.go
+++ b/packages/honker-go/python_interop_test.go
@@ -1,0 +1,234 @@
+package honker
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+}
+
+func findInteropPython(t *testing.T) string {
+	t.Helper()
+	repo := repoRoot(t)
+	if p := os.Getenv("HONKER_INTEROP_PYTHON"); p != "" {
+		cmd := exec.Command(p, "-c", "import honker")
+		cmd.Env = interopPythonEnv(t, "")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("HONKER_INTEROP_PYTHON cannot import honker: %v\n%s", err, string(out))
+		}
+		return p
+	}
+	candidates := []string{
+		filepath.Join(repo, ".venv", "bin", "python"),
+		filepath.Join(repo, ".venv", "Scripts", "python.exe"),
+		"python3",
+		"python",
+	}
+	for _, p := range candidates {
+		cmd := exec.Command(p, "-c", "import honker")
+		cmd.Env = interopPythonEnv(t, "")
+		if err := cmd.Run(); err == nil {
+			return p
+		}
+	}
+	t.Skipf(
+		"Python honker binding unavailable; build it first, or set HONKER_INTEROP_PYTHON. tried %v",
+		candidates,
+	)
+	return ""
+}
+
+func interopPythonEnv(t *testing.T, dbPath string) []string {
+	t.Helper()
+	repo := repoRoot(t)
+	paths := []string{
+		filepath.Join(repo, "packages", "honker", "python"),
+		filepath.Join(repo, "packages"),
+	}
+	env := os.Environ()
+	if old := os.Getenv("PYTHONPATH"); old != "" {
+		paths = append(paths, old)
+	}
+	env = append(env, "PYTHONPATH="+strings.Join(paths, string(os.PathListSeparator)))
+	if dbPath != "" {
+		env = append(env, "DB_PATH="+dbPath)
+	}
+	return env
+}
+
+func runInteropPython(t *testing.T, python string, dbPath string, script string) string {
+	t.Helper()
+	cmd := exec.Command(python, "-c", script)
+	cmd.Env = interopPythonEnv(t, dbPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("python interop failed: %v\n%s", err, string(out))
+	}
+	return string(out)
+}
+
+func TestGoPythonInteropQueueStreamAndNotify(t *testing.T) {
+	extPath := findExtension(t)
+	python := findInteropPython(t)
+	dbPath := filepath.Join(t.TempDir(), "go-python.db")
+
+	db, err := Open(dbPath, extPath)
+	if err != nil {
+		t.Fatalf("open go db: %v", err)
+	}
+	defer db.Close()
+
+	goQueue := db.Queue("go-to-python", QueueOptions{})
+	for i := 0; i < 25; i++ {
+		if _, err := goQueue.Enqueue(map[string]any{
+			"source": "go",
+			"seq":    i,
+			"key":    "go-" + string(rune('a'+i)),
+		}, EnqueueOptions{}); err != nil {
+			t.Fatalf("go enqueue %d: %v", i, err)
+		}
+	}
+	if _, err := db.Notify("from-go", map[string]any{"source": "go", "count": 25}); err != nil {
+		t.Fatalf("go notify: %v", err)
+	}
+	if _, err := db.Stream("interop").Publish(map[string]any{"source": "go", "kind": "stream"}); err != nil {
+		t.Fatalf("go stream publish: %v", err)
+	}
+
+	out := runInteropPython(t, python, dbPath, `
+import json
+import os
+import honker
+
+db = honker.open(os.environ["DB_PATH"])
+
+go_jobs = db.queue("go-to-python").claim_batch("python-worker", 50)
+go_payloads = [job.payload for job in go_jobs]
+acked = db.queue("go-to-python").ack_batch(
+    [job.id for job in go_jobs],
+    "python-worker",
+)
+
+go_note = db.query(
+    "SELECT payload FROM _honker_notifications "
+    "WHERE channel='from-go' ORDER BY id DESC LIMIT 1"
+)
+go_events = db.stream("interop")._read_since(0, 10)
+
+py_q = db.queue("python-to-go")
+for i in range(25):
+    py_q.enqueue({"source": "python", "seq": i, "key": f"py-{i:02d}"})
+with db.transaction() as tx:
+    tx.notify("from-python", {"source": "python", "count": len(go_jobs)})
+db.stream("interop").publish({"source": "python", "kind": "stream"})
+
+print(json.dumps({
+    "acked": acked,
+    "go_payloads": go_payloads,
+    "go_note": json.loads(go_note[0]["payload"]),
+    "go_events": [ev["payload"] for ev in go_events],
+}))
+`)
+
+	var pyObserved struct {
+		Acked      int64             `json:"acked"`
+		GoPayloads []map[string]any  `json:"go_payloads"`
+		GoNote     map[string]any    `json:"go_note"`
+		GoEvents   []json.RawMessage `json:"go_events"`
+	}
+	if err := json.Unmarshal([]byte(out), &pyObserved); err != nil {
+		t.Fatalf("unmarshal python output %q: %v", out, err)
+	}
+	if pyObserved.Acked != 25 {
+		t.Fatalf("python acked %d go jobs, want 25", pyObserved.Acked)
+	}
+	if len(pyObserved.GoPayloads) != 25 {
+		t.Fatalf("python claimed %d go jobs, want 25", len(pyObserved.GoPayloads))
+	}
+	goSeqs := make([]int, 0, 25)
+	for _, payload := range pyObserved.GoPayloads {
+		if payload["source"] != "go" {
+			t.Fatalf("unexpected go payload source: %#v", payload)
+		}
+		goSeqs = append(goSeqs, int(payload["seq"].(float64)))
+	}
+	sort.Ints(goSeqs)
+	for i, seq := range goSeqs {
+		if seq != i {
+			t.Fatalf("go seqs = %v, want 0..24", goSeqs)
+		}
+	}
+	if pyObserved.GoNote["source"] != "go" || int(pyObserved.GoNote["count"].(float64)) != 25 {
+		t.Fatalf("python saw wrong go notification: %#v", pyObserved.GoNote)
+	}
+	if len(pyObserved.GoEvents) != 1 {
+		t.Fatalf("python saw %d go stream events, want 1", len(pyObserved.GoEvents))
+	}
+
+	pyQueue := db.Queue("python-to-go", QueueOptions{})
+	pyJobs, err := pyQueue.ClaimBatch("go-worker", 50)
+	if err != nil {
+		t.Fatalf("go claim python jobs: %v", err)
+	}
+	if len(pyJobs) != 25 {
+		t.Fatalf("go claimed %d python jobs, want 25", len(pyJobs))
+	}
+	pySeqs := make([]int, 0, 25)
+	ids := make([]int64, 0, 25)
+	for _, job := range pyJobs {
+		ids = append(ids, job.ID)
+		var payload map[string]any
+		if err := json.Unmarshal(job.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal python job: %v", err)
+		}
+		if payload["source"] != "python" {
+			t.Fatalf("unexpected python payload source: %#v", payload)
+		}
+		pySeqs = append(pySeqs, int(payload["seq"].(float64)))
+	}
+	sort.Ints(pySeqs)
+	for i, seq := range pySeqs {
+		if seq != i {
+			t.Fatalf("python seqs = %v, want 0..24", pySeqs)
+		}
+	}
+	acked, err := pyQueue.AckBatch(ids, "go-worker")
+	if err != nil {
+		t.Fatalf("go ack python jobs: %v", err)
+	}
+	if acked != 25 {
+		t.Fatalf("go acked %d python jobs, want 25", acked)
+	}
+
+	var notePayload string
+	if err := db.Raw().QueryRow(
+		"SELECT payload FROM _honker_notifications WHERE channel='from-python' ORDER BY id DESC LIMIT 1",
+	).Scan(&notePayload); err != nil {
+		t.Fatalf("read python notification: %v", err)
+	}
+	var note map[string]any
+	if err := json.Unmarshal([]byte(notePayload), &note); err != nil {
+		t.Fatalf("unmarshal python notification: %v", err)
+	}
+	if note["source"] != "python" || int(note["count"].(float64)) != 25 {
+		t.Fatalf("go saw wrong python notification: %#v", note)
+	}
+
+	events, err := db.Stream("interop").ReadSince(0, 10)
+	if err != nil {
+		t.Fatalf("go read stream: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("go saw %d stream events, want 2", len(events))
+	}
+}

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -183,3 +183,178 @@ def test_live_enqueuer_while_worker_drains(tmp_path):
     combined = a + b
     assert sorted(combined) == list(range(60))
     assert set(a).isdisjoint(set(b))
+
+
+def _run_pressure_producer_script(
+    db_path: str,
+    producer_id: int,
+    count: int,
+) -> subprocess.CompletedProcess:
+    script = textwrap.dedent(
+        f"""
+        import json
+        import os
+        import sys
+        import time
+
+        sys.path.insert(0, {os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "packages")!r})
+        import honker
+
+        db = honker.open({db_path!r})
+        q = db.queue("pressure")
+        keys = []
+        for i in range({count}):
+            key = f"p{producer_id}-{{i:03d}}"
+            q.enqueue({{
+                "producer": {producer_id},
+                "seq": i,
+                "key": key,
+            }}, priority=i % 7)
+            keys.append(key)
+            if i % 11 == 0:
+                time.sleep(0.001)
+        print(json.dumps(keys))
+        """
+    )
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _run_pressure_worker_script(
+    db_path: str,
+    worker_id: str,
+    idle_after_s: float = 1.0,
+) -> subprocess.CompletedProcess:
+    script = textwrap.dedent(
+        f"""
+        import json
+        import os
+        import sys
+        import time
+
+        sys.path.insert(0, {os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "packages")!r})
+        import honker
+
+        db = honker.open({db_path!r})
+        q = db.queue("pressure", visibility_timeout_s=30)
+        processed = []
+        idle_since = None
+        while True:
+            jobs = q.claim_batch({worker_id!r}, 7)
+            if jobs:
+                ids = []
+                for job in jobs:
+                    ids.append(job.id)
+                    processed.append({{
+                        "id": job.id,
+                        "key": job.payload["key"],
+                        "producer": job.payload["producer"],
+                        "seq": job.payload["seq"],
+                    }})
+                acked = q.ack_batch(ids, {worker_id!r})
+                if acked != len(ids):
+                    raise RuntimeError(f"acked {{acked}} of {{len(ids)}} jobs")
+                idle_since = None
+                # Small yield so the single SQLite writer lock rotates
+                # across workers instead of one process draining alone.
+                time.sleep(0.002)
+                continue
+
+            now = time.time()
+            if idle_since is None:
+                idle_since = now
+            elif now - idle_since >= {idle_after_s!r}:
+                break
+            time.sleep(0.01)
+
+        print(json.dumps(processed))
+        """
+    )
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+
+
+def test_many_processes_enqueue_claim_and_ack_exactly_once(tmp_path):
+    """Pressure proof for the queue claim path.
+
+    This is the real scary shape:
+
+    - several independent producer processes all write to one SQLite file
+    - several independent worker processes claim in batches
+    - every worker acks through the shared SQL function
+    - the parent proves every produced logical key was processed once
+
+    This catches bugs that single-process tests miss: writer-lock
+    serialization mistakes, claim UPDATE overlap, duplicate batch
+    returns, acking the wrong worker's claim, and dropped rows under
+    concurrent producer/consumer pressure.
+    """
+    db_path = str(tmp_path / "pressure.db")
+    producer_count = 4
+    jobs_per_producer = 75
+    worker_count = 6
+    total_jobs = producer_count * jobs_per_producer
+
+    import honker
+
+    # Bootstrap before subprocesses race to open the file.
+    db = honker.open(db_path)
+    del db
+
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=producer_count + worker_count
+    ) as ex:
+        producer_futs = [
+            ex.submit(_run_pressure_producer_script, db_path, p, jobs_per_producer)
+            for p in range(producer_count)
+        ]
+        # Start workers while producers are still writing, not after the
+        # queue is already full.
+        import time
+
+        time.sleep(0.03)
+        worker_futs = [
+            ex.submit(_run_pressure_worker_script, db_path, f"worker-{w}")
+            for w in range(worker_count)
+        ]
+        producer_results = [f.result() for f in producer_futs]
+        worker_results = [f.result() for f in worker_futs]
+
+    produced = []
+    for i, res in enumerate(producer_results):
+        assert res.returncode == 0, f"producer {i} failed: {res.stderr}"
+        produced.extend(json.loads(res.stdout.strip()))
+
+    processed = []
+    workers_that_helped = 0
+    for i, res in enumerate(worker_results):
+        assert res.returncode == 0, f"worker {i} failed: {res.stderr}"
+        rows = json.loads(res.stdout.strip())
+        if rows:
+            workers_that_helped += 1
+        processed.extend(rows)
+
+    produced_keys = sorted(produced)
+    processed_keys = sorted(row["key"] for row in processed)
+    assert len(produced_keys) == total_jobs
+    assert len(processed_keys) == total_jobs
+    assert processed_keys == produced_keys
+    assert len(set(processed_keys)) == total_jobs
+    assert len({row["id"] for row in processed}) == total_jobs
+    assert workers_that_helped >= 2
+
+    db = honker.open(db_path)
+    live = db.query("SELECT COUNT(*) AS c FROM _honker_live WHERE queue='pressure'")
+    dead = db.query("SELECT COUNT(*) AS c FROM _honker_dead WHERE queue='pressure'")
+    assert live[0]["c"] == 0
+    assert dead[0]["c"] == 0


### PR DESCRIPTION
## What

Add more proof that Honker works in the shape users actually run:

- many Python processes writing, claiming, and acking jobs from one SQLite file
- Go and Python using the same database file together
- queue rows, notifications, and stream rows crossing the language line

## Why

Small tests are good, but they can lie by being too cozy.

This checks the scary shape:

- several producers write at the same time
- several workers claim batches at the same time
- every produced job is processed once
- no duplicate claim
- no lost job
- no leftover live/dead rows
- Go can write and Python can read/ack
- Python can write and Go can read/ack

That gives us better proof before we keep building harder features on top.

## How

Python gets a new multiprocess pressure test:

```py
# 4 producer subprocesses
# 6 worker subprocesses
# 300 total jobs
# parent process checks exact once
```

Go gets a Python interop test:

```go
// Go enqueues jobs, sends a notification, publishes a stream event.
// Python claims and acks those jobs, sees the notification/event,
// then writes its own jobs/notification/event back.
// Go claims and acks the Python jobs and reads the Python rows.
```

CI now sets `HONKER_INTEROP_PYTHON` in the aggregate binding job. That means the Go/Python test must use the Python binding built earlier in the job. If Python is missing there, the test fails instead of quietly skipping.

## Checked

- `HONKER_INTEROP_PYTHON=../../.venv/bin/python go test -count=1 -tags sqlite_load_extension ./...`
- `.venv/bin/pytest tests/test_multiprocess.py -q`

I also tried the full local Python suite. After installing the missing local `pytest-asyncio`, it passed through the new multiprocess tests and then hung later in older process-management tests, so I stopped that local run. CI should be the real judge for the full matrix.
