### PR TITLE
Use trusted publishing for PyPI release

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   wheels:
@@ -56,17 +57,5 @@ jobs:
           python scripts/proof/check-python-wheel.py dist/*.whl
 
       - name: Upload wheels to PyPI
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          REF_NAME: ${{ github.ref_name }}
-          SHOULD_PUBLISH: ${{ github.event.inputs.publish }}
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          if [[ "$EVENT_NAME" == "push" && "$REF_NAME" == py-v* ]]; then
-            python -m maturin upload --skip-existing dist/*.whl
-          elif [[ "$EVENT_NAME" == "workflow_dispatch" && "$SHOULD_PUBLISH" == "true" ]]; then
-            python -m maturin upload --skip-existing dist/*.whl
-          else
-            echo "built wheels only; not publishing"
-          fi
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref_name, 'py-v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0


### PR DESCRIPTION
## Summary
- switch the PyPI release workflow from an absent API-token secret to OIDC trusted publishing
- keep the PyPI publish action pinned to the v1.14.0 commit

## Verification
- parsed the workflow YAML locally