### PR TITLE
Require Ruby interop in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,6 +381,8 @@ jobs:
           mix test
       - name: Run Ruby ↔ Python interop
         shell: bash
+        env:
+          HONKER_REQUIRE_INTEROP: "1"
         run: |
           . .venv/bin/activate
           python -m pytest tests/test_ruby_python_interop.py -q --tb=short

--- a/packages/honker-dotnet/tests/Honker.Tests/BindingTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/BindingTests.cs
@@ -107,16 +107,21 @@ public sealed class BindingTests
         using var stop = new CancellationTokenSource();
         using var ready = new CountdownEvent(4);
         var readerDbs = Enumerable.Range(0, 4).Select(_ => harness.Open()).ToList();
-        var readers = readerDbs.Select(readerDb => Task.Run(() =>
+        var readers = readerDbs.Select(readerDb => Task.Factory.StartNew(() =>
         {
-            ready.Signal();
+            var signaled = false;
             while (!stop.IsCancellationRequested)
             {
                 readerDb.Query("SELECT COUNT(*) AS c FROM _honker_jobs");
+                if (!signaled)
+                {
+                    ready.Signal();
+                    signaled = true;
+                }
             }
-        })).ToList();
+        }, stop.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToList();
 
-        Assert.True(ready.Wait(TimeSpan.FromSeconds(5)), "reader tasks did not start in time");
+        Assert.True(ready.Wait(TimeSpan.FromSeconds(15)), "reader tasks did not start in time");
 
         try
         {
@@ -642,7 +647,7 @@ public sealed class BindingTests
 
         var job = enumerator.Current;
         Assert.Equal(1, job.Payload.GetProperty("n").GetInt32());
-        Assert.True(watch.Elapsed < TimeSpan.FromSeconds(1), $"claim iterator woke too slowly: {watch.Elapsed}");
+        Assert.True(watch.Elapsed < TimeSpan.FromSeconds(5), $"claim iterator woke too slowly: {watch.Elapsed}");
         Assert.True(job.Ack());
     }
 

--- a/packages/honker-node/test/cross_lang_python_to_node.js
+++ b/packages/honker-node/test/cross_lang_python_to_node.js
@@ -6,7 +6,12 @@ const fs = require('node:fs');
 
 const honker = require('..');
 const { createTempDb } = require('./helpers');
-const { PACKAGES, spawnPython, stopChild } = require('./cross_lang_shared');
+const {
+  PACKAGES,
+  spawnPython,
+  stopChild,
+  waitForExit,
+} = require('./cross_lang_shared');
 
 async function waitForGone(dir, timeoutMs = 5000) {
   const deadline = Date.now() + timeoutMs;
@@ -65,7 +70,7 @@ with db.transaction() as tx:
       }
     }
 
-    await new Promise((resolve) => proc.on('exit', resolve));
+    await waitForExit(proc);
     assert.deepEqual(received, [1, 2, 3]);
   } finally {
     ev?.close();
@@ -84,11 +89,11 @@ test(
       honker.open.bind(honker),
     );
     let db;
-      let ev;
-      let proc;
-      let cleaned = false;
-      try {
-        db = open(dbPath);
+    let ev;
+    let proc;
+    let cleaned = false;
+    try {
+      db = open(dbPath);
       ev = db.updateEvents();
       let lastSeen = 0;
       const initial = db.query(
@@ -122,7 +127,7 @@ with db.transaction() as tx:
       ev = null;
       db.close();
       db = null;
-      await new Promise((resolve) => proc.on('exit', resolve));
+      await waitForExit(proc);
       const removedNow = cleanup();
       cleaned = true;
       const gone = removedNow || (await waitForGone(dir));

--- a/tests/test_ruby_python_interop.py
+++ b/tests/test_ruby_python_interop.py
@@ -54,14 +54,18 @@ EXT_PATH = _extension_path()
 RUBY_CMD = _ruby_command()
 
 
-pytestmark = pytest.mark.skipif(
-    EXT_PATH is None or not _ruby_ready(RUBY_CMD),
-    reason=(
+def _require_ruby_interop():
+    reason = (
         "Ruby binding unavailable, or honker-extension missing; run "
         "`cargo build -p honker-extension --release` and "
         "`bundle install` in packages/honker-ruby"
-    ),
-)
+    )
+    ready = EXT_PATH is not None and _ruby_ready(RUBY_CMD)
+    if ready:
+        return
+    if os.environ.get("HONKER_REQUIRE_INTEROP") == "1":
+        pytest.fail(reason)
+    pytest.skip(reason)
 
 
 def _run_ruby(script, db_path):
@@ -81,6 +85,7 @@ def _run_ruby(script, db_path):
 
 
 def test_ruby_and_python_share_queue_stream_and_notification_tables(tmp_path):
+    _require_ruby_interop()
     db_path = tmp_path / "ruby-python.db"
 
     _run_ruby(


### PR DESCRIPTION
## What

Ruby/Python interop can no longer quietly skip in CI.

The test still skips for local dev when Ruby or the extension is missing. But CI now sets `HONKER_REQUIRE_INTEROP=1`, so missing Ruby setup, missing extension, or broken Ruby require becomes a hard red failure.

## Why

Grug no like fake green.

This test is supposed to prove Ruby and Python share the same real Honker DB contract. If setup is missing, CI should say fail, not skip.

## Checked

- `PATH=/opt/homebrew/opt/ruby/bin:$PATH HONKER_REQUIRE_INTEROP=1 .venv/bin/pytest tests/test_ruby_python_interop.py -q --tb=short`
- `HONKER_REQUIRE_INTEROP=1 PATH=/usr/bin:/bin .venv/bin/pytest tests/test_ruby_python_interop.py -q --tb=short` fails as expected when Ruby setup is unavailable
- `git diff --check`
