### PR TITLE
Add scary core and binding interop tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,10 @@ jobs:
         working-directory: packages/honker-node
         shell: bash
         run: node --test test/basic.js
+      - name: Test (parity — node API surface)
+        working-directory: packages/honker-node
+        shell: bash
+        run: node --test test/parity.test.js
       - name: Test (direct proof — python writes, node updateEvents observes)
         working-directory: packages/honker-node
         shell: bash
@@ -282,6 +286,10 @@ jobs:
         working-directory: packages/honker-node
         shell: bash
         run: node --test test/cross_lang_supporting.js
+      - name: Test (direct proof — node and python share queues, streams, notify)
+        working-directory: packages/honker-node
+        shell: bash
+        run: node --test test/cross_lang_queue_stream_notify.js
 
   binding-smoke:
     name: binding smoke · ubuntu aggregate
@@ -297,6 +305,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: packages/honker-go/go.mod
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
       - uses: mlugg/setup-zig@v2
       - uses: oven-sh/setup-bun@v2
       - uses: ruby/setup-ruby@v1
@@ -325,19 +336,31 @@ jobs:
           cd packages/honker
           maturin develop --release
       - name: Rust wrapper
+        env:
+          HONKER_INTEROP_PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: cargo test --manifest-path packages/honker-rs/Cargo.toml
       - name: Go
         working-directory: packages/honker-go
         env:
           HONKER_INTEROP_PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: go test -tags sqlite_load_extension ./...
+      - name: .NET Python interop
+        env:
+          HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+          HONKER_INTEROP_PYTHON: ${{ github.workspace }}/.venv/bin/python
+          HONKER_REQUIRE_INTEROP: "1"
+        run: dotnet test packages/honker-dotnet/tests/Honker.Tests/Honker.Tests.csproj --filter FullyQualifiedName~PythonInteropTests --verbosity normal
       - name: C++
         working-directory: packages/honker-cpp
+        env:
+          HONKER_INTEROP_PYTHON: ${{ github.workspace }}/.venv/bin/python
+          HONKER_REQUIRE_INTEROP: "1"
         run: zig build test -Dhonker-ext="${GITHUB_WORKSPACE}/target/release/libhonker_ext.so"
       - name: Bun
         working-directory: packages/honker-bun
         env:
           HONKER_EXT_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+          HONKER_INTEROP_PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: |
           bun install --frozen-lockfile
           bun test
@@ -350,6 +373,9 @@ jobs:
           bundle exec ruby -Ilib spec/parity_spec.rb
       - name: Elixir
         working-directory: packages/honker-ex
+        env:
+          HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+          HONKER_INTEROP_PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: |
           mix deps.get
           mix test

--- a/honker-core/src/cron.rs
+++ b/honker-core/src/cron.rs
@@ -204,7 +204,10 @@ fn next_or_first(set: &BTreeSet<u32>, current: u32) -> (u32, bool) {
     }
 }
 
-fn cron_next_after_naive(sched: &CronSchedule, from: NaiveDateTime) -> Result<NaiveDateTime, String> {
+fn cron_next_after_naive(
+    sched: &CronSchedule,
+    from: NaiveDateTime,
+) -> Result<NaiveDateTime, String> {
     let mut cand = from + Duration::seconds(1);
     let cap_year = cand.year() + 100;
 
@@ -212,7 +215,11 @@ fn cron_next_after_naive(sched: &CronSchedule, from: NaiveDateTime) -> Result<Na
         let month = cand.month();
         if !sched.months.contains(&month) {
             let (next_month, wrapped) = next_or_first(&sched.months, month);
-            let year = if wrapped { cand.year() + 1 } else { cand.year() };
+            let year = if wrapped {
+                cand.year() + 1
+            } else {
+                cand.year()
+            };
             cand = make_dt(year, next_month, 1, 0, 0, 0);
             continue;
         }
@@ -249,7 +256,14 @@ fn cron_next_after_naive(sched: &CronSchedule, from: NaiveDateTime) -> Result<Na
                     0,
                 );
             } else {
-                cand = make_dt(cand.year(), cand.month(), cand.day(), cand.hour(), next_minute, 0);
+                cand = make_dt(
+                    cand.year(),
+                    cand.month(),
+                    cand.day(),
+                    cand.hour(),
+                    next_minute,
+                    0,
+                );
             }
             continue;
         }
@@ -258,8 +272,14 @@ fn cron_next_after_naive(sched: &CronSchedule, from: NaiveDateTime) -> Result<Na
         if !sched.seconds.contains(&second) {
             let (next_second, wrapped) = next_or_first(&sched.seconds, second);
             if wrapped {
-                cand = make_dt(cand.year(), cand.month(), cand.day(), cand.hour(), cand.minute(), 0)
-                    + Duration::minutes(1);
+                cand = make_dt(
+                    cand.year(),
+                    cand.month(),
+                    cand.day(),
+                    cand.hour(),
+                    cand.minute(),
+                    0,
+                ) + Duration::minutes(1);
                 cand = make_dt(
                     cand.year(),
                     cand.month(),

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -807,9 +807,232 @@ impl Drop for SharedUpdateWatcher {
 mod tests {
     use super::*;
     use rusqlite::Connection;
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
 
     fn mem() -> Connection {
         Connection::open_in_memory().unwrap()
+    }
+
+    fn temp_db(name: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "honker-{name}-{}-{:?}.db",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_file(&p);
+        let _ = std::fs::remove_file(format!("{}-wal", p.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", p.display()));
+        p
+    }
+
+    fn open_core_test_conn(path: &Path) -> Connection {
+        let conn = open_conn(path.to_str().unwrap(), true).unwrap();
+        attach_honker_functions(&conn).unwrap();
+        conn.query_row("SELECT honker_bootstrap()", [], |_| Ok(()))
+            .unwrap();
+        conn
+    }
+
+    #[test]
+    fn core_sql_functions_survive_concurrent_queue_stream_notify_pressure() {
+        let path = temp_db("core-pressure");
+        let producer_count = 4usize;
+        let jobs_per_producer = 75usize;
+        let worker_count = 6usize;
+        let total_jobs = producer_count * jobs_per_producer;
+
+        {
+            let conn = open_core_test_conn(&path);
+            let mode: String = conn
+                .pragma_query_value(None, "journal_mode", |r| r.get(0))
+                .unwrap();
+            assert_eq!(mode.to_ascii_uppercase(), "WAL");
+        }
+
+        let start = Arc::new(Barrier::new(producer_count + worker_count));
+        let producers_done = Arc::new(AtomicUsize::new(0));
+        let processed = Arc::new(Mutex::new(Vec::<(i64, String)>::new()));
+        let mut handles = Vec::new();
+
+        for producer in 0..producer_count {
+            let path = path.clone();
+            let start = start.clone();
+            let producers_done = producers_done.clone();
+            handles.push(std::thread::spawn(move || {
+                let conn = open_core_test_conn(&path);
+                start.wait();
+                for seq in 0..jobs_per_producer {
+                    let key = format!("p{producer}-{seq:03}");
+                    let payload = format!(r#"{{"producer":{producer},"seq":{seq},"key":"{key}"}}"#);
+                    conn.query_row(
+                        "SELECT honker_enqueue('pressure', ?1, NULL, NULL, ?2, 3, NULL)",
+                        rusqlite::params![payload, (seq % 7) as i64],
+                        |r| r.get::<_, i64>(0),
+                    )
+                    .unwrap();
+                    conn.query_row(
+                        "SELECT honker_stream_publish('pressure-events', ?1, ?2)",
+                        rusqlite::params![key, payload],
+                        |r| r.get::<_, i64>(0),
+                    )
+                    .unwrap();
+                    conn.query_row(
+                        "SELECT notify('pressure-note', ?1)",
+                        rusqlite::params![format!(r#"{{"key":"{key}"}}"#)],
+                        |r| r.get::<_, i64>(0),
+                    )
+                    .unwrap();
+                    if seq % 11 == 0 {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                }
+                producers_done.fetch_add(1, Ordering::Release);
+            }));
+        }
+
+        for worker in 0..worker_count {
+            let path = path.clone();
+            let start = start.clone();
+            let producers_done = producers_done.clone();
+            let processed = processed.clone();
+            handles.push(std::thread::spawn(move || {
+                let conn = open_core_test_conn(&path);
+                start.wait();
+                let worker_id = format!("core-worker-{worker}");
+                let deadline = Instant::now() + Duration::from_secs(20);
+                let mut idle_since: Option<Instant> = None;
+                loop {
+                    assert!(Instant::now() < deadline, "{worker_id} timed out");
+                    let rows_json: String = conn
+                        .query_row(
+                            "SELECT honker_claim_batch('pressure', ?1, 7, 30)",
+                            rusqlite::params![worker_id],
+                            |r| r.get(0),
+                        )
+                        .unwrap();
+                    let mut stmt = conn
+                        .prepare(
+                            "SELECT
+                               json_extract(value, '$.id'),
+                               json_extract(json_extract(value, '$.payload'), '$.key')
+                             FROM json_each(?1)",
+                        )
+                        .unwrap();
+                    let claimed = stmt
+                        .query_map(rusqlite::params![rows_json], |r| {
+                            Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+                        })
+                        .unwrap()
+                        .collect::<Result<Vec<_>, _>>()
+                        .unwrap();
+
+                    if claimed.is_empty() {
+                        if producers_done.load(Ordering::Acquire) == producer_count {
+                            match idle_since {
+                                Some(t) if t.elapsed() >= Duration::from_millis(500) => break,
+                                Some(_) => {}
+                                None => idle_since = Some(Instant::now()),
+                            }
+                        }
+                        std::thread::sleep(Duration::from_millis(5));
+                        continue;
+                    }
+
+                    idle_since = None;
+                    let ids_json = format!(
+                        "[{}]",
+                        claimed
+                            .iter()
+                            .map(|(id, _)| id.to_string())
+                            .collect::<Vec<_>>()
+                            .join(",")
+                    );
+                    let acked: i64 = conn
+                        .query_row(
+                            "SELECT honker_ack_batch(?1, ?2)",
+                            rusqlite::params![ids_json, worker_id],
+                            |r| r.get(0),
+                        )
+                        .unwrap();
+                    assert_eq!(acked as usize, claimed.len());
+                    processed.lock().extend(claimed);
+                    std::thread::sleep(Duration::from_millis(2));
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let processed = processed.lock();
+        assert_eq!(processed.len(), total_jobs);
+        let unique_ids: HashSet<i64> = processed.iter().map(|(id, _)| *id).collect();
+        assert_eq!(unique_ids.len(), total_jobs, "job id claimed twice");
+        let unique_keys: HashSet<String> = processed.iter().map(|(_, k)| k.clone()).collect();
+        assert_eq!(unique_keys.len(), total_jobs, "logical key claimed twice");
+        for producer in 0..producer_count {
+            for seq in 0..jobs_per_producer {
+                assert!(
+                    unique_keys.contains(&format!("p{producer}-{seq:03}")),
+                    "missing key p{producer}-{seq:03}"
+                );
+            }
+        }
+        drop(processed);
+
+        let conn = open_core_test_conn(&path);
+        let live: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM _honker_live WHERE queue='pressure'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let dead: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM _honker_dead WHERE queue='pressure'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let stream_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM _honker_stream WHERE topic='pressure-events'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let notes: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM _honker_notifications WHERE channel='pressure-note'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let enqueue_wakes: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM _honker_notifications WHERE channel='honker:pressure'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let integrity: String = conn
+            .query_row("PRAGMA integrity_check", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(live, 0);
+        assert_eq!(dead, 0);
+        assert_eq!(stream_rows as usize, total_jobs);
+        assert_eq!(notes as usize, total_jobs);
+        assert_eq!(enqueue_wakes as usize, total_jobs);
+        assert_eq!(integrity, "ok");
+
+        drop(conn);
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
     }
 
     #[test]
@@ -882,10 +1105,7 @@ mod tests {
 
     #[test]
     fn readers_close_returns_closed_err() {
-        let tmp = std::env::temp_dir().join(format!(
-            "honker-readers-close-{}",
-            std::process::id()
-        ));
+        let tmp = std::env::temp_dir().join(format!("honker-readers-close-{}", std::process::id()));
         let _ = std::fs::remove_file(&tmp);
         // Create the file so open_conn succeeds.
         Connection::open(&tmp)

--- a/packages/honker-bun/test/python_interop.test.ts
+++ b/packages/honker-bun/test/python_interop.test.ts
@@ -1,0 +1,142 @@
+import { test, expect } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { open } from "../src/index.ts";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..");
+const PYTHONPATH = [
+  join(REPO_ROOT, "packages", "honker", "python"),
+  join(REPO_ROOT, "packages"),
+].join(delimiter);
+
+function findPython(): string | null {
+  const probeScript = `
+import os
+import tempfile
+import honker
+
+p = tempfile.mktemp(prefix="honker-probe-", suffix=".db")
+db = honker.open(p)
+db.query("SELECT 1")
+db = None
+try:
+    os.remove(p)
+except OSError:
+    pass
+`;
+  const candidates = [
+    process.env.HONKER_INTEROP_PYTHON,
+    join(REPO_ROOT, ".venv", process.platform === "win32" ? "Scripts/python.exe" : "bin/python"),
+    "python3",
+    "python",
+  ].filter(Boolean) as string[];
+
+  for (const python of candidates) {
+    const probe = spawnSync(python, ["-c", probeScript], {
+      env: { ...process.env, PYTHONPATH },
+      stdio: "ignore",
+    });
+    if (probe.status === 0) return python;
+  }
+
+  if (process.env.HONKER_INTEROP_PYTHON) {
+    throw new Error("HONKER_INTEROP_PYTHON cannot import honker");
+  }
+  return null;
+}
+
+function findExtension(): string | null {
+  const candidates = [
+    process.env.HONKER_EXT_PATH,
+    join(REPO_ROOT, "target/release/libhonker_ext.dylib"),
+    join(REPO_ROOT, "target/release/libhonker_ext.so"),
+  ].filter(Boolean) as string[];
+  return candidates.find((p) => existsSync(p)) ?? null;
+}
+
+function runPython(python: string, dbPath: string, script: string): string {
+  const out = spawnSync(python, ["-c", script], {
+    env: { ...process.env, PYTHONPATH, DB_PATH: dbPath },
+    encoding: "utf8",
+  });
+  expect(out.status, out.stderr || out.stdout).toBe(0);
+  return out.stdout;
+}
+
+test("bun and python share queue, stream, and notify rows", () => {
+  const python = findPython();
+  const extPath = findExtension();
+  if (!python || !extPath) {
+    if (process.env.CI) throw new Error("python or honker extension missing in CI");
+    return;
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), "honker-bun-python-"));
+  const dbPath = join(dir, "bun-python.db");
+  const db = open(dbPath, extPath);
+  try {
+    const bunQueue = db.queue("bun-to-python");
+    for (let i = 0; i < 25; i += 1) {
+      bunQueue.enqueue({ source: "bun", seq: i, key: `bun-${i.toString().padStart(2, "0")}` });
+    }
+    db.notify("from-bun", { source: "bun", count: 25 });
+    db.stream("interop").publish({ source: "bun", kind: "stream" });
+
+    const observed = JSON.parse(runPython(python, dbPath, `
+import json
+import os
+import honker
+
+db = honker.open(os.environ["DB_PATH"])
+
+jobs = db.queue("bun-to-python").claim_batch("python-worker", 50)
+payloads = [job.payload for job in jobs]
+acked = db.queue("bun-to-python").ack_batch([job.id for job in jobs], "python-worker")
+note = db.query(
+    "SELECT payload FROM _honker_notifications "
+    "WHERE channel='from-bun' ORDER BY id DESC LIMIT 1"
+)
+events = db.stream("interop")._read_since(0, 10)
+
+py_q = db.queue("python-to-bun")
+for i in range(25):
+    py_q.enqueue({"source": "python", "seq": i, "key": f"py-{i:02d}"})
+with db.transaction() as tx:
+    tx.notify("from-python", {"source": "python", "count": len(jobs)})
+db.stream("interop").publish({"source": "python", "kind": "stream"})
+
+print(json.dumps({
+    "acked": acked,
+    "payloads": payloads,
+    "note": json.loads(note[0]["payload"]),
+    "event_count": len(events),
+}))
+`));
+
+    expect(observed.acked).toBe(25);
+    expect(observed.payloads).toHaveLength(25);
+    expect(observed.note).toEqual({ source: "bun", count: 25 });
+    expect(observed.event_count).toBe(1);
+
+    const pyQueue = db.queue("python-to-bun");
+    const pyJobs = pyQueue.claimBatch("bun-worker", 50);
+    expect(pyJobs).toHaveLength(25);
+    const seqs = pyJobs.map((job) => (job.payload as any).seq).sort((a, b) => a - b);
+    expect(seqs).toEqual(Array.from({ length: 25 }, (_, i) => i));
+    expect(pyQueue.ackBatch(pyJobs.map((job) => job.id), "bun-worker")).toBe(25);
+
+    const note = db.raw
+      .query<{ payload: string }, []>(
+        "SELECT payload FROM _honker_notifications WHERE channel='from-python' ORDER BY id DESC LIMIT 1",
+      )
+      .get()!;
+    expect(JSON.parse(note.payload)).toEqual({ source: "python", count: 25 });
+    expect(db.stream("interop").readSince(0, 10)).toHaveLength(2);
+  } finally {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/honker-cpp/test/test_parity.cpp
+++ b/packages/honker-cpp/test/test_parity.cpp
@@ -5,11 +5,14 @@
 
 #include "honker.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
+#include <fstream>
 #include <filesystem>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -29,6 +32,45 @@ static void cleanup(const std::string& path) {
     fs::remove(path);
     fs::remove(path + "-wal");
     fs::remove(path + "-shm");
+}
+
+static std::string shell_quote(const std::string& s) {
+    std::string out = "'";
+    for (char c : s) {
+        if (c == '\'') out += "'\\''";
+        else out += c;
+    }
+    out += "'";
+    return out;
+}
+
+static std::string repo_root() {
+    auto p = fs::canonical(fs::path(__FILE__));
+    // .../packages/honker-cpp/test/test_parity.cpp -> repo root
+    return p.parent_path().parent_path().parent_path().parent_path().string();
+}
+
+static std::string scalar_text(sqlite3* db, const char* sql) {
+    sqlite3_stmt* stmt = nullptr;
+    std::string out;
+    assert(sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) == SQLITE_OK);
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        const unsigned char* text = sqlite3_column_text(stmt, 0);
+        if (text) out = reinterpret_cast<const char*>(text);
+    }
+    sqlite3_finalize(stmt);
+    return out;
+}
+
+static int64_t scalar_i64(sqlite3* db, const char* sql) {
+    sqlite3_stmt* stmt = nullptr;
+    int64_t out = 0;
+    assert(sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) == SQLITE_OK);
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        out = sqlite3_column_int64(stmt, 0);
+    }
+    sqlite3_finalize(stmt);
+    return out;
 }
 
 #define TEST(name) void test_##name(const char* ext)
@@ -474,6 +516,98 @@ TEST(stream_key_optional) {
     cleanup(db_path);
 }
 
+TEST(python_interop_queue_stream_notify) {
+#ifdef _WIN32
+    const char* require = std::getenv("HONKER_REQUIRE_INTEROP");
+    assert(!require || std::string{require} != "1");
+    return;
+#else
+    const char* py = std::getenv("HONKER_INTEROP_PYTHON");
+    const char* require = std::getenv("HONKER_REQUIRE_INTEROP");
+    if (!py || !*py) {
+        assert(!require || std::string{require} != "1");
+        return;
+    }
+
+    auto db_path = tmp_db();
+    honker::Database db{db_path, ext};
+    auto cpp_q = db.queue("cpp-to-python");
+    for (int i = 0; i < 25; ++i) {
+        cpp_q.enqueue(
+            std::string{"{\"source\":\"cpp\",\"seq\":"} + std::to_string(i) +
+            ",\"key\":\"cpp-" + (i < 10 ? "0" : "") + std::to_string(i) + "\"}");
+    }
+    db.notify("from-cpp", R"({"source":"cpp","count":25})");
+    db.stream("interop").publish(R"({"source":"cpp","kind":"stream"})");
+
+    auto script_path = fs::path(db_path).replace_extension(".py");
+    {
+        std::ofstream py_script{script_path};
+        py_script << R"PY(
+import json
+import os
+import honker
+
+db = honker.open(os.environ["DB_PATH"])
+
+jobs = db.queue("cpp-to-python").claim_batch("python-worker", 50)
+payloads = [job.payload for job in jobs]
+assert len(payloads) == 25, payloads
+assert all(p["source"] == "cpp" for p in payloads), payloads
+assert db.queue("cpp-to-python").ack_batch([job.id for job in jobs], "python-worker") == 25
+note = db.query(
+    "SELECT payload FROM _honker_notifications "
+    "WHERE channel='from-cpp' ORDER BY id DESC LIMIT 1"
+)
+assert json.loads(note[0]["payload"]) == {"source": "cpp", "count": 25}
+assert len(db.stream("interop")._read_since(0, 10)) == 1
+
+py_q = db.queue("python-to-cpp")
+for i in range(25):
+    py_q.enqueue({"source": "python", "seq": i, "key": f"py-{i:02d}"})
+with db.transaction() as tx:
+    tx.notify("from-python", {"source": "python", "count": len(jobs)})
+db.stream("interop").publish({"source": "python", "kind": "stream"})
+)PY";
+    }
+
+    const auto pp = repo_root() + "/packages/honker/python:" + repo_root() + "/packages";
+    std::ostringstream cmd;
+    cmd << "PYTHONPATH=" << shell_quote(pp)
+        << " DB_PATH=" << shell_quote(db_path)
+        << " " << shell_quote(py)
+        << " " << shell_quote(script_path.string());
+    const int rc = std::system(cmd.str().c_str());
+    assert(rc == 0);
+
+    auto py_q = db.queue("python-to-cpp");
+    auto py_jobs = py_q.claim_batch("cpp-worker", 50);
+    assert(py_jobs.size() == 25);
+    std::vector<int> seqs;
+    std::vector<int64_t> ids;
+    for (const auto& job : py_jobs) {
+        auto payload = nlohmann::json::parse(job.payload());
+        assert(payload["source"] == "python");
+        seqs.push_back(payload["seq"].get<int>());
+        ids.push_back(job.id());
+    }
+    std::sort(seqs.begin(), seqs.end());
+    for (int i = 0; i < 25; ++i) assert(seqs[static_cast<size_t>(i)] == i);
+    assert(py_q.ack_batch(ids, "cpp-worker") == 25);
+
+    auto note = nlohmann::json::parse(scalar_text(
+        db.raw(),
+        "SELECT payload FROM _honker_notifications WHERE channel='from-python' ORDER BY id DESC LIMIT 1"));
+    assert(note["source"] == "python");
+    assert(note["count"] == 25);
+    assert(db.stream("interop").read_since(0, 10).size() == 2);
+    assert(scalar_i64(db.raw(), "SELECT COUNT(*) FROM _honker_live WHERE queue IN ('cpp-to-python', 'python-to-cpp')") == 0);
+
+    fs::remove(script_path);
+    cleanup(db_path);
+#endif
+}
+
 TEST(lock_raii_release) {
     auto db_path = tmp_db();
     honker::Database db{db_path, ext};
@@ -539,9 +673,10 @@ int main() {
     RUN(enqueue_with_priority);
     RUN(multiple_queues_isolated);
     RUN(stream_key_optional);
+    RUN(python_interop_queue_stream_notify);
     RUN(lock_raii_release);
     RUN(result_ttl_expiry);
 
-    std::cout << "ALL OK (27 tests)\n";
+    std::cout << "ALL OK (28 tests)\n";
     return 0;
 }

--- a/packages/honker-dotnet/tests/Honker.Tests/NotifyStreamTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/NotifyStreamTests.cs
@@ -13,9 +13,10 @@ public sealed class NotifyStreamTests
 
         var got = new List<string>();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var listener = db.Listen("orders");
         var task = Task.Run(async () =>
         {
-            await foreach (var notification in db.Listen("orders").WithCancellation(cts.Token))
+            await foreach (var notification in listener.WithCancellation(cts.Token))
             {
                 got.Add(AsString(notification.Payload));
                 if (got.Count == 2)
@@ -25,7 +26,6 @@ public sealed class NotifyStreamTests
             }
         }, cts.Token);
 
-        await Task.Delay(50, cts.Token);
         db.Notify("unrelated", "skip");
         db.Notify("orders", "one");
         db.Notify("other", "skip");

--- a/packages/honker-dotnet/tests/Honker.Tests/OutboxLockTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/OutboxLockTests.cs
@@ -291,7 +291,12 @@ public sealed class OutboxLockTests
 
         var watch = System.Diagnostics.Stopwatch.StartNew();
         cts.Cancel();
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await worker);
+        var stopped = await Task.WhenAny(worker, Task.Delay(TimeSpan.FromSeconds(2))) == worker;
+        Assert.True(stopped, $"worker cancel was too slow: {watch.Elapsed}");
+        if (!worker.IsCompletedSuccessfully)
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await worker);
+        }
         Assert.True(watch.Elapsed < TimeSpan.FromSeconds(2), $"worker cancel was too slow: {watch.Elapsed}");
     }
 

--- a/packages/honker-dotnet/tests/Honker.Tests/PythonInteropTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/PythonInteropTests.cs
@@ -1,0 +1,235 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Honker.Tests;
+
+public sealed class PythonInteropTests
+{
+    [Fact]
+    public void DotnetAndPythonShareQueueStreamAndNotifyRows()
+    {
+        var python = FindPython();
+        var extension = FindExtension();
+        if (python is null || extension is null)
+        {
+            if (Environment.GetEnvironmentVariable("HONKER_REQUIRE_INTEROP") == "1")
+            {
+                throw new InvalidOperationException("python honker binding or honker extension missing");
+            }
+
+            return;
+        }
+
+        var dir = Path.Combine(Path.GetTempPath(), $"honker-dotnet-python-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var dbPath = Path.Combine(dir, "dotnet-python.db");
+            using var db = Database.Open(dbPath, new OpenOptions { ExtensionPath = extension });
+
+            var dotnetQueue = db.Queue("dotnet-to-python");
+            for (var i = 0; i < 25; i += 1)
+            {
+                dotnetQueue.Enqueue(new { source = "dotnet", seq = i, key = $"dotnet-{i:00}" });
+            }
+
+            db.Notify("from-dotnet", new { source = "dotnet", count = 25 });
+            db.Stream("interop").Publish(new { source = "dotnet", kind = "stream" });
+
+            var observed = RunPython(python, dbPath, """
+import json
+import os
+import honker
+
+db = honker.open(os.environ["DB_PATH"])
+
+jobs = db.queue("dotnet-to-python").claim_batch("python-worker", 50)
+payloads = [job.payload for job in jobs]
+acked = db.queue("dotnet-to-python").ack_batch([job.id for job in jobs], "python-worker")
+note = db.query(
+    "SELECT payload FROM _honker_notifications "
+    "WHERE channel='from-dotnet' ORDER BY id DESC LIMIT 1"
+)
+events = db.stream("interop")._read_since(0, 10)
+
+py_q = db.queue("python-to-dotnet")
+for i in range(25):
+    py_q.enqueue({"source": "python", "seq": i, "key": f"py-{i:02d}"})
+with db.transaction() as tx:
+    tx.notify("from-python", {"source": "python", "count": len(jobs)})
+db.stream("interop").publish({"source": "python", "kind": "stream"})
+
+print(json.dumps({
+    "acked": acked,
+    "payloads": payloads,
+    "note": json.loads(note[0]["payload"]),
+    "event_count": len(events),
+}))
+""");
+
+            using var doc = JsonDocument.Parse(observed);
+            var root = doc.RootElement;
+            Assert.Equal(25, root.GetProperty("acked").GetInt32());
+            Assert.Equal(25, root.GetProperty("payloads").GetArrayLength());
+            Assert.Equal("dotnet", root.GetProperty("note").GetProperty("source").GetString());
+            Assert.Equal(25, root.GetProperty("note").GetProperty("count").GetInt32());
+            Assert.Equal(1, root.GetProperty("event_count").GetInt32());
+
+            var pyQueue = db.Queue("python-to-dotnet");
+            var pyJobs = pyQueue.ClaimBatch("dotnet-worker", 50);
+            Assert.Equal(25, pyJobs.Count);
+            Assert.Equal(
+                Enumerable.Range(0, 25).ToArray(),
+                pyJobs.Select(job =>
+                {
+                    Assert.Equal("python", job.Payload.GetProperty("source").GetString());
+                    return job.Payload.GetProperty("seq").GetInt32();
+                }).Order().ToArray()
+            );
+            Assert.Equal(25, pyQueue.AckBatch(pyJobs.Select(job => job.Id), "dotnet-worker"));
+
+            var note = Convert.ToString(db.Query(
+                "SELECT payload FROM _honker_notifications WHERE channel='from-python' ORDER BY id DESC LIMIT 1"
+            )[0]["payload"]);
+            using var noteDoc = JsonDocument.Parse(note!);
+            Assert.Equal("python", noteDoc.RootElement.GetProperty("source").GetString());
+            Assert.Equal(25, noteDoc.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal(2, db.Stream("interop").ReadSince(0, 10).Count);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+            catch
+            {
+                // best effort cleanup
+            }
+        }
+    }
+
+    private static string? FindPython()
+    {
+        var root = FindRepoRoot();
+        var candidates = new[]
+        {
+            Environment.GetEnvironmentVariable("HONKER_INTEROP_PYTHON"),
+            Path.Combine(root, ".venv", OperatingSystem.IsWindows() ? "Scripts/python.exe" : "bin/python"),
+            "python3",
+            "python",
+        }.Where(p => !string.IsNullOrWhiteSpace(p));
+
+        foreach (var python in candidates)
+        {
+            var result = RunProcess(python!, ["-c", PythonProbeScript], new Dictionary<string, string?>
+            {
+                ["PYTHONPATH"] = PythonPath(root),
+            });
+            if (result.ExitCode == 0)
+            {
+                return python;
+            }
+        }
+
+        return null;
+    }
+
+    private const string PythonProbeScript = """
+import os
+import tempfile
+import honker
+
+p = tempfile.mktemp(prefix="honker-probe-", suffix=".db")
+db = honker.open(p)
+db.query("SELECT 1")
+db = None
+try:
+    os.remove(p)
+except OSError:
+    pass
+""";
+
+    private static string RunPython(string python, string dbPath, string script)
+    {
+        var root = FindRepoRoot();
+        var result = RunProcess(python, ["-c", script], new Dictionary<string, string?>
+        {
+            ["PYTHONPATH"] = PythonPath(root),
+            ["DB_PATH"] = dbPath,
+        });
+        Assert.Equal(0, result.ExitCode);
+        return result.Stdout;
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunProcess(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        IReadOnlyDictionary<string, string?> env)
+    {
+        using var proc = new Process();
+        proc.StartInfo.FileName = fileName;
+        foreach (var argument in arguments)
+        {
+            proc.StartInfo.ArgumentList.Add(argument);
+        }
+        proc.StartInfo.RedirectStandardOutput = true;
+        proc.StartInfo.RedirectStandardError = true;
+        foreach (var (key, value) in env)
+        {
+            proc.StartInfo.Environment[key] = value;
+        }
+
+        try
+        {
+            proc.Start();
+        }
+        catch
+        {
+            return (127, "", "");
+        }
+
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        proc.WaitForExit();
+        return (proc.ExitCode, stdout, stderr);
+    }
+
+    private static string PythonPath(string root)
+    {
+        return string.Join(
+            Path.PathSeparator,
+            Path.Combine(root, "packages", "honker", "python"),
+            Path.Combine(root, "packages")
+        );
+    }
+
+    private static string? FindExtension()
+    {
+        var root = FindRepoRoot();
+        return new[]
+        {
+            Environment.GetEnvironmentVariable("HONKER_EXTENSION_PATH"),
+            Environment.GetEnvironmentVariable("HONKER_EXT_PATH"),
+            Path.Combine(root, "target", "release", OperatingSystem.IsWindows() ? "honker_ext.dll" : "libhonker_ext.dylib"),
+            Path.Combine(root, "target", "release", "libhonker_ext.so"),
+        }.FirstOrDefault(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(current))
+        {
+            if (Directory.Exists(Path.Combine(current, "honker-core")) &&
+                File.Exists(Path.Combine(current, "Cargo.toml")))
+            {
+                return current;
+            }
+
+            current = Directory.GetParent(current)?.FullName ?? "";
+        }
+
+        throw new InvalidOperationException("could not find repo root");
+    }
+}

--- a/packages/honker-ex/test/python_interop_test.exs
+++ b/packages/honker-ex/test/python_interop_test.exs
@@ -1,0 +1,164 @@
+defmodule HonkerPythonInteropTest do
+  use ExUnit.Case, async: false
+
+  alias Honker.{Job, Queue, Stream}
+
+  @repo_root Path.expand("../../..", __DIR__)
+
+  defp python_path do
+    Enum.join(
+      [
+        Path.join([@repo_root, "packages", "honker", "python"]),
+        Path.join([@repo_root, "packages"])
+      ],
+      if(:os.type() |> elem(0) == :win32, do: ";", else: ":")
+    )
+  end
+
+  defp find_python do
+    probe = """
+    import os
+    import tempfile
+    import honker
+
+    p = tempfile.mktemp(prefix="honker-probe-", suffix=".db")
+    db = honker.open(p)
+    db.query("SELECT 1")
+    db = None
+    try:
+        os.remove(p)
+    except OSError:
+        pass
+    """
+
+    candidates =
+      [
+        System.get_env("HONKER_INTEROP_PYTHON"),
+        Path.join([@repo_root, ".venv", "bin", "python"]),
+        Path.join([@repo_root, ".venv", "Scripts", "python.exe"]),
+        "python3",
+        "python"
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    Enum.find(candidates, fn python ->
+      {_, status} =
+        System.cmd(python, ["-c", probe],
+          env: [{"PYTHONPATH", python_path()}],
+          stderr_to_stdout: true
+        )
+
+      status == 0
+    end)
+  end
+
+  defp find_extension do
+    [
+      System.get_env("HONKER_EXTENSION_PATH"),
+      System.get_env("HONKER_EXT_PATH"),
+      Path.join([@repo_root, "target", "release", "libhonker_ext.dylib"]),
+      Path.join([@repo_root, "target", "release", "libhonker_ext.so"])
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.find(&File.exists?/1)
+  end
+
+  setup do
+    python = find_python()
+    ext = find_extension()
+
+    if (python == nil or ext == nil) and System.get_env("CI") do
+      flunk("python honker binding or honker extension missing in CI")
+    end
+
+    if python == nil or ext == nil do
+      {:ok, skip: true}
+    else
+      dir = Path.join(System.tmp_dir!(), "honker-ex-python-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      db_path = Path.join(dir, "elixir-python.db")
+      on_exit(fn -> File.rm_rf!(dir) end)
+      {:ok, db} = Honker.open(db_path, extension_path: ext)
+      {:ok, db: db, db_path: db_path, python: python}
+    end
+  end
+
+  test "elixir and python share queue stream and notify rows", ctx do
+    if Map.get(ctx, :skip) do
+      :ok
+    else
+      for i <- 0..24 do
+        {:ok, _} =
+          Queue.enqueue(ctx.db, "elixir-to-python", %{
+            "source" => "elixir",
+            "seq" => i,
+            "key" => "elixir-#{String.pad_leading(Integer.to_string(i), 2, "0")}"
+          })
+      end
+
+      {:ok, _} = Honker.notify(ctx.db, "from-elixir", %{"source" => "elixir", "count" => 25})
+      {:ok, _} = Stream.publish(ctx.db, "interop", %{"source" => "elixir", "kind" => "stream"})
+
+      script = """
+      import json
+      import os
+      import honker
+
+      db = honker.open(os.environ["DB_PATH"])
+
+      jobs = db.queue("elixir-to-python").claim_batch("python-worker", 50)
+      payloads = [job.payload for job in jobs]
+      acked = db.queue("elixir-to-python").ack_batch([job.id for job in jobs], "python-worker")
+      note = db.query(
+          "SELECT payload FROM _honker_notifications "
+          "WHERE channel='from-elixir' ORDER BY id DESC LIMIT 1"
+      )
+      events = db.stream("interop")._read_since(0, 10)
+
+      py_q = db.queue("python-to-elixir")
+      for i in range(25):
+          py_q.enqueue({"source": "python", "seq": i, "key": f"py-{i:02d}"})
+      with db.transaction() as tx:
+          tx.notify("from-python", {"source": "python", "count": len(jobs)})
+      db.stream("interop").publish({"source": "python", "kind": "stream"})
+
+      print(json.dumps({
+          "acked": acked,
+          "payloads": payloads,
+          "note": json.loads(note[0]["payload"]),
+          "event_count": len(events),
+      }))
+      """
+
+      {out, status} =
+        System.cmd(ctx.python, ["-c", script],
+          env: [{"PYTHONPATH", python_path()}, {"DB_PATH", ctx.db_path}],
+          stderr_to_stdout: true
+        )
+
+      assert status == 0, out
+      observed = Jason.decode!(out)
+      assert observed["acked"] == 25
+      assert length(observed["payloads"]) == 25
+      assert observed["note"] == %{"source" => "elixir", "count" => 25}
+      assert observed["event_count"] == 1
+
+      {:ok, py_jobs} = Queue.claim_batch(ctx.db, "python-to-elixir", "elixir-worker", 50)
+      assert length(py_jobs) == 25
+      assert Enum.map(py_jobs, & &1.payload["seq"]) |> Enum.sort() == Enum.to_list(0..24)
+      assert Enum.all?(py_jobs, &(&1.payload["source"] == "python"))
+      assert Enum.all?(py_jobs, fn job -> Job.ack(ctx.db, job) == {:ok, true} end)
+
+      {:ok, [note]} =
+        Honker.query_first(
+          ctx.db.conn,
+          "SELECT payload FROM _honker_notifications WHERE channel='from-python' ORDER BY id DESC LIMIT 1",
+          []
+        )
+
+      assert Jason.decode!(note) == %{"source" => "python", "count" => 25}
+      {:ok, events} = Stream.read_since(ctx.db, "interop", 0, 10)
+      assert length(events) == 2
+    end
+  end
+end

--- a/packages/honker-go/python_interop_test.go
+++ b/packages/honker-go/python_interop_test.go
@@ -21,7 +21,7 @@ func findInteropPython(t *testing.T) string {
 	t.Helper()
 	repo := repoRoot(t)
 	if p := os.Getenv("HONKER_INTEROP_PYTHON"); p != "" {
-		cmd := exec.Command(p, "-c", "import honker")
+		cmd := exec.Command(p, "-c", pythonProbeScript)
 		cmd.Env = interopPythonEnv(t, "")
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("HONKER_INTEROP_PYTHON cannot import honker: %v\n%s", err, string(out))
@@ -35,7 +35,7 @@ func findInteropPython(t *testing.T) string {
 		"python",
 	}
 	for _, p := range candidates {
-		cmd := exec.Command(p, "-c", "import honker")
+		cmd := exec.Command(p, "-c", pythonProbeScript)
 		cmd.Env = interopPythonEnv(t, "")
 		if err := cmd.Run(); err == nil {
 			return p
@@ -47,6 +47,21 @@ func findInteropPython(t *testing.T) string {
 	)
 	return ""
 }
+
+const pythonProbeScript = `
+import os
+import tempfile
+import honker
+
+p = tempfile.mktemp(prefix="honker-probe-", suffix=".db")
+db = honker.open(p)
+db.query("SELECT 1")
+db = None
+try:
+    os.remove(p)
+except OSError:
+    pass
+`
 
 func interopPythonEnv(t *testing.T, dbPath string) []string {
 	t.Helper()

--- a/packages/honker-node/test/cross_lang_queue_stream_notify.js
+++ b/packages/honker-node/test/cross_lang_queue_stream_notify.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const honker = require('..');
+const { createTempDb } = require('./helpers');
+const { PACKAGES, spawnPython } = require('./cross_lang_shared');
+
+test('direct proof: node and python share queue, stream, and notify rows', async () => {
+  const { path: dbPath, open, cleanup } = createTempDb(
+    'xlang-node-py-contract-',
+    honker.open.bind(honker),
+  );
+  let db;
+  try {
+    db = open(dbPath);
+    const nodeQueue = db.queue('node-to-python');
+    for (let i = 0; i < 25; i += 1) {
+      nodeQueue.enqueue({
+        source: 'node',
+        seq: i,
+        key: `node-${String(i).padStart(2, '0')}`,
+      });
+    }
+    db.notify('from-node', { source: 'node', count: 25 });
+    db.stream('interop').publish({ source: 'node', kind: 'stream' });
+
+    const pyScript = `
+import json, sys
+sys.path.insert(0, ${JSON.stringify(PACKAGES)})
+import honker
+
+db = honker.open(${JSON.stringify(dbPath)})
+jobs = db.queue("node-to-python").claim_batch("python-worker", 50)
+payloads = [job.payload for job in jobs]
+acked = db.queue("node-to-python").ack_batch([job.id for job in jobs], "python-worker")
+note = db.query(
+    "SELECT payload FROM _honker_notifications "
+    "WHERE channel='from-node' ORDER BY id DESC LIMIT 1"
+)
+events = db.stream("interop")._read_since(0, 10)
+
+py_q = db.queue("python-to-node")
+for i in range(25):
+    py_q.enqueue({"source": "python", "seq": i, "key": f"py-{i:02d}"})
+with db.transaction() as tx:
+    tx.notify("from-python", {"source": "python", "count": len(jobs)})
+db.stream("interop").publish({"source": "python", "kind": "stream"})
+
+print(json.dumps({
+    "acked": acked,
+    "payloads": payloads,
+    "note": json.loads(note[0]["payload"]),
+    "event_count": len(events),
+}))
+`;
+    const proc = spawnPython(pyScript, ['ignore', 'pipe', 'inherit']);
+    let stdout = '';
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk.toString('utf8');
+    });
+    const code = await new Promise((resolve) => proc.on('exit', resolve));
+    assert.equal(code, 0);
+    const observed = JSON.parse(stdout);
+    assert.equal(observed.acked, 25);
+    assert.equal(observed.payloads.length, 25);
+    assert.deepEqual(
+      observed.payloads.map((p) => p.seq).sort((a, b) => a - b),
+      Array.from({ length: 25 }, (_, i) => i),
+    );
+    assert.deepEqual(observed.note, { source: 'node', count: 25 });
+    assert.equal(observed.event_count, 1);
+
+    const pyQueue = db.queue('python-to-node');
+    const pyJobs = pyQueue.claimBatch('node-worker', 50);
+    assert.equal(pyJobs.length, 25);
+    assert.deepEqual(
+      pyJobs.map((job) => job.payload.seq).sort((a, b) => a - b),
+      Array.from({ length: 25 }, (_, i) => i),
+    );
+    assert.equal(pyQueue.ackBatch(pyJobs.map((job) => job.id), 'node-worker'), 25);
+
+    const note = db.query(
+      "SELECT payload FROM _honker_notifications WHERE channel='from-python' ORDER BY id DESC LIMIT 1",
+    );
+    assert.deepEqual(JSON.parse(note[0].payload), { source: 'python', count: 25 });
+    assert.equal(db.stream('interop').readSince(0, 10).length, 2);
+  } finally {
+    db?.close();
+    cleanup();
+  }
+});

--- a/packages/honker-rs/Cargo.lock
+++ b/packages/honker-rs/Cargo.lock
@@ -183,7 +183,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "honker"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "honker-core",
  "parking_lot",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "honker-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "file-id",

--- a/packages/honker-rs/tests/python_interop.rs
+++ b/packages/honker-rs/tests/python_interop.rs
@@ -1,0 +1,195 @@
+use honker::{Database, EnqueueOpts, QueueOpts};
+use serde_json::json;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .unwrap()
+}
+
+fn interop_python() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("HONKER_INTEROP_PYTHON") {
+        let status = Command::new(&path)
+            .arg("-c")
+            .arg(python_probe())
+            .env("PYTHONPATH", python_path())
+            .status()
+            .unwrap_or_else(|e| panic!("run HONKER_INTEROP_PYTHON={path}: {e}"));
+        assert!(
+            status.success(),
+            "HONKER_INTEROP_PYTHON cannot import honker"
+        );
+        return Some(path.into());
+    }
+
+    let root = repo_root();
+    for candidate in [
+        root.join(".venv").join("bin").join("python"),
+        root.join(".venv").join("Scripts").join("python.exe"),
+        PathBuf::from("python3"),
+        PathBuf::from("python"),
+    ] {
+        if Command::new(&candidate)
+            .arg("-c")
+            .arg(python_probe())
+            .env("PYTHONPATH", python_path())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+        {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn python_probe() -> &'static str {
+    r#"import os, tempfile, honker
+p = tempfile.mktemp(prefix="honker-probe-", suffix=".db")
+db = honker.open(p)
+db.query("SELECT 1")
+db = None
+try:
+    os.remove(p)
+except OSError:
+    pass
+"#
+}
+
+fn python_path() -> String {
+    let root = repo_root();
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    [
+        root.join("packages").join("honker").join("python"),
+        root.join("packages"),
+    ]
+    .iter()
+    .map(|p| p.to_string_lossy().into_owned())
+    .collect::<Vec<_>>()
+    .join(sep)
+}
+
+fn run_python(python: &Path, db_path: &Path, script: &str) -> String {
+    let out = Command::new(python)
+        .arg("-c")
+        .arg(script)
+        .env("PYTHONPATH", python_path())
+        .env("DB_PATH", db_path)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "python interop failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).unwrap()
+}
+
+#[test]
+fn rust_wrapper_and_python_share_queue_stream_and_notify() {
+    let Some(python) = interop_python() else {
+        eprintln!("python honker binding unavailable; skipping rust/python interop");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path().join("rust-python.db");
+    let db = Database::open(&db_path).unwrap();
+
+    let rust_q = db.queue("rust-to-python", QueueOpts::default());
+    for i in 0..25 {
+        rust_q
+            .enqueue(
+                &json!({"source": "rust", "seq": i, "key": format!("rust-{i:02}")}),
+                EnqueueOpts::default(),
+            )
+            .unwrap();
+    }
+    db.notify("from-rust", &json!({"source": "rust", "count": 25}))
+        .unwrap();
+    db.stream("interop")
+        .publish(&json!({"source": "rust", "kind": "stream"}))
+        .unwrap();
+
+    let out = run_python(
+        &python,
+        &db_path,
+        r#"
+import json
+import os
+import honker
+
+db = honker.open(os.environ["DB_PATH"])
+
+rust_jobs = db.queue("rust-to-python").claim_batch("python-worker", 50)
+rust_payloads = [job.payload for job in rust_jobs]
+acked = db.queue("rust-to-python").ack_batch(
+    [job.id for job in rust_jobs],
+    "python-worker",
+)
+
+rust_note = db.query(
+    "SELECT payload FROM _honker_notifications "
+    "WHERE channel='from-rust' ORDER BY id DESC LIMIT 1"
+)
+rust_events = db.stream("interop")._read_since(0, 10)
+
+py_q = db.queue("python-to-rust")
+for i in range(25):
+    py_q.enqueue({"source": "python", "seq": i, "key": f"py-{i:02d}"})
+with db.transaction() as tx:
+    tx.notify("from-python", {"source": "python", "count": len(rust_jobs)})
+db.stream("interop").publish({"source": "python", "kind": "stream"})
+
+print(json.dumps({
+    "acked": acked,
+    "rust_payloads": rust_payloads,
+    "rust_note": json.loads(rust_note[0]["payload"]),
+    "rust_event_count": len(rust_events),
+}))
+"#,
+    );
+
+    let observed: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(observed["acked"], 25);
+    assert_eq!(observed["rust_payloads"].as_array().unwrap().len(), 25);
+    assert_eq!(observed["rust_note"]["source"], "rust");
+    assert_eq!(observed["rust_note"]["count"], 25);
+    assert_eq!(observed["rust_event_count"], 1);
+
+    let py_q = db.queue("python-to-rust", QueueOpts::default());
+    let py_jobs = py_q.claim_batch("rust-worker", 50).unwrap();
+    assert_eq!(py_jobs.len(), 25);
+    let mut seqs = py_jobs
+        .iter()
+        .map(|job| {
+            let payload: serde_json::Value = job.payload_as().unwrap();
+            assert_eq!(payload["source"], "python");
+            payload["seq"].as_i64().unwrap()
+        })
+        .collect::<Vec<_>>();
+    seqs.sort_unstable();
+    assert_eq!(seqs, (0..25).collect::<Vec<_>>());
+    let ids = py_jobs.iter().map(|job| job.id).collect::<Vec<_>>();
+    assert_eq!(py_q.ack_batch(&ids, "rust-worker").unwrap(), 25);
+
+    let py_note: String = db.with_conn(|c| {
+        c.query_row(
+            "SELECT payload FROM _honker_notifications WHERE channel='from-python' ORDER BY id DESC LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap()
+    });
+    let py_note: serde_json::Value = serde_json::from_str(&py_note).unwrap();
+    assert_eq!(py_note["source"], "python");
+    assert_eq!(py_note["count"], 25);
+
+    let events = db.stream("interop").read_since(0, 10).unwrap();
+    assert_eq!(events.len(), 2);
+}

--- a/tests/test_cross_process_wake_latency.py
+++ b/tests/test_cross_process_wake_latency.py
@@ -16,6 +16,7 @@ Kept as a test because the claim is load-bearing and the bench
 """
 
 import os
+import math
 import subprocess
 import sys
 import time
@@ -116,8 +117,14 @@ def test_cross_process_wake_latency_p99_under_bound(tmp_path):
     # and p90. With 30 samples, p90 tolerates up to 3 outliers, which
     # is enough to absorb scheduler noise while still catching
     # anything that shifts the distribution.
-    p50 = times_ms[int(len(times_ms) * 0.5)]
-    p90 = times_ms[int(len(times_ms) * 0.9)]
+    def percentile(samples, pct):
+        # Nearest-rank percentile, zero-indexed. For 30 samples,
+        # p90 is sample 27, which tolerates 3 slow scheduler outliers
+        # like the comment above says.
+        return samples[math.ceil(len(samples) * pct) - 1]
+
+    p50 = percentile(times_ms, 0.5)
+    p90 = percentile(times_ms, 0.9)
     median_bound = 25.0   # real p50 ~= 1-2 ms on M-series
     p90_bound = 100.0     # real p90 rarely exceeds 30 ms
 

--- a/tests/test_ruby_python_interop.py
+++ b/tests/test_ruby_python_interop.py
@@ -80,7 +80,7 @@ def _run_ruby(script, db_path):
     return proc.stdout
 
 
-def test_ruby_and_python_share_queue_and_notification_tables(tmp_path):
+def test_ruby_and_python_share_queue_stream_and_notification_tables(tmp_path):
     db_path = tmp_path / "ruby-python.db"
 
     _run_ruby(
@@ -91,28 +91,46 @@ def test_ruby_and_python_share_queue_and_notification_tables(tmp_path):
           ENV.fetch("DB_PATH"),
           extension_path: ENV.fetch("HONKER_EXTENSION_PATH"),
         )
-        db.queue("emails").enqueue({"to" => "ruby@example.com"})
-        db.notify("from-ruby", {"source" => "ruby"})
+        q = db.queue("ruby-to-python")
+        25.times do |i|
+          q.enqueue({"source" => "ruby", "seq" => i, "key" => "ruby-%02d" % i})
+        end
+        db.notify("from-ruby", {"source" => "ruby", "count" => 25})
+        db.stream("interop").publish({"source" => "ruby", "kind" => "stream"})
         db.close
         ''',
         db_path,
     )
 
     py_db = honker.open(str(db_path))
-    ruby_job = py_db.queue("emails").claim_one("python-worker")
-    assert ruby_job is not None
-    assert ruby_job.payload == {"to": "ruby@example.com"}
-    assert ruby_job.ack()
+    ruby_jobs = py_db.queue("ruby-to-python").claim_batch("python-worker", 50)
+    assert len(ruby_jobs) == 25
+    assert sorted(job.payload["seq"] for job in ruby_jobs) == list(range(25))
+    assert all(job.payload["source"] == "ruby" for job in ruby_jobs)
+    assert (
+        py_db.queue("ruby-to-python").ack_batch(
+            [job.id for job in ruby_jobs],
+            "python-worker",
+        )
+        == 25
+    )
 
     ruby_notification = py_db.query(
         "SELECT payload FROM _honker_notifications "
         "WHERE channel = 'from-ruby' ORDER BY id DESC LIMIT 1"
     )
-    assert json.loads(ruby_notification[0]["payload"]) == {"source": "ruby"}
+    assert json.loads(ruby_notification[0]["payload"]) == {
+        "source": "ruby",
+        "count": 25,
+    }
+    assert len(py_db.stream("interop")._read_since(0, 10)) == 1
 
-    py_db.queue("python-jobs").enqueue({"to": "python@example.com"})
+    py_q = py_db.queue("python-to-ruby")
+    for i in range(25):
+        py_q.enqueue({"source": "python", "seq": i, "key": f"py-{i:02d}"})
     with py_db.transaction() as tx:
-        tx.notify("from-python", {"source": "python"})
+        tx.notify("from-python", {"source": "python", "count": 25})
+    py_db.stream("interop").publish({"source": "python", "kind": "stream"})
 
     out = _run_ruby(
         r'''
@@ -123,23 +141,26 @@ def test_ruby_and_python_share_queue_and_notification_tables(tmp_path):
           ENV.fetch("DB_PATH"),
           extension_path: ENV.fetch("HONKER_EXTENSION_PATH"),
         )
-        job = db.queue("python-jobs").claim_one("ruby-worker")
+        jobs = db.queue("python-to-ruby").claim_batch("ruby-worker", 50)
         note = db.db.get_first_row(
           "SELECT payload FROM _honker_notifications " \
           "WHERE channel = 'from-python' ORDER BY id DESC LIMIT 1"
         )
+        events = db.stream("interop").read_since(0, 10)
         puts JSON.generate({
-          job_payload: job.payload,
-          acked: job.ack,
+          payloads: jobs.map(&:payload),
+          acked: db.queue("python-to-ruby").ack_batch(jobs.map(&:id), "ruby-worker"),
           notification: JSON.parse(note[0]),
+          event_count: events.length,
         })
         db.close
         ''',
         db_path,
     )
     observed = json.loads(out)
-    assert observed == {
-        "job_payload": {"to": "python@example.com"},
-        "acked": True,
-        "notification": {"source": "python"},
-    }
+    assert len(observed["payloads"]) == 25
+    assert sorted(row["seq"] for row in observed["payloads"]) == list(range(25))
+    assert all(row["source"] == "python" for row in observed["payloads"])
+    assert observed["acked"] == 25
+    assert observed["notification"] == {"source": "python", "count": 25}
+    assert observed["event_count"] == 2


### PR DESCRIPTION
## What

Add scary tests. Not tiny proof. Real proof.

- Core gets one pressure test with many producers and workers on one SQLite file.
- Producers use the same SQL functions bindings use: `honker_enqueue`, `honker_stream_publish`, and `notify`.
- Workers race on `honker_claim_batch` and `honker_ack_batch`.
- Test proves every job is claimed once, no jobs are missing, live/dead queues are empty, streams/notifications exist, and SQLite says integrity is ok.

Also add binding interop tests.

Each binding writes real queue jobs, stream rows, and notifications. Python reads them. Then Python writes the same things back. The binding reads them. If one binding drifts from the shared Honker contract, this should hurt loudly.

Covered here:

- Node
- Rust wrapper
- Go through existing interop path
- Bun
- Ruby
- Elixir
- C++
- .NET

## Why

Honker is one core with many language faces. If bindings look same but act different, users lose.

So this PR adds scary proof around the boring truth we need: same database, same tables, same queue behavior, same stream behavior, same notify behavior.

## How

Core test makes load:

```text
4 producers x 75 jobs
6 workers claiming and acking
same SQLite WAL database
```

Binding test shape is simple:

```text
binding writes 25 queue jobs + notify + stream
python claims and checks them
python writes 25 queue jobs + notify + stream
binding claims and checks them
```

No mock. No fake adapter. Real SQLite file. Real extension/binding calls.

CI also now runs Node parity directly, and the Ubuntu binding aggregate runs the interop proofs with the built Python binding and shared extension.
Also fix two brittle tests this hardening pass exposed:

- wake-latency p90 now uses nearest-rank math, so the test matches its own "3 slow scheduler outliers are ok" rule
- .NET listener/cancel tests now assert the real contract instead of depending on task scheduling luck


## Checked

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p honker-core --lib --features bundled-sqlite`
- `cargo test -p honker-core core_sql_functions_survive_concurrent_queue_stream_notify_pressure --lib`
- `cargo test -p honker-core core_sql_functions_survive_concurrent_queue_stream_notify_pressure --lib --features bundled-sqlite`
- `node --test test/cross_lang_queue_stream_notify.js`
- `node --test test/parity.test.js`
- `HONKER_INTEROP_PYTHON=../../.venv/bin/python cargo test --manifest-path packages/honker-rs/Cargo.toml --test python_interop`
- `HONKER_INTEROP_PYTHON=../../.venv/bin/python go test -count=1 -tags sqlite_load_extension ./...`
- `bun test test/python_interop.test.ts`
- `mix test test/python_interop_test.exs`
- `dotnet test packages/honker-dotnet/tests/Honker.Tests/Honker.Tests.csproj --filter FullyQualifiedName~PythonInteropTests --verbosity minimal`
- `python -m pytest tests/test_ruby_python_interop.py -q --tb=short`
- `zig build test -Dhonker-ext=../../target/release/libhonker_ext.dylib -Dsqlite-prefix=/opt/homebrew/opt/sqlite -Djson-prefix=/opt/homebrew/opt/nlohmann-json`

