### PR TITLE
Use PyPI token for Python release

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -59,3 +59,6 @@ jobs:
       - name: Upload wheels to PyPI
         if: ${{ (github.event_name == 'push' && startsWith(github.ref_name, 'py-v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') }}
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          attestations: false


### PR DESCRIPTION
## Summary
- configure the PyPI publish step to use the project-scoped PYPI_TOKEN secret from GitHub Actions
- disable attestations for token-based upload

## Verification
- parsed workflow YAML locally