### PR TITLE
Fix Python wheel release packaging

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,0 +1,72 @@
+name: Release · PyPI
+
+on:
+  push:
+    tags:
+      - "py-v*"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Upload built wheels to PyPI"
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  wheels:
+    name: python wheel · ${{ matrix.os }}
+    timeout-minutes: 20
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.14"
+
+      - name: Install maturin
+        run: python -m pip install "maturin>=1.7,<2"
+
+      - name: Build ABI3 wheel
+        shell: bash
+        env:
+          RUNNER_OS_NAME: ${{ runner.os }}
+        run: |
+          cargo build --release -p honker-extension
+          scripts/copy-python-extension.sh
+          if [[ "$RUNNER_OS_NAME" == "Windows" ]]; then
+            python -m maturin build --release \
+              --features bundled-sqlite \
+              --manifest-path packages/honker/Cargo.toml \
+              --out dist
+          else
+            python -m maturin build --release \
+              --manifest-path packages/honker/Cargo.toml \
+              --out dist
+          fi
+          python scripts/proof/check-python-wheel.py dist/*.whl
+
+      - name: Upload wheels to PyPI
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          SHOULD_PUBLISH: ${{ github.event.inputs.publish }}
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          if [[ "$EVENT_NAME" == "push" && "$REF_NAME" == py-v* ]]; then
+            python -m maturin upload --skip-existing dist/*.whl
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" && "$SHOULD_PUBLISH" == "true" ]]; then
+            python -m maturin upload --skip-existing dist/*.whl
+          else
+            echo "built wheels only; not publishing"
+          fi

--- a/.github/workflows/scary-nightly.yml
+++ b/.github/workflows/scary-nightly.yml
@@ -36,6 +36,7 @@ jobs:
           . .venv/bin/activate
           uv pip install pytest pytest-asyncio pytest-xdist maturin
           cargo build --release -p honker-extension
+          scripts/copy-python-extension.sh
           cd packages/honker
           maturin develop --release
       - name: Cross-process and crash proofs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 2026-05-20 — Python 0.2.5
+
+- Python `honker`: 0.2.5
+- Python wheels now use the CPython stable ABI for Python 3.11+, so
+  each OS/arch wheel covers Python 3.11 through 3.14 instead of forcing
+  unsupported interpreters to fall back to source installs.
+- Python release proof now rejects wheels missing the bundled Honker
+  SQLite loadable extension.
+
 ## 2026-05-20 — Python 0.2.4
 
 - Python `honker`: 0.2.4

--- a/packages/honker/Cargo.toml
+++ b/packages/honker/Cargo.toml
@@ -29,7 +29,7 @@ shm-fast-path = ["honker-core/shm-fast-path"]
 [dependencies]
 honker-core = { path = "../../honker-core", version = "0.2.3" }
 parking_lot = "0.12.5"
-pyo3 = { version = "0.28.3", features = ["extension-module"] }
+pyo3 = { version = "0.28.3", features = ["extension-module", "abi3-py311"] }
 rusqlite = { version = "0.39.0", features = ["functions", "hooks"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/packages/honker/pyproject.toml
+++ b/packages/honker/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "honker"
-version = "0.2.4"
+version = "0.2.5"
 description = "Durable queues, streams, pub/sub, and cron scheduler on SQLite. One file, zero servers."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Rust",
   "Topic :: Database",
   "Topic :: System :: Distributed Computing",

--- a/scripts/proof/check-python-wheel.py
+++ b/scripts/proof/check-python-wheel.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import sys
+import zipfile
+from pathlib import Path
+
+
+def check_wheel(path: Path) -> None:
+    if "-abi3-" not in path.name:
+        raise SystemExit(f"python wheel is not abi3: {path}")
+
+    with zipfile.ZipFile(path) as zf:
+        names = zf.namelist()
+
+    has_native = any(
+        name.startswith("honker/") and "_honker_native" in name for name in names
+    )
+    has_extension = any(
+        name.startswith("honker/_lib/") and "honker_ext" in name for name in names
+    )
+    if not has_native:
+        raise SystemExit(f"python wheel is missing _honker_native: {path}")
+    if not has_extension:
+        raise SystemExit(f"python wheel is missing bundled SQLite extension: {path}")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("usage: check-python-wheel.py WHEEL [WHEEL ...]")
+    for arg in sys.argv[1:]:
+        check_wheel(Path(arg))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/proof/package-install-smoke.sh
+++ b/scripts/proof/package-install-smoke.sh
@@ -43,6 +43,7 @@ echo "== python wheel install =="
   -i "$TMP/py/bin/python" \
   --manifest-path "$ROOT/packages/honker/Cargo.toml" \
   --out "$TMP/wheels"
+"$PYTHON_BIN" "$ROOT/scripts/proof/check-python-wheel.py" "$TMP"/wheels/*.whl
 "$TMP/py/bin/python" -m pip install "$TMP"/wheels/*.whl >/dev/null
 "$TMP/py/bin/python" - <<'PY'
 import tempfile


### PR DESCRIPTION
## Summary
- publish Python wheels as cp311-abi3 so Python 3.11+ users do not fall back to sdist installs
- add a PyPI release workflow that builds Linux/macOS/Windows wheels and verifies the bundled SQLite extension
- bump Python honker to 0.2.5 and add release notes

## Verification
- built local ABI3 wheel with maturin
- verified wheel contains honker/_lib/libhonker_ext.dylib and _honker_native.abi3.so
- installed the wheel in a temp venv and confirmed honker.extension_info() resolves the bundled extension
- parsed changed workflow YAML files