### PR TITLE
[codex] Improve Python extension loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,10 @@ jobs:
           fi
           uv pip install --python "$VENV_PY" pytest pytest-asyncio pytest-xdist maturin
       - name: Build honker-extension
-        run: cargo build --release -p honker-extension --features kernel-watcher,shm-fast-path
+        shell: bash
+        run: |
+          cargo build --release -p honker-extension --features kernel-watcher,shm-fast-path
+          scripts/copy-python-extension.sh
       - name: Build PyO3 _honker_native (maturin develop)
         working-directory: packages/honker
         shell: bash
@@ -357,7 +360,8 @@ jobs:
       - name: Install C++ binding deps
         run: sudo apt-get install -y libsqlite3-dev nlohmann-json3-dev
       - name: Build honker-extension
-        run: cargo build --release -p honker-extension --features kernel-watcher,shm-fast-path
+        run: |
+          cargo build --release -p honker-extension --features kernel-watcher,shm-fast-path
       - name: Build Python binding
         shell: bash
         run: |

--- a/.github/workflows/package-proof.yml
+++ b/.github/workflows/package-proof.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: "10.0.x"
-      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f  # v1
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f  # v1.306.0
         with:
           ruby-version: "3.4"
       - name: Run packaged install proof

--- a/.github/workflows/scary-nightly.yml
+++ b/.github/workflows/scary-nightly.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: "10.0.x"
-      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f  # v1
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f  # v1.306.0
         with:
           ruby-version: "3.4"
       - name: Run packaged install proof

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,10 @@ test-all: test test-python-slow
 
 # ---- builds ----
 
-build: build-pyo3 build-ext
+build: build-ext build-pyo3
 
-build-pyo3:
+build-pyo3: build-ext
+	scripts/copy-python-extension.sh
 	cd packages/honker && VIRTUAL_ENV=$(CURDIR)/.venv \
 		$(CURDIR)/.venv/bin/python -m maturin develop --release
 

--- a/README.md
+++ b/README.md
@@ -466,8 +466,7 @@ Load `libhonker_ext` on your ORM's connection and call the SQL functions inside 
 # SQLAlchemy
 @event.listens_for(engine, "connect")
 def _load_honker(conn, _):
-    conn.enable_load_extension(True)
-    conn.load_extension("/path/to/libhonker_ext")
+    honker.load_extension(conn)
     conn.execute("SELECT honker_bootstrap()")
 
 with Session(engine) as s, s.begin():

--- a/packages/honker/README.md
+++ b/packages/honker/README.md
@@ -13,12 +13,33 @@ Full docs live in the main repo and docs site:
 pip install honker
 ```
 
-You also need the Honker SQLite extension. Use a release build from the main repo, or build it yourself:
+The Python wheel includes Honker's SQLite loadable extension when the
+package is built through the release/proof workflow. To load Honker into
+your own `sqlite3` or ORM connection:
+
+```python
+import honker
+import sqlite3
+
+conn = sqlite3.connect("app.db")
+honker.load_extension(conn)
+conn.execute("SELECT honker_bootstrap()")
+```
+
+If a client needs the raw pieces instead, use `extension_info()`:
+
+```python
+path, entrypoint = honker.extension_info()
+```
+
+For local source builds, build and copy the extension before building
+the wheel:
 
 ```bash
 git clone https://github.com/russellromney/honker
 cd honker
 cargo build --release -p honker-extension
+scripts/copy-python-extension.sh
 ```
 
 ## Quick start

--- a/packages/honker/pyproject.toml
+++ b/packages/honker/pyproject.toml
@@ -34,3 +34,4 @@ Documentation = "https://honker.dev/docs/"
 python-source = "python"
 module-name = "honker._honker_native"
 features = ["pyo3/extension-module"]
+include = [{ path = "python/honker/_lib/*", format = "wheel" }]

--- a/packages/honker/python/honker/__init__.py
+++ b/packages/honker/python/honker/__init__.py
@@ -1,3 +1,7 @@
+import os
+import sys
+from pathlib import Path
+
 from honker._honker import (
     Database,
     Event,
@@ -24,6 +28,72 @@ from honker._tasks import (
     run_workers,
 )
 
+EXTENSION_ENTRYPOINT = "sqlite3_honkerext_init"
+
+
+def _extension_filenames() -> tuple[str, ...]:
+    if sys.platform == "win32":
+        return ("honker_ext.dll",)
+    if sys.platform == "darwin":
+        return ("libhonker_ext.dylib",)
+    return ("libhonker_ext.so",)
+
+
+def _extension_candidates() -> list[Path]:
+    names = _extension_filenames()
+    candidates: list[Path] = []
+
+    package_dir = Path(__file__).resolve().parent
+    candidates.extend(package_dir / "_lib" / name for name in names)
+
+    for parent in package_dir.parents:
+        candidates.extend(parent / "target" / "release" / name for name in names)
+
+    return candidates
+
+
+def extension_info() -> tuple[str, str]:
+    """Return the bundled SQLite extension path and entrypoint.
+
+    This is for users who want to load Honker into their own sqlite3,
+    SQLAlchemy, or other SQLite connection instead of using honker.open().
+    Honker does not wrap those clients; it just exposes the loadable
+    extension artifact when one is available.
+    """
+    env_path = os.environ.get("HONKER_EXTENSION_PATH")
+    if env_path:
+        candidate = Path(env_path)
+        if candidate.is_file():
+            return str(candidate), EXTENSION_ENTRYPOINT
+        raise FileNotFoundError(f"HONKER_EXTENSION_PATH does not exist: {candidate}")
+
+    for candidate in _extension_candidates():
+        if candidate.is_file():
+            return str(candidate), EXTENSION_ENTRYPOINT
+    searched = ", ".join(str(p) for p in _extension_candidates())
+    raise FileNotFoundError(f"Honker SQLite extension not found; searched: {searched}")
+
+
+def load_extension(conn) -> None:
+    """Load Honker's SQLite extension into an existing DB-API connection."""
+    path, entrypoint = extension_info()
+    enable = getattr(conn, "enable_load_extension", None)
+    if enable is not None:
+        enable(True)
+    try:
+        load = getattr(conn, "load_extension", None)
+        if load is None:
+            conn.execute("SELECT load_extension(?, ?)", (path, entrypoint))
+        else:
+            try:
+                load(path, entrypoint=entrypoint)
+            except TypeError:
+                conn.execute("SELECT load_extension(?, ?)", (path, entrypoint))
+    finally:
+        if enable is not None:
+            enable(False)
+
+
 __all__ = [
     "CronSchedule",
     "Database",
@@ -39,8 +109,11 @@ __all__ = [
     "Stream",
     "TaskResult",
     "UnknownTaskError",
+    "EXTENSION_ENTRYPOINT",
     "crontab",
     "every_s",
+    "extension_info",
+    "load_extension",
     "open",
     "registry",
     "run_workers",

--- a/packages/honker/src/lib.rs
+++ b/packages/honker/src/lib.rs
@@ -62,11 +62,24 @@ fn py_to_value(item: &Bound<'_, PyAny>) -> PyResult<Value> {
     )))
 }
 
-fn build_params(params: Option<&Bound<'_, PyList>>) -> PyResult<Vec<Value>> {
+fn build_params(params: Option<&Bound<'_, PyAny>>) -> PyResult<Vec<Value>> {
     let mut out = Vec::new();
     if let Some(p) = params {
-        for item in p.iter() {
-            out.push(py_to_value(&item)?);
+        if p.is_none() {
+            return Ok(out);
+        }
+        if p.cast::<PyDict>().is_ok() {
+            return Err(PyTypeError::new_err(
+                "SQL params must be a positional sequence, not a dict",
+            ));
+        }
+        if p.cast::<PyBytes>().is_ok() || p.extract::<String>().is_ok() {
+            return Err(PyTypeError::new_err(
+                "SQL params must be a sequence of values, not a string or bytes",
+            ));
+        }
+        for item in p.try_iter()? {
+            out.push(py_to_value(&item?)?);
         }
     }
     Ok(out)
@@ -76,7 +89,7 @@ fn run_query<'py>(
     py: Python<'py>,
     conn: &Connection,
     sql: &str,
-    params: Option<&Bound<'_, PyList>>,
+    params: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<Bound<'py, PyList>> {
     let values = build_params(params)?;
     // prepare_cached hits rusqlite's per-connection statement cache.
@@ -110,7 +123,7 @@ fn run_query<'py>(
 fn run_execute(
     conn: &Connection,
     sql: &str,
-    params: Option<&Bound<'_, PyList>>,
+    params: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<usize> {
     let values = build_params(params)?;
     let mut stmt = conn.prepare_cached(sql).map_err(core_err)?;
@@ -239,7 +252,7 @@ impl Database {
         &self,
         py: Python<'py>,
         sql: String,
-        params: Option<Bound<'py, PyList>>,
+        params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyList>> {
         let conn = self.readers.acquire().map_err(core_err)?;
         let result = run_query(py, &conn, &sql, params.as_ref());
@@ -413,7 +426,7 @@ impl Transaction {
         &self,
         _py: Python<'_>,
         sql: String,
-        params: Option<Bound<'_, PyList>>,
+        params: Option<Bound<'_, PyAny>>,
     ) -> PyResult<()> {
         let state = self.inner.lock();
         let conn = state
@@ -429,7 +442,7 @@ impl Transaction {
         &self,
         py: Python<'py>,
         sql: String,
-        params: Option<Bound<'py, PyList>>,
+        params: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyList>> {
         let state = self.inner.lock();
         let conn = state

--- a/scripts/copy-python-extension.sh
+++ b/scripts/copy-python-extension.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="$ROOT/target/release"
+DEST_DIR="$ROOT/packages/honker/python/honker/_lib"
+
+case "$(uname -s)" in
+  Darwin)
+    EXT_NAME="libhonker_ext.dylib"
+    ;;
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    EXT_NAME="honker_ext.dll"
+    ;;
+  *)
+    EXT_NAME="libhonker_ext.so"
+    ;;
+esac
+
+SRC="$SRC_DIR/$EXT_NAME"
+if [[ ! -f "$SRC" ]]; then
+  echo "honker extension not found at $SRC" >&2
+  echo "run: cargo build --release -p honker-extension" >&2
+  exit 1
+fi
+
+rm -rf "$DEST_DIR"
+mkdir -p "$DEST_DIR"
+cp "$SRC" "$DEST_DIR/$EXT_NAME"
+echo "copied $SRC -> $DEST_DIR/$EXT_NAME"

--- a/scripts/proof/package-install-smoke.sh
+++ b/scripts/proof/package-install-smoke.sh
@@ -34,6 +34,7 @@ if [[ ! -f "$EXT" ]]; then
   echo "honker extension not found at $EXT" >&2
   exit 1
 fi
+scripts/copy-python-extension.sh
 
 echo "== python wheel install =="
 "$PYTHON_BIN" -m venv "$TMP/py"
@@ -45,6 +46,7 @@ echo "== python wheel install =="
 "$TMP/py/bin/python" -m pip install "$TMP"/wheels/*.whl >/dev/null
 "$TMP/py/bin/python" - <<'PY'
 import tempfile
+import sqlite3
 import honker
 
 with tempfile.TemporaryDirectory() as d:
@@ -55,6 +57,14 @@ with tempfile.TemporaryDirectory() as d:
     assert job and job.id == job_id
     assert job.payload["to"] == "alice@example.com"
     assert job.ack()
+    path, entrypoint = honker.extension_info()
+    con = sqlite3.connect(f"{d}/ext.db")
+    con.enable_load_extension(True)
+    con.load_extension(path, entrypoint=entrypoint)
+    con.execute("SELECT honker_bootstrap()")
+    helper_con = sqlite3.connect(f"{d}/helper.db")
+    honker.load_extension(helper_con)
+    helper_con.execute("SELECT honker_bootstrap()")
 print("python package smoke ok")
 PY
 

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -1,0 +1,100 @@
+import sqlite3
+
+import pytest
+
+import honker
+
+
+def test_extension_info_honors_env_override(tmp_path, monkeypatch):
+    fake_ext = tmp_path / "custom_ext.so"
+    fake_ext.write_bytes(b"not really a dylib")
+    monkeypatch.setenv("HONKER_EXTENSION_PATH", str(fake_ext))
+
+    assert honker.extension_info() == (str(fake_ext), "sqlite3_honkerext_init")
+
+
+def test_extension_info_rejects_missing_env_override(tmp_path, monkeypatch):
+    missing = tmp_path / "missing_ext.so"
+    monkeypatch.setenv("HONKER_EXTENSION_PATH", str(missing))
+
+    with pytest.raises(FileNotFoundError, match="HONKER_EXTENSION_PATH"):
+        honker.extension_info()
+
+
+def test_load_extension_falls_back_to_sql_entrypoint(tmp_path, monkeypatch):
+    fake_ext = tmp_path / "custom_ext.so"
+    fake_ext.write_bytes(b"not really a dylib")
+    monkeypatch.setenv("HONKER_EXTENSION_PATH", str(fake_ext))
+
+    calls = []
+
+    class Conn:
+        def enable_load_extension(self, enabled):
+            calls.append(("enable", enabled))
+
+        def load_extension(self, path, *, entrypoint=None):
+            calls.append(("method", path, entrypoint))
+            raise TypeError("old sqlite3 signature")
+
+        def execute(self, sql, params):
+            calls.append(("execute", sql, params))
+
+    honker.load_extension(Conn())
+
+    assert calls == [
+        ("enable", True),
+        ("method", str(fake_ext), "sqlite3_honkerext_init"),
+        (
+            "execute",
+            "SELECT load_extension(?, ?)",
+            (str(fake_ext), "sqlite3_honkerext_init"),
+        ),
+        ("enable", False),
+    ]
+
+
+def test_transaction_execute_and_query_accept_tuple_params(tmp_path):
+    db = honker.open(str(tmp_path / "tuple-params.db"))
+
+    with db.transaction() as tx:
+        tx.execute("CREATE TABLE emails (id INTEGER PRIMARY KEY, object_id TEXT)")
+        tx.execute("INSERT INTO emails (object_id) VALUES (?)", ("msg-1",))
+        rows = tx.query("SELECT id FROM emails WHERE object_id = ?", ("msg-1",))
+
+    assert rows == [{"id": 1}]
+
+
+def test_query_rejects_dict_params(tmp_path):
+    db = honker.open(str(tmp_path / "dict-params.db"))
+
+    with pytest.raises(TypeError, match="positional sequence"):
+        db.query("SELECT ?", {"value": 1})
+
+
+def test_extension_info_loads_sqlite_extension_when_available(tmp_path):
+    if not hasattr(sqlite3.connect(":memory:"), "enable_load_extension"):
+        pytest.skip("stdlib sqlite3 was built without load-extension support")
+
+    try:
+        path, entrypoint = honker.extension_info()
+    except FileNotFoundError as exc:
+        pytest.skip(str(exc))
+
+    conn = sqlite3.connect(str(tmp_path / "extension-info.db"))
+    conn.enable_load_extension(True)
+    conn.load_extension(path, entrypoint=entrypoint)
+    conn.execute("SELECT honker_bootstrap()")
+
+
+def test_load_extension_helper_loads_sqlite_extension_when_available(tmp_path):
+    if not hasattr(sqlite3.connect(":memory:"), "enable_load_extension"):
+        pytest.skip("stdlib sqlite3 was built without load-extension support")
+
+    try:
+        honker.extension_info()
+    except FileNotFoundError as exc:
+        pytest.skip(str(exc))
+
+    conn = sqlite3.connect(str(tmp_path / "load-helper.db"))
+    honker.load_extension(conn)
+    conn.execute("SELECT honker_bootstrap()")


### PR DESCRIPTION
## What changed

- Broadened Python transaction/query parameter handling so tuple params and other positional sequences work like normal `sqlite3` calls.
- Added `honker.extension_info()` and `honker.load_extension(conn)` for loading the Honker SQLite extension into an existing SQLite/ORM connection without taking a dependency on APSW or wrapping third-party clients.
- Added wheel packaging support for the built `honker-extension` artifact and wired CI/package proof paths to copy it before building Python.
- Updated docs and package proof smoke coverage for the new extension-loading path.

## Why

Issues #49 and #50 exposed two rough edges in the Python story: tuple SQL params were rejected by the native PyO3 signature, and Python users had no packaged way to locate/load the SQLite extension after `pip install honker`.

## Validation

- `cargo check --manifest-path packages/honker/Cargo.toml`
- `python3 -m compileall -q packages/honker/python/honker tests/test_python_api.py`
- `python -m pytest tests/test_python_api.py -q --tb=short -o addopts=''`
- `python -m pytest tests/test_extension_interop.py tests/test_python_api.py -q --tb=short -o addopts=''`
- Built a wheel with `maturin build`, inspected that it contains `honker/_lib/libhonker_ext.dylib`, installed that wheel in a clean venv, and loaded the bundled extension from `site-packages`.
