### PR TITLE
Use twine for cross-platform PyPI upload

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -58,7 +58,10 @@ jobs:
 
       - name: Upload wheels to PyPI
         if: ${{ (github.event_name == 'push' && startsWith(github.ref_name, 'py-v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') }}
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
-          attestations: false
+        shell: bash
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          python -m pip install twine
+          python -m twine upload --skip-existing dist/*.whl


### PR DESCRIPTION
## Summary
- replace the Linux-only PyPI publish action with twine upload so macOS and Windows wheel jobs can publish too
- keep --skip-existing so reruns leave already uploaded wheels alone

## Verification
- parsed workflow YAML locally