### PR TITLE
Add real app and package install proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,8 @@ jobs:
         with:
           dotnet-version: "10.0.x"
       - uses: mlugg/setup-zig@v2
+        with:
+          use-cache: false
       - uses: oven-sh/setup-bun@v2
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/package-proof.yml
+++ b/.github/workflows/package-proof.yml
@@ -19,18 +19,20 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.14"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "24"
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: "10.0.x"
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f  # v1
         with:
           ruby-version: "3.4"
       - name: Run packaged install proof

--- a/.github/workflows/package-proof.yml
+++ b/.github/workflows/package-proof.yml
@@ -1,0 +1,37 @@
+name: Proof · packaged installs
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Sunday morning UTC. This is release proof, not PR proof.
+    - cron: "17 8 * * 0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  packaged-installs:
+    name: packaged installs · ubuntu
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+      - name: Run packaged install proof
+        run: scripts/proof/package-install-smoke.sh

--- a/.github/workflows/scary-nightly.yml
+++ b/.github/workflows/scary-nightly.yml
@@ -1,0 +1,80 @@
+name: Proof · scary nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekday morning UTC. Not PR-default; this is bigger proof.
+    - cron: "23 7 * * 1-5"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scary-python-core:
+    name: scary core · ubuntu
+    timeout-minutes: 35
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Build Python binding
+        shell: bash
+        run: |
+          uv venv --python "3.14" .venv
+          . .venv/bin/activate
+          uv pip install pytest pytest-asyncio pytest-xdist maturin
+          cargo build --release -p honker-extension
+          cd packages/honker
+          maturin develop --release
+      - name: Cross-process and crash proofs
+        shell: bash
+        run: |
+          . .venv/bin/activate
+          python -m pytest -q -n 0 --tb=short \
+            tests/test_crash_recovery.py \
+            tests/test_cross_process_wake_latency.py \
+            tests/test_multiprocess.py \
+            tests/test_resource_bounds.py \
+            tests/test_real_app_example.py
+      - name: Slow soak proofs
+        shell: bash
+        run: |
+          . .venv/bin/activate
+          python -m pytest -q -n 0 -o addopts="" -m slow tests/test_soak.py --tb=short
+      - name: Linux fault-injection proofs
+        shell: bash
+        run: |
+          . .venv/bin/activate
+          python -m pytest -q -n 0 -o addopts="" -m linux_only tests/test_fault_injection.py --tb=short
+
+  packaged-installs:
+    name: packaged installs · ubuntu
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+      - name: Run packaged install proof
+        run: scripts/proof/package-install-smoke.sh

--- a/.github/workflows/scary-nightly.yml
+++ b/.github/workflows/scary-nightly.yml
@@ -46,6 +46,7 @@ jobs:
             tests/test_crash_recovery.py \
             tests/test_cross_process_wake_latency.py \
             tests/test_multiprocess.py \
+            tests/test_real_e2e_scenarios.py \
             tests/test_resource_bounds.py \
             tests/test_real_app_example.py
       - name: Slow soak proofs

--- a/.github/workflows/scary-nightly.yml
+++ b/.github/workflows/scary-nightly.yml
@@ -19,12 +19,14 @@ jobs:
     timeout-minutes: 35
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.14"
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
         with:
           enable-cache: true
       - name: Build Python binding
@@ -62,18 +64,20 @@ jobs:
     timeout-minutes: 25
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.14"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "24"
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: "10.0.x"
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f  # v1
         with:
           ruby-version: "3.4"
       - name: Run packaged install proof

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -1,0 +1,45 @@
+# Binding Support
+
+Honker's core is Rust. The extension owns the SQLite schema and SQL
+functions. Bindings are thin language wrappers over that same shape.
+
+This table is meant to be boring and honest. "Yes" means the feature
+has a typed binding and runs in root CI. "SQL" means the extension
+feature is available through raw SQL, but the language wrapper does
+not expose the nice API yet.
+
+| Binding | Package proof | Queue | Streams | Notify/listen | Scheduler | Wake behavior |
+|---|---:|---:|---:|---:|---:|---|
+| SQLite extension | load smoke | SQL | SQL | notify SQL only | SQL | host language must watch/read |
+| Python `honker` | yes | yes | yes | yes | yes | shared Rust `UpdateWatcher` |
+| Node `@russellthehippo/honker-node` | yes | yes | yes | yes | yes | shared Rust `UpdateWatcher` |
+| .NET `Honker` | yes | yes | yes | yes | yes | .NET `PRAGMA data_version` poller |
+| Rust `honker` | CI | yes | yes | yes | yes | shared Rust `UpdateWatcher` |
+| Go | CI | yes | yes | yes | yes | Go `PRAGMA data_version` poller |
+| Bun `@russellthehippo/honker-bun` | CI | yes | yes | yes | yes | Bun `PRAGMA data_version` poller |
+| C++ | CI | yes | yes | yes | yes | C++ `PRAGMA data_version` poller |
+| Ruby `honker` | yes | yes | yes | notify yes, listen no | yes | no async listener API yet |
+| Elixir `honker` | CI | yes | yes | notify yes, listen no | yes | local update snapshots + PRAGMA polling |
+
+## What CI Proves
+
+- PR CI runs Rust core/extension on Linux, macOS, and Windows.
+- PR CI runs Python on Linux, macOS, and Windows.
+- PR CI runs Node on Linux, macOS, and Windows.
+- PR CI runs .NET on Linux, macOS, and Windows.
+- The aggregate Linux binding smoke runs Rust wrapper, Go, .NET
+  Python interop, C++, Bun, Ruby, Elixir, and Ruby <-> Python interop.
+- The packaged-install proof workflow builds and installs Python,
+  Node, Ruby, and .NET packages into clean throwaway consumers.
+
+## What Is Not Proven Yet
+
+- Published registry installs after release. The proof workflow uses
+  locally-built artifacts, which catches packaging shape but not registry
+  permissions or CDN weirdness.
+- Every possible cross-language pair. CI proves representative pairs
+  and shared table behavior. It does not run N x N interop.
+- Long soak on every OS. The scary nightly workflow soaks Linux; PR CI
+  stays shorter.
+- Ruby and Elixir do not yet have the same async listener API as
+  Python/Node/.NET/Rust/Go/Bun/C++.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 honker ships as a [Rust crate](https://crates.io/crates/honker) (`honker`, plus `honker-core`/`honker-extension`), a [SQLite loadable extension](#sqlite-extension-any-sqlite-39-client), and language packages: Python (`honker`), Node (`@russellthehippo/honker-node`), Bun (`@russellthehippo/honker-bun`), Ruby (`honker`), Go, Elixir, C++, and .NET / C#. The on-disk layout is defined once in Rust; every binding is a thin wrapper around the loadable extension.
 
+See [Binding support](BINDINGS.md) for the current truth table: which
+bindings have typed queue/stream/listen/scheduler APIs, which ones have
+packaged-install proof, and what CI actually proves.
+
 `honker` works by replacing application-level polling with a single-digit-µs `PRAGMA data_version` read on the database every 1ms, achieving push-like semantics and cross-process notifications with single-digit-millisecond delivery.
 
 > Experimental. API may change.

--- a/bench/README.md
+++ b/bench/README.md
@@ -57,6 +57,20 @@ Replay became a million-per-second after swapping `list.pop(0)` for
 `collections.deque.popleft()` on the 1000-row refresh buffer — the
 O(n) shift-everything was the bottleneck, not the SQL.
 
+### Wake / idle watcher
+
+```
+cross-process notify/listen wake:      p50 ~= 0.7ms on M-series
+PRAGMA data_version poll cost:         ~3.5us/poll
+idle watcher cost at 1kHz:             ~3.5ms CPU/sec per Database
+```
+
+The wake path is intentionally boring: one `PRAGMA data_version` read
+every 1ms per open `Database`, then fan-out to subscribers. 100
+listeners still means one poll thread. The faster shm reader benchmark
+exists, but the current CPU cost is low enough that correctness and
+portability win for now.
+
 ## Platform ceiling
 
 Raw Python `sqlite3` single-tx on the same WAL+`synchronous=NORMAL`

--- a/packages/honker-node/index.js
+++ b/packages/honker-node/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-android-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-android-arm-eabi')
         const bindingPackageVersion = require('@russellthehippo/honker-node-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-x64-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-x64-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-ia32-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-arm64-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@russellthehippo/honker-node-darwin-universal')
       const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-darwin-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-darwin-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-freebsd-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-freebsd-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-x64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-x64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm-musleabihf')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-loong64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-loong64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-riscv64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-riscv64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-linux-ppc64-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-linux-s390x-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-arm')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.3.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/packages/honker/examples/README.md
+++ b/packages/honker/examples/README.md
@@ -14,6 +14,7 @@ PYTHONPATH=packages .venv/bin/python packages/honker/examples/atomic.py
 | [`notify_listen.py`](notify_listen.py) | Ephemeral `pg_notify`-style pub/sub. |
 | [`stream.py`](stream.py) | Durable pub/sub with per-consumer offset tracking + resume-after-crash. |
 | [`scheduler.py`](scheduler.py) | Time-trigger scheduling with leader election. Shows cron-style schedules; the library also supports `every_s(...)` and 6-field cron. |
+| [`real_app.py`](real_app.py) | One small app-shaped proof: business write, queue, stream, notify, worker, and scheduler all on one `.db`. |
 
 The task example also demonstrates the CLI worker flow:
 

--- a/packages/honker/examples/real_app.py
+++ b/packages/honker/examples/real_app.py
@@ -1,14 +1,16 @@
 """Small real-app proof.
 
-One process pretends to be a web request:
+One process is a web request. A second process is already waiting like
+a worker:
 
 * insert an order
 * enqueue an email
 * publish a durable stream event
 * notify a live listener
 
-All four writes commit together. Then a worker claims the email, the
-stream consumer reads the event, and a scheduler fires a cleanup job.
+All four writes commit together. The worker process must wake, claim the
+email, observe the notification, and read the stream event promptly. Then
+a scheduler fires a cleanup job.
 
 Run:
 
@@ -18,12 +20,25 @@ Run:
 from __future__ import annotations
 
 import asyncio
+import json
 import os
+import sys
 import tempfile
+import time
 from dataclasses import dataclass
 
 import honker
 from honker import Scheduler, every_s
+
+
+WORKER_IDLE_POLL_S = 30.0
+WORKER_RESULT_TIMEOUT_S = 8.0
+
+
+def _close_db(db) -> None:
+    close = getattr(getattr(db, "_inner", None), "close", None)
+    if callable(close):
+        close()
 
 
 @dataclass
@@ -33,6 +48,98 @@ class Proof:
     stream_event: dict
     notification: dict
     scheduler_payload: dict
+    worker_wake_ms: float
+
+
+async def _worker_claim_email(db, worker_id: str) -> dict:
+    emails = db.queue("emails")
+    async for job in emails.claim(worker_id, idle_poll_s=WORKER_IDLE_POLL_S):
+        payload = job.payload
+        assert job.ack()
+        return payload
+    raise RuntimeError("email worker stopped before claiming a job")
+
+
+async def _worker_listen_order(db) -> dict:
+    async for note in db.listen("orders"):
+        return note.payload
+    raise RuntimeError("listener stopped before receiving an order notification")
+
+
+async def _worker_read_stream(db) -> dict:
+    events = db.stream("order-events")
+    stream_iter = events.subscribe(
+        consumer="dashboard-worker",
+        save_every_n=0,
+        save_every_s=0,
+    )
+    event = await stream_iter.__anext__()
+    events.save_offset("dashboard-worker", event.offset)
+    return event.payload
+
+
+async def _worker_process(db_path: str) -> None:
+    db = honker.open(db_path)
+
+    try:
+        email_task = asyncio.create_task(_worker_claim_email(db, "mailer-1"))
+        notification_task = asyncio.create_task(_worker_listen_order(db))
+        stream_task = asyncio.create_task(_worker_read_stream(db))
+
+        # Let each async iterator subscribe before the parent writes. This is
+        # the user shape we care about: worker asleep first, writer commits later.
+        await asyncio.sleep(0.05)
+        print("READY", flush=True)
+
+        email_payload, notification, stream_event = await asyncio.wait_for(
+            asyncio.gather(email_task, notification_task, stream_task),
+            timeout=WORKER_RESULT_TIMEOUT_S,
+        )
+        print(
+            "RESULT "
+            + json.dumps(
+                {
+                    "email": email_payload,
+                    "notification": notification,
+                    "stream_event": stream_event,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+    finally:
+        _close_db(db)
+
+
+async def _read_child_line(proc, timeout_s: float) -> str:
+    assert proc.stdout is not None
+    line = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout_s)
+    if not line:
+        stderr = ""
+        if proc.stderr is not None:
+            stderr = (await proc.stderr.read()).decode(errors="replace")
+        raise RuntimeError(f"worker exited before writing a line: {stderr}")
+    return line.decode().strip()
+
+
+async def _start_worker(db_path: str):
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        os.path.abspath(__file__),
+        "--worker",
+        db_path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        ready = await _read_child_line(proc, timeout_s=5.0)
+        assert ready == "READY", f"worker did not become ready: {ready!r}"
+
+        return proc
+    except BaseException:
+        proc.kill()
+        await proc.wait()
+        raise
 
 
 async def run(db_path: str) -> Proof:
@@ -47,31 +154,33 @@ async def run(db_path: str) -> Proof:
             "(id INTEGER PRIMARY KEY, email TEXT NOT NULL, total INTEGER NOT NULL)"
         )
 
-    async def wait_for_order_notification():
-        async for note in db.listen("orders"):
-            return note.payload
+    worker_proc = await _start_worker(db_path)
 
-    notification_task = asyncio.create_task(wait_for_order_notification())
-    await asyncio.sleep(0.05)
+    try:
+        with db.transaction() as tx:
+            tx.execute(
+                "INSERT INTO orders (id, email, total) VALUES (?, ?, ?)",
+                [1, "alice@example.com", 4999],
+            )
+            emails.enqueue({"order_id": 1, "to": "alice@example.com"}, tx=tx)
+            events.publish({"order_id": 1, "kind": "created"}, tx=tx)
+            tx.notify("orders", {"order_id": 1, "kind": "created"})
+        committed_at = time.perf_counter()
 
-    with db.transaction() as tx:
-        tx.execute(
-            "INSERT INTO orders (id, email, total) VALUES (?, ?, ?)",
-            [1, "alice@example.com", 4999],
+        result_line = await _read_child_line(
+            worker_proc,
+            timeout_s=WORKER_RESULT_TIMEOUT_S,
         )
-        emails.enqueue({"order_id": 1, "to": "alice@example.com"}, tx=tx)
-        events.publish({"order_id": 1, "kind": "created"}, tx=tx)
-        tx.notify("orders", {"order_id": 1, "kind": "created"})
+        result_received_at = time.perf_counter()
+        assert result_line.startswith("RESULT "), result_line
+        worker_result = json.loads(result_line.removeprefix("RESULT "))
 
-    notification = await asyncio.wait_for(notification_task, timeout=3.0)
-
-    email_job = emails.claim_one("mailer-1")
-    assert email_job is not None
-    assert email_job.ack()
-
-    stream_iter = events.subscribe(consumer="dashboard")
-    stream_event = await asyncio.wait_for(stream_iter.__anext__(), timeout=3.0)
-    events.save_offset("dashboard", stream_event.offset)
+        code = await asyncio.wait_for(worker_proc.wait(), timeout=3.0)
+        assert code == 0
+    finally:
+        if worker_proc.returncode is None:
+            worker_proc.kill()
+            await worker_proc.wait()
 
     scheduler = Scheduler(db)
     scheduler.add(
@@ -96,13 +205,16 @@ async def run(db_path: str) -> Proof:
         stop.set()
         await asyncio.wait_for(scheduler_task, timeout=3.0)
 
-    return Proof(
+    proof = Proof(
         order_id=1,
-        email_sent_to=email_job.payload["to"],
-        stream_event=stream_event.payload,
-        notification=notification,
+        email_sent_to=worker_result["email"]["to"],
+        stream_event=worker_result["stream_event"],
+        notification=worker_result["notification"],
         scheduler_payload=scheduled_job.payload,
+        worker_wake_ms=(result_received_at - committed_at) * 1000.0,
     )
+    _close_db(db)
+    return proof
 
 
 async def main() -> None:
@@ -113,7 +225,11 @@ async def main() -> None:
         print(f"stream: {proof.stream_event}")
         print(f"notify: {proof.notification}")
         print(f"scheduler: {proof.scheduler_payload}")
+        print(f"worker wake: {proof.worker_wake_ms:.1f} ms")
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    if len(sys.argv) == 3 and sys.argv[1] == "--worker":
+        asyncio.run(_worker_process(sys.argv[2]))
+    else:
+        asyncio.run(main())

--- a/packages/honker/examples/real_app.py
+++ b/packages/honker/examples/real_app.py
@@ -1,0 +1,119 @@
+"""Small real-app proof.
+
+One process pretends to be a web request:
+
+* insert an order
+* enqueue an email
+* publish a durable stream event
+* notify a live listener
+
+All four writes commit together. Then a worker claims the email, the
+stream consumer reads the event, and a scheduler fires a cleanup job.
+
+Run:
+
+    python packages/honker/examples/real_app.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from dataclasses import dataclass
+
+import honker
+from honker import Scheduler, every_s
+
+
+@dataclass
+class Proof:
+    order_id: int
+    email_sent_to: str
+    stream_event: dict
+    notification: dict
+    scheduler_payload: dict
+
+
+async def run(db_path: str) -> Proof:
+    db = honker.open(db_path)
+    emails = db.queue("emails")
+    maintenance = db.queue("maintenance")
+    events = db.stream("order-events")
+
+    with db.transaction() as tx:
+        tx.execute(
+            "CREATE TABLE IF NOT EXISTS orders "
+            "(id INTEGER PRIMARY KEY, email TEXT NOT NULL, total INTEGER NOT NULL)"
+        )
+
+    async def wait_for_order_notification():
+        async for note in db.listen("orders"):
+            return note.payload
+
+    notification_task = asyncio.create_task(wait_for_order_notification())
+    await asyncio.sleep(0.05)
+
+    with db.transaction() as tx:
+        tx.execute(
+            "INSERT INTO orders (id, email, total) VALUES (?, ?, ?)",
+            [1, "alice@example.com", 4999],
+        )
+        emails.enqueue({"order_id": 1, "to": "alice@example.com"}, tx=tx)
+        events.publish({"order_id": 1, "kind": "created"}, tx=tx)
+        tx.notify("orders", {"order_id": 1, "kind": "created"})
+
+    notification = await asyncio.wait_for(notification_task, timeout=3.0)
+
+    email_job = emails.claim_one("mailer-1")
+    assert email_job is not None
+    assert email_job.ack()
+
+    stream_iter = events.subscribe(consumer="dashboard")
+    stream_event = await asyncio.wait_for(stream_iter.__anext__(), timeout=3.0)
+    events.save_offset("dashboard", stream_event.offset)
+
+    scheduler = Scheduler(db)
+    scheduler.add(
+        name="cleanup",
+        queue="maintenance",
+        schedule=every_s(1),
+        payload={"task": "prune_notifications"},
+    )
+    stop = asyncio.Event()
+    scheduler_task = asyncio.create_task(scheduler.run(stop))
+    try:
+        deadline = asyncio.get_running_loop().time() + 3.0
+        scheduled_job = None
+        while asyncio.get_running_loop().time() < deadline:
+            scheduled_job = maintenance.claim_one("maint-1")
+            if scheduled_job is not None:
+                break
+            await asyncio.sleep(0.05)
+        assert scheduled_job is not None
+        assert scheduled_job.ack()
+    finally:
+        stop.set()
+        await asyncio.wait_for(scheduler_task, timeout=3.0)
+
+    return Proof(
+        order_id=1,
+        email_sent_to=email_job.payload["to"],
+        stream_event=stream_event.payload,
+        notification=notification,
+        scheduler_payload=scheduled_job.payload,
+    )
+
+
+async def main() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        proof = await run(os.path.join(d, "app.db"))
+        print(f"order: {proof.order_id}")
+        print(f"email: {proof.email_sent_to}")
+        print(f"stream: {proof.stream_event}")
+        print(f"notify: {proof.notification}")
+        print(f"scheduler: {proof.scheduler_payload}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/proof/package-install-smoke.sh
+++ b/scripts/proof/package-install-smoke.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build packages, install them into throwaway consumer projects, and run
+# tiny user-shaped smoke tests. This is release proof, not normal dev CI.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="${TMPDIR:-/tmp}/honker-package-proof-$$"
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [[ -z "$PYTHON_BIN" && -x "$ROOT/.venv/bin/python" ]]; then
+  PYTHON_BIN="$ROOT/.venv/bin/python"
+fi
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+RUBY_BIN="${RUBY_BIN:-}"
+if [[ -z "$RUBY_BIN" ]] && command -v brew >/dev/null 2>&1; then
+  BREW_RUBY="$(brew --prefix ruby 2>/dev/null || true)"
+  if [[ -n "$BREW_RUBY" && -x "$BREW_RUBY/bin/ruby" ]]; then
+    RUBY_BIN="$BREW_RUBY/bin/ruby"
+  fi
+fi
+RUBY_BIN="${RUBY_BIN:-ruby}"
+mkdir -p "$TMP"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$ROOT"
+
+echo "== build extension =="
+cargo build --release -p honker-extension
+EXT="$ROOT/target/release/libhonker_ext.so"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  EXT="$ROOT/target/release/libhonker_ext.dylib"
+fi
+if [[ ! -f "$EXT" ]]; then
+  echo "honker extension not found at $EXT" >&2
+  exit 1
+fi
+
+echo "== python wheel install =="
+"$PYTHON_BIN" -m venv "$TMP/py"
+"$TMP/py/bin/python" -m pip install --upgrade pip maturin >/dev/null
+"$TMP/py/bin/python" -m maturin build --release \
+  -i "$TMP/py/bin/python" \
+  --manifest-path "$ROOT/packages/honker/Cargo.toml" \
+  --out "$TMP/wheels"
+"$TMP/py/bin/python" -m pip install "$TMP"/wheels/*.whl >/dev/null
+"$TMP/py/bin/python" - <<'PY'
+import tempfile
+import honker
+
+with tempfile.TemporaryDirectory() as d:
+    db = honker.open(f"{d}/app.db")
+    q = db.queue("emails")
+    job_id = q.enqueue({"to": "alice@example.com"})
+    job = q.claim_one("worker-1")
+    assert job and job.id == job_id
+    assert job.payload["to"] == "alice@example.com"
+    assert job.ack()
+print("python package smoke ok")
+PY
+
+echo "== node package install =="
+mkdir -p "$TMP/npm"
+(
+  cd "$ROOT/packages/honker-node"
+  npm install
+  npx napi build --platform --release
+  npm pack --pack-destination "$TMP/npm"
+)
+mkdir -p "$TMP/node-consumer"
+(
+  cd "$TMP/node-consumer"
+  npm init -y >/dev/null
+  npm install "$TMP"/npm/*.tgz >/dev/null
+  node <<'JS'
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { open } = require('@russellthehippo/honker-node');
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'honker-node-proof-'));
+try {
+  const db = open(path.join(dir, 'app.db'));
+  const q = db.queue('emails');
+  const id = q.enqueue({ to: 'alice@example.com' });
+  const job = q.claimOne('worker-1');
+  assert.equal(job.id, id);
+  assert.equal(job.payload.to, 'alice@example.com');
+  assert.equal(job.ack(), true);
+  db.close();
+  console.log('node package smoke ok');
+} finally {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+JS
+)
+
+echo "== ruby gem install =="
+(
+  cd "$ROOT/packages/honker-ruby"
+  "$RUBY_BIN" -S gem build honker.gemspec --output "$TMP/honker.gem"
+)
+GEM_HOME="$TMP/gems" GEM_PATH="$TMP/gems" "$RUBY_BIN" -S gem install "$TMP/honker.gem" >/dev/null
+GEM_HOME="$TMP/gems" GEM_PATH="$TMP/gems" HONKER_EXTENSION_PATH="$EXT" "$RUBY_BIN" <<'RB'
+require "tmpdir"
+require "honker"
+
+Dir.mktmpdir("honker-ruby-proof-") do |dir|
+  db = Honker::Database.new(File.join(dir, "app.db"), extension_path: ENV.fetch("HONKER_EXTENSION_PATH"))
+  q = db.queue("emails")
+  id = q.enqueue({to: "alice@example.com"})
+  job = q.claim_one("worker-1")
+  raise "claim failed" unless job && job.id == id
+  raise "payload mismatch" unless job.payload["to"] == "alice@example.com"
+  raise "ack failed" unless job.ack
+  db.close
+end
+puts "ruby package smoke ok"
+RB
+
+echo "== dotnet nuget install =="
+RID="linux-x64"
+NATIVE="libhonker_ext.so"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  RID="osx-arm64"
+  NATIVE="libhonker_ext.dylib"
+fi
+mkdir -p "$ROOT/packages/honker-dotnet/src/Honker/package-assets/runtimes/$RID/native"
+cp "$EXT" "$ROOT/packages/honker-dotnet/src/Honker/package-assets/runtimes/$RID/native/$NATIVE"
+dotnet pack "$ROOT/packages/honker-dotnet/src/Honker/Honker.csproj" \
+  -c Release \
+  -p:PackageVersion=0.0.0-proof \
+  -o "$TMP/nuget" >/dev/null
+mkdir -p "$TMP/dotnet-consumer"
+(
+  cd "$TMP/dotnet-consumer"
+  dotnet new console >/dev/null
+  dotnet add package Honker --version 0.0.0-proof --source "$TMP/nuget" >/dev/null
+  cat > Program.cs <<'CS'
+using Honker;
+using System.Text.Json;
+
+var dir = Path.Combine(Path.GetTempPath(), $"honker-dotnet-proof-{Guid.NewGuid():N}");
+Directory.CreateDirectory(dir);
+try
+{
+    using var db = Database.Open(Path.Combine(dir, "app.db"));
+    var q = db.Queue("emails");
+    var id = q.Enqueue(new { to = "alice@example.com" });
+    var job = q.ClaimOne("worker-1") ?? throw new Exception("claim failed");
+    if (job.Id != id) throw new Exception("id mismatch");
+    if (job.Payload.GetProperty("to").GetString() != "alice@example.com")
+        throw new Exception("payload mismatch");
+    if (!job.Ack()) throw new Exception("ack failed");
+    Console.WriteLine("dotnet package smoke ok");
+}
+finally
+{
+    Directory.Delete(dir, recursive: true);
+}
+CS
+  dotnet run --no-restore
+)
+
+echo "package install proof ok"

--- a/tests/test_real_app_example.py
+++ b/tests/test_real_app_example.py
@@ -23,3 +23,4 @@ async def test_real_app_example_proves_request_worker_stream_notify_scheduler(db
     assert proof.stream_event == {"order_id": 1, "kind": "created"}
     assert proof.notification == {"order_id": 1, "kind": "created"}
     assert proof.scheduler_payload == {"task": "prune_notifications"}
+    assert proof.worker_wake_ms < 5000.0

--- a/tests/test_real_app_example.py
+++ b/tests/test_real_app_example.py
@@ -1,0 +1,25 @@
+import importlib.util
+import sys
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location(
+        "honker_real_app_example",
+        "packages/honker/examples/real_app.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+async def test_real_app_example_proves_request_worker_stream_notify_scheduler(db_path):
+    example = _load_example()
+    proof = await example.run(db_path)
+
+    assert proof.order_id == 1
+    assert proof.email_sent_to == "alice@example.com"
+    assert proof.stream_event == {"order_id": 1, "kind": "created"}
+    assert proof.notification == {"order_id": 1, "kind": "created"}
+    assert proof.scheduler_payload == {"task": "prune_notifications"}

--- a/tests/test_real_e2e_scenarios.py
+++ b/tests/test_real_e2e_scenarios.py
@@ -1,0 +1,490 @@
+"""Real user-shaped end-to-end scenarios.
+
+These tests use separate Python processes that share one SQLite file.
+That is the deployment shape Honker is trying to make boring: an app
+process commits data, sleeping workers/listeners wake, and all state is
+in the same database file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import textwrap
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+import honker
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PACKAGES_ROOT = os.path.join(REPO_ROOT, "packages")
+HONKER_PYTHON_ROOT = os.path.join(PACKAGES_ROOT, "honker", "python")
+IDLE_POLL_S = 30.0
+
+EXT_CANDIDATES = [
+    os.path.join(REPO_ROOT, "target", "release", "libhonker_ext.dylib"),
+    os.path.join(REPO_ROOT, "target", "release", "libhonker_ext.so"),
+    os.path.join(REPO_ROOT, "target", "release", "honker_ext.dll"),
+]
+EXT_PATH = next((p for p in EXT_CANDIDATES if os.path.exists(p)), None)
+HAS_LOAD_EXTENSION = hasattr(sqlite3.connect(":memory:"), "enable_load_extension")
+
+
+CHILD = r"""
+import asyncio
+import json
+import os
+import sqlite3
+import sys
+import time
+
+sys.path.insert(0, {honker_python!r})
+sys.path.insert(0, {packages!r})
+import honker
+
+IDLE_POLL_S = {idle_poll_s!r}
+
+
+def close_db(db):
+    close = getattr(getattr(db, "_inner", None), "close", None)
+    if callable(close):
+        close()
+
+
+async def claim_and_ack(db_path, queue, worker):
+    db = honker.open(db_path)
+    try:
+        q = db.queue(queue)
+        it = q.claim(worker, idle_poll_s=IDLE_POLL_S)
+        print("READY", flush=True)
+        async for job in it:
+            payload = job.payload
+            claimed_at = time.time()
+            assert job.ack()
+            print("RESULT " + json.dumps({{
+                "payload": payload,
+                "claimed_at": claimed_at,
+                "job_id": job.id,
+            }}, sort_keys=True), flush=True)
+            return
+    finally:
+        close_db(db)
+
+
+def crash_after_claim(db_path, queue, worker):
+    db = honker.open(db_path)
+    q = db.queue(queue, visibility_timeout_s=2)
+    job = q.claim_one(worker)
+    assert job is not None
+    print("CLAIMED " + json.dumps(job.payload, sort_keys=True), flush=True)
+    os._exit(0)
+
+
+async def retry_claim(db_path, queue, worker, delay_s):
+    db = honker.open(db_path)
+    try:
+        q = db.queue(queue, max_attempts=2)
+        it = q.claim(worker, idle_poll_s=IDLE_POLL_S)
+        print("READY", flush=True)
+        async for job in it:
+            assert job.retry(delay_s=int(delay_s), error=f"retry by {{worker}}")
+            print("RETRIED " + json.dumps({{
+                "attempts": job.attempts,
+                "payload": job.payload,
+                "at": time.time(),
+            }}, sort_keys=True), flush=True)
+            return
+    finally:
+        close_db(db)
+
+
+async def save_result_worker(db_path, queue):
+    db = honker.open(db_path)
+    try:
+        q = db.queue(queue)
+        it = q.claim("result-worker", idle_poll_s=IDLE_POLL_S)
+        print("READY", flush=True)
+        async for job in it:
+            value = {{"sum": job.payload["x"] + job.payload["y"]}}
+            q.save_result(job.id, value, ttl=60)
+            assert job.ack()
+            print("SAVED " + json.dumps(value, sort_keys=True), flush=True)
+            return
+    finally:
+        close_db(db)
+
+
+async def wait_result(db_path, queue, job_id):
+    db = honker.open(db_path)
+    try:
+        q = db.queue(queue)
+        waiter = asyncio.create_task(q.wait_result(int(job_id), timeout=IDLE_POLL_S))
+        await asyncio.sleep(0.05)
+        print("READY", flush=True)
+        value = await waiter
+        print("RESULT " + json.dumps(value, sort_keys=True), flush=True)
+    finally:
+        close_db(db)
+
+
+def rate_limit_once(db_path, name, limit, per):
+    db = honker.open(db_path)
+    try:
+        ok = db.try_rate_limit(name, limit=int(limit), per=int(per))
+        print("RESULT " + json.dumps({{"ok": ok}}), flush=True)
+    finally:
+        close_db(db)
+
+
+def lock_holder_crash(db_path, name, ttl):
+    db = honker.open(db_path)
+    lock = db.lock(name, ttl=int(ttl), owner="holder")
+    lock.__enter__()
+    print("HELD", flush=True)
+    os._exit(0)
+
+
+async def lock_waiter(db_path, name, ttl):
+    db = honker.open(db_path)
+    try:
+        try:
+            with db.lock(name, ttl=int(ttl), owner="waiter"):
+                print("UNEXPECTED", flush=True)
+                return
+        except honker.LockHeld:
+            print("BLOCKED", flush=True)
+        await asyncio.sleep(int(ttl) + 1.2)
+        with db.lock(name, ttl=int(ttl), owner="waiter"):
+            print("ACQUIRED", flush=True)
+    finally:
+        close_db(db)
+
+
+async def stream_read(db_path, stream_name, consumer, count):
+    db = honker.open(db_path)
+    try:
+        stream = db.stream(stream_name)
+        it = stream.subscribe(
+            consumer=consumer,
+            save_every_n=0,
+            save_every_s=0,
+        )
+        print("READY", flush=True)
+        out = []
+        for _ in range(int(count)):
+            event = await asyncio.wait_for(it.__anext__(), timeout=IDLE_POLL_S)
+            out.append({{"offset": event.offset, "payload": event.payload}})
+            stream.save_offset(consumer, event.offset)
+        print("RESULT " + json.dumps(out, sort_keys=True), flush=True)
+    finally:
+        close_db(db)
+
+
+def raw_sql_enqueue(db_path, ext_path, commit):
+    conn = sqlite3.connect(db_path)
+    conn.enable_load_extension(True)
+    conn.load_extension(ext_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("SELECT honker_bootstrap()")
+    conn.execute("CREATE TABLE IF NOT EXISTS orders (id INTEGER PRIMARY KEY, email TEXT)")
+    conn.execute("BEGIN IMMEDIATE")
+    conn.execute("INSERT INTO orders (id, email) VALUES (1, 'alice@example.com')")
+    conn.execute(
+        "SELECT honker_enqueue(?, ?, NULL, NULL, 0, 3, NULL)",
+        ("emails", json.dumps({{"to": "alice@example.com", "order_id": 1}})),
+    )
+    if commit == "commit":
+        conn.commit()
+        print("COMMIT", flush=True)
+    else:
+        conn.rollback()
+        print("ROLLBACK", flush=True)
+    conn.close()
+
+
+async def main():
+    role = sys.argv[1]
+    if role == "claim":
+        await claim_and_ack(sys.argv[2], sys.argv[3], sys.argv[4])
+    elif role == "crash-after-claim":
+        crash_after_claim(sys.argv[2], sys.argv[3], sys.argv[4])
+    elif role == "retry-claim":
+        await retry_claim(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+    elif role == "save-result-worker":
+        await save_result_worker(sys.argv[2], sys.argv[3])
+    elif role == "wait-result":
+        await wait_result(sys.argv[2], sys.argv[3], sys.argv[4])
+    elif role == "rate-limit":
+        rate_limit_once(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+    elif role == "lock-holder-crash":
+        lock_holder_crash(sys.argv[2], sys.argv[3], sys.argv[4])
+    elif role == "lock-waiter":
+        await lock_waiter(sys.argv[2], sys.argv[3], sys.argv[4])
+    elif role == "stream-read":
+        await stream_read(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+    elif role == "raw-sql-enqueue":
+        raw_sql_enqueue(sys.argv[2], sys.argv[3], sys.argv[4])
+    else:
+        raise SystemExit(f"unknown role: {{role}}")
+
+
+asyncio.run(main())
+""".format(
+    honker_python=HONKER_PYTHON_ROOT,
+    packages=PACKAGES_ROOT,
+    idle_poll_s=IDLE_POLL_S,
+)
+
+
+def _spawn(*args: str) -> subprocess.Popen:
+    return subprocess.Popen(
+        [sys.executable, "-c", CHILD, *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _run(*args: str, timeout: float = 20.0) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", CHILD, *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _line(proc: subprocess.Popen, timeout: float = 12.0) -> str:
+    assert proc.stdout is not None
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        line = proc.stdout.readline()
+        if line:
+            return line.strip()
+        if proc.poll() is not None:
+            break
+    stderr = ""
+    if proc.stderr is not None:
+        stderr = proc.stderr.read()
+    raise AssertionError(f"child produced no line; rc={proc.poll()} stderr={stderr}")
+
+
+def _json_line(line: str, prefix: str = "RESULT ") -> dict | list:
+    assert line.startswith(prefix), line
+    return json.loads(line.removeprefix(prefix))
+
+
+def _finish(proc: subprocess.Popen, timeout: float = 5.0) -> None:
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5.0)
+    assert proc.returncode == 0, (
+        f"child exited {proc.returncode}; stderr="
+        f"{proc.stderr.read() if proc.stderr else ''}"
+    )
+
+
+def test_delayed_job_wakes_sleeping_worker_process(db_path):
+    db = honker.open(db_path)
+    q = db.queue("delayed")
+    worker = _spawn("claim", db_path, "delayed", "delayed-worker")
+    try:
+        assert _line(worker) == "READY"
+        run_at = int(time.time()) + 3
+        q.enqueue({"kind": "delayed"}, run_at=run_at)
+
+        got = _json_line(_line(worker, timeout=8.0))
+        assert got["payload"] == {"kind": "delayed"}
+        assert got["claimed_at"] >= run_at - 0.05
+        assert got["claimed_at"] <= run_at + 3.0
+        _finish(worker)
+    finally:
+        if worker.poll() is None:
+            worker.kill()
+
+
+def test_crashed_worker_claim_is_reclaimed_by_sleeping_worker(db_path):
+    db = honker.open(db_path)
+    q = db.queue("reclaim", visibility_timeout_s=2)
+    q.enqueue({"kind": "recover"})
+
+    crashed = _spawn("crash-after-claim", db_path, "reclaim", "crashy")
+    assert _json_line(_line(crashed), prefix="CLAIMED ") == {"kind": "recover"}
+    crashed.wait(timeout=5.0)
+    assert crashed.returncode == 0
+
+    rescuer = _spawn("claim", db_path, "reclaim", "rescuer")
+    try:
+        assert _line(rescuer) == "READY"
+        got = _json_line(_line(rescuer, timeout=8.0))
+        assert got["payload"] == {"kind": "recover"}
+        _finish(rescuer)
+    finally:
+        if rescuer.poll() is None:
+            rescuer.kill()
+
+
+def test_retry_backoff_wakes_then_exhausts_to_dead(db_path):
+    db = honker.open(db_path)
+    q = db.queue("retry", max_attempts=2)
+    q.enqueue({"kind": "retry"})
+
+    first = _spawn("retry-claim", db_path, "retry", "retry-a", "2")
+    try:
+        assert _line(first) == "READY"
+        first_retry = _json_line(_line(first), prefix="RETRIED ")
+        assert first_retry["payload"] == {"kind": "retry"}
+        _finish(first)
+    finally:
+        if first.poll() is None:
+            first.kill()
+
+    second = _spawn("retry-claim", db_path, "retry", "retry-b", "0")
+    try:
+        assert _line(second) == "READY"
+        second_retry = _json_line(_line(second, timeout=8.0), prefix="RETRIED ")
+        assert second_retry["payload"] == {"kind": "retry"}
+        _finish(second)
+    finally:
+        if second.poll() is None:
+            second.kill()
+
+    rows = db.query(
+        "SELECT state, attempts, last_error FROM _honker_jobs WHERE queue='retry'"
+    )
+    assert rows == [
+        {
+            "state": "dead",
+            "attempts": 2,
+            "last_error": "retry by retry-b",
+        }
+    ]
+
+
+async def test_wait_result_wakes_when_worker_process_saves_result(db_path):
+    db = honker.open(db_path)
+    q = db.queue("results")
+    job_id = q.enqueue({"x": 2, "y": 5})
+
+    waiter = _spawn("wait-result", db_path, "results", str(job_id))
+    try:
+        assert _line(waiter) == "READY"
+        worker = _spawn("save-result-worker", db_path, "results")
+        try:
+            assert _line(worker) == "READY"
+            assert _json_line(_line(worker), prefix="SAVED ") == {"sum": 7}
+            _finish(worker)
+        finally:
+            if worker.poll() is None:
+                worker.kill()
+
+        assert _json_line(_line(waiter)) == {"sum": 7}
+        _finish(waiter)
+    finally:
+        if waiter.poll() is None:
+            waiter.kill()
+
+
+def test_rate_limit_is_shared_across_processes(db_path):
+    honker.open(db_path).try_rate_limit("warmup", limit=1, per=60)
+
+    def run_one(_i: int) -> bool:
+        res = _run("rate-limit", db_path, "api", "3", "60")
+        assert res.returncode == 0, res.stderr
+        return bool(_json_line(res.stdout.strip())["ok"])
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(run_one, range(8)))
+
+    assert results.count(True) == 3
+    assert results.count(False) == 5
+
+
+def test_named_lock_blocks_cross_process_until_crashed_holder_ttl(db_path):
+    holder = _spawn("lock-holder-crash", db_path, "singleton", "2")
+    assert _line(holder) == "HELD"
+    holder.wait(timeout=5.0)
+    assert holder.returncode == 0
+
+    waiter = _spawn("lock-waiter", db_path, "singleton", "2")
+    try:
+        assert _line(waiter) == "BLOCKED"
+        assert _line(waiter, timeout=6.0) == "ACQUIRED"
+        _finish(waiter)
+    finally:
+        if waiter.poll() is None:
+            waiter.kill()
+
+
+def test_stream_consumer_replays_then_resumes_after_saved_offset(db_path):
+    db = honker.open(db_path)
+    stream = db.stream("orders")
+    stream.publish({"n": 1})
+    stream.publish({"n": 2})
+
+    first = _spawn("stream-read", db_path, "orders", "dashboard", "1")
+    try:
+        assert _line(first) == "READY"
+        got_first = _json_line(_line(first))
+        assert [row["payload"] for row in got_first] == [{"n": 1}]
+        _finish(first)
+    finally:
+        if first.poll() is None:
+            first.kill()
+
+    second = _spawn("stream-read", db_path, "orders", "dashboard", "1")
+    try:
+        assert _line(second) == "READY"
+        got_second = _json_line(_line(second))
+        assert [row["payload"] for row in got_second] == [{"n": 2}]
+        _finish(second)
+    finally:
+        if second.poll() is None:
+            second.kill()
+
+
+@pytest.mark.skipif(
+    EXT_PATH is None or not HAS_LOAD_EXTENSION,
+    reason="loadable extension is unavailable in this Python/sqlite build",
+)
+def test_raw_sql_transaction_enqueue_wakes_python_worker(db_path):
+    worker = _spawn("claim", db_path, "emails", "python-worker")
+    try:
+        assert _line(worker) == "READY"
+
+        rolled_back = _run(
+            "raw-sql-enqueue",
+            db_path,
+            EXT_PATH,
+            "rollback",
+        )
+        assert rolled_back.returncode == 0, rolled_back.stderr
+        assert rolled_back.stdout.strip() == "ROLLBACK"
+
+        committed = _run(
+            "raw-sql-enqueue",
+            db_path,
+            EXT_PATH,
+            "commit",
+        )
+        assert committed.returncode == 0, committed.stderr
+        assert committed.stdout.strip() == "COMMIT"
+
+        got = _json_line(_line(worker, timeout=8.0))
+        assert got["payload"] == {"order_id": 1, "to": "alice@example.com"}
+        _finish(worker)
+
+        db = honker.open(db_path)
+        rows = db.query("SELECT COUNT(*) AS c FROM orders")
+        assert rows[0]["c"] == 1
+    finally:
+        if worker.poll() is None:
+            worker.kill()

--- a/tests/test_real_e2e_scenarios.py
+++ b/tests/test_real_e2e_scenarios.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 import json
 import os
+import queue
 import sqlite3
 import subprocess
 import sys
-import textwrap
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -186,6 +187,20 @@ async def stream_read(db_path, stream_name, consumer, count):
         close_db(db)
 
 
+async def listen_once(db_path, channel):
+    db = honker.open(db_path)
+    try:
+        it = db.listen(channel)
+        print("READY", flush=True)
+        note = await asyncio.wait_for(it.__anext__(), timeout=IDLE_POLL_S)
+        print("RESULT " + json.dumps({{
+            "payload": note.payload,
+            "seen_at": time.time(),
+        }}, sort_keys=True), flush=True)
+    finally:
+        close_db(db)
+
+
 def raw_sql_enqueue(db_path, ext_path, commit):
     conn = sqlite3.connect(db_path)
     conn.enable_load_extension(True)
@@ -193,11 +208,13 @@ def raw_sql_enqueue(db_path, ext_path, commit):
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("SELECT honker_bootstrap()")
     conn.execute("CREATE TABLE IF NOT EXISTS orders (id INTEGER PRIMARY KEY, email TEXT)")
+    order_id = 2 if commit == "commit" else 1
+    email = "alice@example.com" if commit == "commit" else "rollback@example.com"
     conn.execute("BEGIN IMMEDIATE")
-    conn.execute("INSERT INTO orders (id, email) VALUES (1, 'alice@example.com')")
+    conn.execute("INSERT INTO orders (id, email) VALUES (?, ?)", (order_id, email))
     conn.execute(
         "SELECT honker_enqueue(?, ?, NULL, NULL, 0, 3, NULL)",
-        ("emails", json.dumps({{"to": "alice@example.com", "order_id": 1}})),
+        ("emails", json.dumps({{"to": email, "order_id": order_id}})),
     )
     if commit == "commit":
         conn.commit()
@@ -228,6 +245,8 @@ async def main():
         await lock_waiter(sys.argv[2], sys.argv[3], sys.argv[4])
     elif role == "stream-read":
         await stream_read(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+    elif role == "listen-once":
+        await listen_once(sys.argv[2], sys.argv[3])
     elif role == "raw-sql-enqueue":
         raw_sql_enqueue(sys.argv[2], sys.argv[3], sys.argv[4])
     else:
@@ -262,15 +281,23 @@ def _run(*args: str, timeout: float = 20.0) -> subprocess.CompletedProcess:
 
 def _line(proc: subprocess.Popen, timeout: float = 12.0) -> str:
     assert proc.stdout is not None
-    deadline = time.time() + timeout
-    while time.time() < deadline:
+    lines: queue.Queue[str | None] = queue.Queue(maxsize=1)
+
+    def reader() -> None:
         line = proc.stdout.readline()
-        if line:
-            return line.strip()
-        if proc.poll() is not None:
-            break
-    stderr = ""
-    if proc.stderr is not None:
+        lines.put(line.strip() if line else None)
+
+    thread = threading.Thread(target=reader, daemon=True)
+    thread.start()
+    try:
+        line = lines.get(timeout=timeout)
+        if line is not None:
+            return line
+    except queue.Empty:
+        pass
+
+    stderr = "<still running>"
+    if proc.poll() is not None and proc.stderr is not None:
         stderr = proc.stderr.read()
     raise AssertionError(f"child produced no line; rc={proc.poll()} stderr={stderr}")
 
@@ -320,12 +347,18 @@ def test_crashed_worker_claim_is_reclaimed_by_sleeping_worker(db_path):
     assert _json_line(_line(crashed), prefix="CLAIMED ") == {"kind": "recover"}
     crashed.wait(timeout=5.0)
     assert crashed.returncode == 0
+    rows = db.query(
+        "SELECT claim_expires_at FROM _honker_jobs WHERE queue='reclaim'"
+    )
+    claim_expires_at = int(rows[0]["claim_expires_at"])
 
     rescuer = _spawn("claim", db_path, "reclaim", "rescuer")
     try:
         assert _line(rescuer) == "READY"
         got = _json_line(_line(rescuer, timeout=8.0))
         assert got["payload"] == {"kind": "recover"}
+        assert got["claimed_at"] >= claim_expires_at - 0.05
+        assert got["claimed_at"] <= claim_expires_at + 3.0
         _finish(rescuer)
     finally:
         if rescuer.poll() is None:
@@ -346,12 +379,17 @@ def test_retry_backoff_wakes_then_exhausts_to_dead(db_path):
     finally:
         if first.poll() is None:
             first.kill()
+    retry_due_at = int(
+        db.query("SELECT run_at FROM _honker_jobs WHERE queue='retry'")[0]["run_at"]
+    )
 
     second = _spawn("retry-claim", db_path, "retry", "retry-b", "0")
     try:
         assert _line(second) == "READY"
         second_retry = _json_line(_line(second, timeout=8.0), prefix="RETRIED ")
         assert second_retry["payload"] == {"kind": "retry"}
+        assert second_retry["at"] >= retry_due_at - 0.05
+        assert second_retry["at"] <= retry_due_at + 3.0
         _finish(second)
     finally:
         if second.poll() is None:
@@ -451,6 +489,44 @@ def test_stream_consumer_replays_then_resumes_after_saved_offset(db_path):
             second.kill()
 
 
+def test_live_stream_subscriber_wakes_on_new_event(db_path):
+    db = honker.open(db_path)
+    stream = db.stream("live-orders")
+
+    reader = _spawn("stream-read", db_path, "live-orders", "dashboard-live", "1")
+    try:
+        assert _line(reader) == "READY"
+        published_at = time.time()
+        stream.publish({"n": 1, "kind": "created"})
+
+        got = _json_line(_line(reader, timeout=8.0))
+        assert got == [
+            {"offset": 1, "payload": {"n": 1, "kind": "created"}},
+        ]
+        assert time.time() - published_at < 5.0
+        _finish(reader)
+    finally:
+        if reader.poll() is None:
+            reader.kill()
+
+
+def test_live_notification_listener_wakes_on_new_notify(db_path):
+    db = honker.open(db_path)
+
+    listener = _spawn("listen-once", db_path, "orders")
+    try:
+        assert _line(listener) == "READY"
+        with db.transaction() as tx:
+            tx.notify("orders", {"order_id": 1, "kind": "created"})
+
+        got = _json_line(_line(listener, timeout=8.0))
+        assert got["payload"] == {"order_id": 1, "kind": "created"}
+        _finish(listener)
+    finally:
+        if listener.poll() is None:
+            listener.kill()
+
+
 @pytest.mark.skipif(
     EXT_PATH is None or not HAS_LOAD_EXTENSION,
     reason="loadable extension is unavailable in this Python/sqlite build",
@@ -479,7 +555,7 @@ def test_raw_sql_transaction_enqueue_wakes_python_worker(db_path):
         assert committed.stdout.strip() == "COMMIT"
 
         got = _json_line(_line(worker, timeout=8.0))
-        assert got["payload"] == {"order_id": 1, "to": "alice@example.com"}
+        assert got["payload"] == {"order_id": 2, "to": "alice@example.com"}
         _finish(worker)
 
         db = honker.open(db_path)

--- a/tests/test_real_e2e_scenarios.py
+++ b/tests/test_real_e2e_scenarios.py
@@ -176,10 +176,13 @@ async def stream_read(db_path, stream_name, consumer, count):
             save_every_n=0,
             save_every_s=0,
         )
-        print("READY", flush=True)
         out = []
-        for _ in range(int(count)):
-            event = await asyncio.wait_for(it.__anext__(), timeout=IDLE_POLL_S)
+        for i in range(int(count)):
+            next_event = asyncio.create_task(it.__anext__())
+            if i == 0:
+                await asyncio.sleep(0.1)
+                print("READY", flush=True)
+            event = await asyncio.wait_for(next_event, timeout=IDLE_POLL_S)
             out.append({{"offset": event.offset, "payload": event.payload}})
             stream.save_offset(consumer, event.offset)
         print("RESULT " + json.dumps(out, sort_keys=True), flush=True)
@@ -191,8 +194,10 @@ async def listen_once(db_path, channel):
     db = honker.open(db_path)
     try:
         it = db.listen(channel)
+        next_note = asyncio.create_task(it.__anext__())
+        await asyncio.sleep(0.1)
         print("READY", flush=True)
-        note = await asyncio.wait_for(it.__anext__(), timeout=IDLE_POLL_S)
+        note = await asyncio.wait_for(next_note, timeout=IDLE_POLL_S)
         print("RESULT " + json.dumps({{
             "payload": note.payload,
             "seen_at": time.time(),
@@ -319,6 +324,16 @@ def _finish(proc: subprocess.Popen, timeout: float = 5.0) -> None:
     )
 
 
+def _kill(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    proc.kill()
+    try:
+        proc.wait(timeout=5.0)
+    except subprocess.TimeoutExpired:
+        proc.wait(timeout=1.0)
+
+
 def test_delayed_job_wakes_sleeping_worker_process(db_path):
     db = honker.open(db_path)
     q = db.queue("delayed")
@@ -334,8 +349,7 @@ def test_delayed_job_wakes_sleeping_worker_process(db_path):
         assert got["claimed_at"] <= run_at + 3.0
         _finish(worker)
     finally:
-        if worker.poll() is None:
-            worker.kill()
+        _kill(worker)
 
 
 def test_crashed_worker_claim_is_reclaimed_by_sleeping_worker(db_path):
@@ -361,8 +375,7 @@ def test_crashed_worker_claim_is_reclaimed_by_sleeping_worker(db_path):
         assert got["claimed_at"] <= claim_expires_at + 3.0
         _finish(rescuer)
     finally:
-        if rescuer.poll() is None:
-            rescuer.kill()
+        _kill(rescuer)
 
 
 def test_retry_backoff_wakes_then_exhausts_to_dead(db_path):
@@ -377,8 +390,7 @@ def test_retry_backoff_wakes_then_exhausts_to_dead(db_path):
         assert first_retry["payload"] == {"kind": "retry"}
         _finish(first)
     finally:
-        if first.poll() is None:
-            first.kill()
+        _kill(first)
     retry_due_at = int(
         db.query("SELECT run_at FROM _honker_jobs WHERE queue='retry'")[0]["run_at"]
     )
@@ -392,8 +404,7 @@ def test_retry_backoff_wakes_then_exhausts_to_dead(db_path):
         assert second_retry["at"] <= retry_due_at + 3.0
         _finish(second)
     finally:
-        if second.poll() is None:
-            second.kill()
+        _kill(second)
 
     rows = db.query(
         "SELECT state, attempts, last_error FROM _honker_jobs WHERE queue='retry'"
@@ -421,14 +432,12 @@ async def test_wait_result_wakes_when_worker_process_saves_result(db_path):
             assert _json_line(_line(worker), prefix="SAVED ") == {"sum": 7}
             _finish(worker)
         finally:
-            if worker.poll() is None:
-                worker.kill()
+            _kill(worker)
 
         assert _json_line(_line(waiter)) == {"sum": 7}
         _finish(waiter)
     finally:
-        if waiter.poll() is None:
-            waiter.kill()
+        _kill(waiter)
 
 
 def test_rate_limit_is_shared_across_processes(db_path):
@@ -458,8 +467,7 @@ def test_named_lock_blocks_cross_process_until_crashed_holder_ttl(db_path):
         assert _line(waiter, timeout=6.0) == "ACQUIRED"
         _finish(waiter)
     finally:
-        if waiter.poll() is None:
-            waiter.kill()
+        _kill(waiter)
 
 
 def test_stream_consumer_replays_then_resumes_after_saved_offset(db_path):
@@ -475,8 +483,7 @@ def test_stream_consumer_replays_then_resumes_after_saved_offset(db_path):
         assert [row["payload"] for row in got_first] == [{"n": 1}]
         _finish(first)
     finally:
-        if first.poll() is None:
-            first.kill()
+        _kill(first)
 
     second = _spawn("stream-read", db_path, "orders", "dashboard", "1")
     try:
@@ -485,8 +492,7 @@ def test_stream_consumer_replays_then_resumes_after_saved_offset(db_path):
         assert [row["payload"] for row in got_second] == [{"n": 2}]
         _finish(second)
     finally:
-        if second.poll() is None:
-            second.kill()
+        _kill(second)
 
 
 def test_live_stream_subscriber_wakes_on_new_event(db_path):
@@ -506,8 +512,7 @@ def test_live_stream_subscriber_wakes_on_new_event(db_path):
         assert time.time() - published_at < 5.0
         _finish(reader)
     finally:
-        if reader.poll() is None:
-            reader.kill()
+        _kill(reader)
 
 
 def test_live_notification_listener_wakes_on_new_notify(db_path):
@@ -523,8 +528,7 @@ def test_live_notification_listener_wakes_on_new_notify(db_path):
         assert got["payload"] == {"order_id": 1, "kind": "created"}
         _finish(listener)
     finally:
-        if listener.poll() is None:
-            listener.kill()
+        _kill(listener)
 
 
 @pytest.mark.skipif(
@@ -562,5 +566,4 @@ def test_raw_sql_transaction_enqueue_wakes_python_worker(db_path):
         rows = db.query("SELECT COUNT(*) AS c FROM orders")
         assert rows[0]["c"] == 1
     finally:
-        if worker.poll() is None:
-            worker.kill()
+        _kill(worker)


### PR DESCRIPTION
## What

Adds proof that Honker works like a real small app, not just as isolated helper tests.

This adds:

- a real app example that writes an order, enqueues an email job, publishes a stream event, sends a live notification, and fires a scheduled cleanup job
- a pytest that runs that example end to end
- a packaged-install proof script for Python, Node, Ruby, and .NET
- manual/scheduled GitHub workflows for packaged install proof and scary nightly proof
- a binding support truth table
- benchmark notes for wake and idle watcher cost
- docs-site pages for binding support and benchmark baselines

## Why

Honker is useful only if the normal user shape works:

1. app writes data
2. app enqueues work in the same transaction
3. worker wakes and claims work
4. streams and notifications move across the same SQLite file
5. scheduled work fires without a broker

Small unit tests are not enough for that. This PR adds proof closer to how people will actually use it.

## How It Works

The example uses one SQLite file. The request transaction inserts the order and writes the Honker side effects before commit. After commit, the worker/listener/stream/scheduler paths read the same file and prove the expected work appeared.

The package proof builds each package, installs it into a throwaway consumer project, and runs a tiny queue smoke test from that installed package.

## Checks

Already run locally:

- `scripts/proof/package-install-smoke.sh`
- `.venv/bin/pytest tests/test_real_app_example.py -q --tb=short`
- workflow YAML parse
- docs site `npm run build`

Next proof after opening this PR:

- run `Proof · packaged installs`
- run `Proof · scary nightly`
