### PR TITLE
Bundle the SQLite extension in the Ruby gem (and compile it for other platforms)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,7 @@ jobs:
           bundle exec ruby -Ilib spec/honker_spec.rb
           bundle exec ruby -Ilib spec/smoke_spec.rb
           bundle exec ruby -Ilib spec/parity_spec.rb
+          bundle exec ruby -Ilib spec/extension_resolution_spec.rb
       - name: Elixir
         working-directory: packages/honker-ex
         env:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -1,0 +1,101 @@
+name: Release · RubyGems
+
+on:
+  push:
+    tags:
+      - "rb-v*"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Upload built gems to RubyGems"
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  platform-gems:
+    name: ruby gem · ${{ matrix.gem_platform }}
+    timeout-minutes: 20
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # Native builds on a matching runner for each precompiled gem.
+      # Windows, Intel macOS, and musl are intentionally not built here;
+      # those users install the generic gem (see the generic-gem job).
+      matrix:
+        include:
+          - os: ubuntu-latest
+            gem_platform: x86_64-linux
+          - os: ubuntu-24.04-arm
+            gem_platform: aarch64-linux
+          - os: macos-latest
+            gem_platform: arm64-darwin
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f  # v1.306.0
+        with:
+          ruby-version: "3.4"
+
+      - name: Build platform gem
+        shell: bash
+        env:
+          HONKER_GEM_PLATFORM: ${{ matrix.gem_platform }}
+        run: |
+          cargo build --release -p honker-extension
+          scripts/copy-ruby-extension.sh
+          cd packages/honker-ruby
+          gem build honker.gemspec --output "$RUNNER_TEMP/honker.gem"
+          ruby ../../scripts/proof/check-ruby-gem.rb "$RUNNER_TEMP/honker.gem"
+
+      - name: Smoke-test the gem
+        shell: bash
+        run: |
+          gem install "$RUNNER_TEMP/honker.gem"
+          ruby scripts/proof/ruby-gem-smoke.rb
+
+      - name: Upload gem to RubyGems
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref_name, 'rb-v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') }}
+        shell: bash
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: gem push "$RUNNER_TEMP/honker.gem"
+
+  generic-gem:
+    name: ruby gem · generic
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f  # v1.306.0
+        with:
+          ruby-version: "3.4"
+
+      - name: Build generic gem
+        shell: bash
+        run: |
+          scripts/copy-ruby-sources.sh
+          cd packages/honker-ruby
+          gem build honker.gemspec --output "$RUNNER_TEMP/honker.gem"
+          ruby ../../scripts/proof/check-ruby-gem.rb --generic "$RUNNER_TEMP/honker.gem"
+
+      - name: Smoke-test the gem (compiles on install)
+        shell: bash
+        run: |
+          gem install "$RUNNER_TEMP/honker.gem"
+          ruby scripts/proof/ruby-gem-smoke.rb
+
+      - name: Upload gem to RubyGems
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref_name, 'rb-v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') }}
+        shell: bash
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: gem push "$RUNNER_TEMP/honker.gem"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 2026-05-20 - Ruby 0.2.0
+
+- Ruby `honker`: 0.2.0
+- Ruby gems now bundle the Honker SQLite loadable extension. Precompiled
+  gems ship the native library for x86_64 Linux, arm64 Linux, and Apple
+  Silicon macOS, so `Honker::Database.new` resolves it automatically and
+  `extension_path:` is now optional. On every other platform, and for
+  `github:` installs, the generic gem compiles the extension from
+  bundled Rust source on install (a Rust toolchain is required).
+- New `Release · RubyGems` workflow builds and smoke-tests those gems;
+  the release proof rejects platform gems missing the bundled extension.
+
 ## 2026-05-20 — Python 0.2.5
 
 - Python `honker`: 0.2.5

--- a/packages/honker-ruby/.gitignore
+++ b/packages/honker-ruby/.gitignore
@@ -2,4 +2,10 @@
 Gemfile.lock
 pkg/
 tmp/
+lib/honker/libhonker_ext.*
+lib/honker/honker_ext.dll
+ext/honker/honker-extension/
+ext/honker/honker-core/
+ext/honker/target/
+ext/honker/Makefile
 .DS_Store

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -13,7 +13,24 @@ Full docs:
 gem "honker"
 ```
 
-You also need the Honker SQLite extension from the main repo.
+How the SQLite extension reaches the gem depends on your platform:
+
+- **Precompiled** (x86_64 Linux, arm64 Linux, and Apple Silicon macOS):
+  the extension is pre-built and included in the gem.
+- **Every other platform**: the generic gem builds the extension after
+  install with `rustc` (from [rustup.rs](https://rustup.rs)).
+
+### Installing from git
+
+`honker` lives in a subdirectory of a polyglot monorepo, so a `github:`
+dependency needs Bundler's `glob:` option to point at the gemspec. The
+git checkout has no prebuilt extension either, so it builds on install
+and needs `rustc`:
+
+```ruby
+gem "honker", github: "russellromney/honker",
+    glob: "packages/honker-ruby/honker.gemspec"
+```
 
 ## Watcher backends
 
@@ -28,7 +45,7 @@ the matching feature.
 ```ruby
 require "honker"
 
-db = Honker::Database.new("app.db", extension_path: "./libhonker_ext.dylib")
+db = Honker::Database.new("app.db")
 q = db.queue("emails")
 
 q.enqueue({to: "alice@example.com"})

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -9,28 +9,134 @@ Full docs:
 
 ## Install
 
+Add it to your `Gemfile`:
+
 ```ruby
+# Gemfile
 gem "honker"
 ```
 
-How the SQLite extension reaches the gem depends on your platform:
+then `bundle install`. Or install it directly:
 
-- **Precompiled** (x86_64 Linux, arm64 Linux, and Apple Silicon macOS):
-  the extension is pre-built and included in the gem.
-- **Every other platform**: the generic gem builds the extension after
-  install with `rustc` (from [rustup.rs](https://rustup.rs)).
+```sh
+gem install honker
+```
+
+Honker is a thin Ruby wrapper around a SQLite loadable extension
+written in Rust. How that extension reaches your gem install depends on
+your platform, with a fallback to compile the extension for other
+platforms.
+
+Most platforms (x86_64 and arm64 for Linux, arm64 for macOS) get a
+platform gem with the extension already built and bundled inside it:
+
+| Platform            | Triple          |
+| ------------------- | --------------- |
+| x86_64 Linux        | `x86_64-linux`  |
+| arm64 Linux         | `aarch64-linux` |
+| Apple Silicon macOS | `arm64-darwin`  |
+
+```sh
+gem install honker
+# Fetching honker-0.2.0-arm64-darwin.gem
+```
+
+`Honker::Database.new("app.db")` then finds the bundled extension
+automatically.
+
+### Where the bundled extension lives
+
+It is shipped inside the gem under `lib/honker/`, with a filename that
+follows the host OS's native shared-library convention:
+
+| Host OS | Extension file                   | Why this name                                |
+| ------- | -------------------------------- | -------------------------------------------- |
+| Linux   | `lib/honker/libhonker_ext.so`    | `lib` prefix, `.so` (shared object)          |
+| macOS   | `lib/honker/libhonker_ext.dylib` | `lib` prefix, `.dylib` (dynamic library)     |
+| Windows | `lib/honker/honker_ext.dll`      | no `lib` prefix, `.dll` (dynamic-link lib)   |
+
+`Honker::Database.new` checks the host OS at load time and resolves to
+the matching filename, so you usually do not need to think about it.
+You only see the difference if you build the extension yourself or set
+`HONKER_EXTENSION_PATH`, in which case the file you point at must match
+the OS the Ruby process is running on.
+
+To find the installed copy:
+
+```sh
+gem which honker            # => …/gems/honker-0.2.0-arm64-darwin/lib/honker.rb
+ls "$(dirname "$(gem which honker)")/honker"
+# libhonker_ext.dylib  ...
+```
+
+### Overriding the extension path
+
+To point at a different copy of the extension (a local dev build, a
+sidecar mounted into a container, a system path) pass `extension_path:`
+or set `HONKER_EXTENSION_PATH`; both override the bundled file.
+
+```ruby
+Honker::Database.new("app.db", extension_path: "./libhonker_ext.dylib")
+```
+
+```sh
+HONKER_EXTENSION_PATH=/opt/honker/libhonker_ext.so ruby app.rb
+```
+
+### Source gem (compiles on install, needs Rust)
+
+Every other platform (Intel macOS, Windows, anything else) gets the
+generic gem, which ships the Rust crate source and compiles the
+extension during `gem install`. Install [`rustc` and `cargo`](https://rustup.rs)
+first; otherwise the install fails with a clear message pointing at
+rustup.
+
+```sh
+gem install honker
+# Fetching honker-0.2.0.gem
+# Building native extensions. This could take a while...
+# honker: building the SQLite extension with cargo
+```
+
+The compiled artifact lands in the same `lib/honker/` directory as the
+prebuilt gems, so `Honker::Database.new` finds it the same way.
 
 ### Installing from git
 
 `honker` lives in a subdirectory of a polyglot monorepo, so a `github:`
-dependency needs Bundler's `glob:` option to point at the gemspec. The
-git checkout has no prebuilt extension either, so it builds on install
-and needs `rustc`:
+dependency needs Bundler's `glob:` option to point at the gemspec. A
+git checkout has no prebuilt extension, so it always takes the
+compile-on-install path and needs `rustc`:
 
 ```ruby
-gem "honker", github: "russellromney/honker",
-    glob: "packages/honker-ruby/honker.gemspec"
+# Gemfile
+gem "honker",
+    github: "russellromney/honker",
+    glob:   "packages/honker-ruby/honker.gemspec"
 ```
+
+To pin to a branch, tag, or commit, add `branch:`, `tag:`, or `ref:`:
+
+```ruby
+# Gemfile
+gem "honker",
+    github: "russellromney/honker",
+    glob:   "packages/honker-ruby/honker.gemspec",
+    branch: "main"
+```
+
+## Using Honker alongside an ORM
+
+`honker-ruby` opens its own `SQLite3::Database` handle (via the
+[`sqlite3`](https://rubygems.org/gems/sqlite3) gem) and loads the
+extension into it. To share a single SQLite file (and a single
+transaction) with Rails/ActiveRecord, Sequel, ROM, or Hanami::DB, get
+the underlying `sqlite3` gem connection your ORM is already using and
+load the Honker extension into that handle, so `honker_enqueue(...)`
+and friends are callable from inside one of its transactions.
+
+See the per-ORM walkthroughs at
+[honker.dev/guides/orm/ruby](https://honker.dev/guides/orm/ruby/).
 
 ## Watcher backends
 

--- a/packages/honker-ruby/examples/atomic.rb
+++ b/packages/honker-ruby/examples/atomic.rb
@@ -6,24 +6,20 @@
 # write; to make the job atomic with your INSERT, drive both from
 # a single transaction on the underlying sqlite3 gem connection.
 #
-#   ruby -Ilib examples/atomic.rb
+# From a checkout, build the extension and point Honker at it:
+#   cargo build --release -p honker-extension
+#   HONKER_EXTENSION_PATH=target/release/libhonker_ext.so ruby examples/atomic.rb
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "honker"
 require "tmpdir"
-
-EXT_PATH = ENV["HONKER_EXTENSION_PATH"] ||
-           File.expand_path(
-             "../../../target/release/libhonker_ext.dylib",
-             __dir__,
-           )
 
 def count(raw, sql)
   raw.get_first_row(sql).first
 end
 
 Dir.mktmpdir("honker-") do |dir|
-  db = Honker::Database.new(File.join(dir, "app.db"), extension_path: EXT_PATH)
+  db = Honker::Database.new(File.join(dir, "app.db"))
   raw = db.db
 
   raw.execute(

--- a/packages/honker-ruby/examples/basic.rb
+++ b/packages/honker-ruby/examples/basic.rb
@@ -2,18 +2,14 @@
 #
 # Basic example: enqueue a few jobs, claim them, ack each.
 #
-#   ruby examples/basic.rb
+# From a checkout, build the extension and point Honker at it:
+#   cargo build --release -p honker-extension
+#   HONKER_EXTENSION_PATH=target/release/libhonker_ext.so ruby examples/basic.rb
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "honker"
 
-EXT_PATH = ENV["HONKER_EXTENSION_PATH"] ||
-           File.expand_path(
-             "../../../target/release/libhonker_extension.dylib",
-             __dir__,
-           )
-
-db = Honker::Database.new("demo.db", extension_path: EXT_PATH)
+db = Honker::Database.new("demo.db")
 q  = db.queue("emails")
 
 3.times do |i|

--- a/packages/honker-ruby/ext/honker/extconf.rb
+++ b/packages/honker-ruby/ext/honker/extconf.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+#
+# Builds the Honker SQLite loadable extension when the generic (source)
+# gem is installed. Precompiled platform gems ship the extension and do
+# not run this. A Rust toolchain is required; see https://rustup.rs.
+#
+# RubyGems runs this script and then `make`. It does the cargo build
+# itself, drops the artifact in lib/honker/, and writes a no-op Makefile.
+
+require "rbconfig"
+require "fileutils"
+
+ext_dir = __dir__
+
+manifest = [
+  File.join(ext_dir, "honker-extension", "Cargo.toml"),                 # vendored in the gem
+  File.expand_path("../../../../honker-extension/Cargo.toml", ext_dir), # repo checkout (github:)
+].find { |path| File.file?(path) }
+
+if manifest.nil?
+  abort "honker: honker-extension crate source not found; cannot build the extension"
+end
+
+cargo_found = system("cargo", "--version", out: File::NULL, err: File::NULL)
+unless cargo_found
+  abort <<~MSG
+    honker: cannot build the SQLite extension because the Rust toolchain
+    (cargo) was not found on PATH.
+
+    This is the honker source gem; it compiles the extension on install.
+    To fix this, either:
+      * install Rust from https://rustup.rs and reinstall honker, or
+      * use a precompiled platform gem (published for x86_64 Linux,
+        arm64 Linux, and Apple Silicon macOS).
+  MSG
+end
+
+ext_name =
+  case RbConfig::CONFIG.fetch("host_os")
+  when /mswin|mingw|cygwin/ then "honker_ext.dll"
+  when /darwin/ then "libhonker_ext.dylib"
+  else "libhonker_ext.so"
+  end
+
+target_dir = File.join(ext_dir, "target")
+
+puts "honker: building the SQLite extension with cargo"
+system(
+  { "CARGO_TARGET_DIR" => target_dir },
+  "cargo", "build", "--release", "--manifest-path", manifest,
+  exception: true,
+)
+
+artifact = File.join(target_dir, "release", ext_name)
+abort "honker: cargo build did not produce #{artifact}" unless File.file?(artifact)
+
+dest_dir = File.expand_path("../../lib/honker", ext_dir)
+FileUtils.mkdir_p(dest_dir)
+FileUtils.cp(artifact, File.join(dest_dir, ext_name))
+FileUtils.rm_rf(target_dir)
+puts "honker: extension ready at lib/honker/#{ext_name}"
+
+# RubyGems runs `make` after this script; the build is already done, so
+# the Makefile only needs targets that succeed as no-ops.
+File.write(File.join(ext_dir, "Makefile"), <<~MAKEFILE)
+  all:
+  clean:
+  install:
+MAKEFILE

--- a/packages/honker-ruby/honker.gemspec
+++ b/packages/honker-ruby/honker.gemspec
@@ -21,10 +21,33 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"]    = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/russellromney/honker"
   spec.metadata["documentation_uri"] = "https://honker.dev/"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.files = Dir.glob("lib/**/*") + %w[honker.gemspec README.md LICENSE LICENSE-MIT LICENSE-APACHE]
+  # HONKER_GEM_PLATFORM is set by the release workflow when building a
+  # precompiled platform gem: it bundles the prebuilt extension next to
+  # the Ruby source in lib/honker/. Without it `gem build` produces the
+  # generic gem, which ships the Rust crate source and compiles the
+  # extension on install (see ext/honker/extconf.rb).
+  gem_platform = ENV.fetch("HONKER_GEM_PLATFORM", nil)
+  generic_gem = gem_platform.nil? || gem_platform.empty?
+  spec.platform = gem_platform unless generic_gem
+
+  extension_files = Dir.glob("lib/honker/{libhonker_ext.*,honker_ext.dll}")
+  ruby_files = Dir.glob("lib/**/*") - extension_files
+  base_files = ruby_files +
+    %w[honker.gemspec README.md LICENSE LICENSE-MIT LICENSE-APACHE]
+
+  if generic_gem
+    spec.extensions = ["ext/honker/extconf.rb"]
+    spec.files = base_files + Dir.glob("ext/**/*").select { |f| File.file?(f) }
+  else
+    spec.files = base_files + extension_files
+  end
   spec.require_paths = ["lib"]
 
+  # CoreWatcher calls into the extension over Fiddle. Declared
+  # explicitly because fiddle stopped being a default gem in Ruby 3.5.
+  spec.add_dependency "fiddle", "~> 1.0"
   # Honker loads the SQLite extension directly, so the Ruby sqlite3
   # binding must expose Database#enable_load_extension/#load_extension.
   # sqlite3 2.0.4 is the first line compatible with our Ruby >= 3.0 floor

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -19,6 +19,7 @@
 
 require "json"
 require "fiddle"
+require "rbconfig"
 require "sqlite3"
 
 require_relative "honker/version"
@@ -28,6 +29,52 @@ require_relative "honker/scheduler"
 require_relative "honker/lock"
 
 module Honker
+  # Honker's error class, raised by ExtensionResolver and CoreWatcher.
+  class Error < StandardError; end
+
+  # Resolves the path to the Honker SQLite loadable extension. Platform
+  # gems ship it bundled in lib/honker/; an explicit path and the
+  # HONKER_EXTENSION_PATH override take precedence.
+  class ExtensionResolver
+    def initialize(env: ENV.fetch("HONKER_EXTENSION_PATH", nil), bundled: nil)
+      @env = env
+      @bundled = bundled || File.expand_path("honker/#{extension_filename}", __dir__)
+    end
+
+    # Returns the extension path: an explicit `extension_path`, else
+    # HONKER_EXTENSION_PATH, else the bundled extension. Raises
+    # Honker::Error when HONKER_EXTENSION_PATH or the bundled extension
+    # is missing.
+    def resolve(extension_path = nil)
+      return extension_path unless extension_path.nil?
+      return env_extension unless env.nil? || env.empty?
+
+      path = bundled
+      return path if File.file?(path)
+
+      raise Error, "Honker SQLite extension not found at #{path}; " \
+                   "set HONKER_EXTENSION_PATH or pass extension_path:"
+    end
+
+    private
+
+    attr_reader :env, :bundled
+
+    def env_extension
+      return env if File.file?(env)
+
+      raise Error, "HONKER_EXTENSION_PATH does not exist: #{env}"
+    end
+
+    def extension_filename
+      case RbConfig::CONFIG.fetch("host_os")
+      when /mswin|mingw|cygwin/ then "honker_ext.dll"
+      when /darwin/ then "libhonker_ext.dylib"
+      else "libhonker_ext.so"
+      end
+    end
+  end
+
   class CoreWatcher
     def initialize(db_path, extension_path, backend)
       @lib = Fiddle.dlopen(extension_path)
@@ -86,21 +133,23 @@ module Honker
   class Database
     attr_reader :db
 
-    def initialize(path, extension_path:, watcher_backend: nil)
+    def initialize(path, extension_path: nil, watcher_backend: nil,
+                   extension_resolver: ExtensionResolver.new)
       unless watcher_backend.nil? || watcher_backend.is_a?(String)
         raise ArgumentError, "unknown watcher backend"
       end
 
+      resolved_extension = extension_resolver.resolve(extension_path)
       @db = SQLite3::Database.new(path)
       @local_update_seq = 0
       @db.busy_timeout = 5000
       @db.execute("PRAGMA mmap_size = 0")
       @db.enable_load_extension(true)
-      @db.load_extension(extension_path)
+      @db.load_extension(resolved_extension)
       @db.enable_load_extension(false)
       @db.execute_batch(DEFAULT_PRAGMAS)
       @db.execute("SELECT honker_bootstrap()")
-      @watcher = CoreWatcher.new(path, extension_path, watcher_backend)
+      @watcher = CoreWatcher.new(path, resolved_extension, watcher_backend)
     end
 
     def close

--- a/packages/honker-ruby/lib/honker/README.md
+++ b/packages/honker-ruby/lib/honker/README.md
@@ -1,0 +1,28 @@
+# lib/honker
+
+Ruby source for the `honker` gem.
+
+## The bundled SQLite extension
+
+Released **platform gems** also ship the prebuilt Honker SQLite loadable
+extension in this directory. It is not checked into the source
+repository: it is a build artifact, gitignored, copied in at release
+time by `scripts/copy-ruby-extension.sh` and verified by
+`scripts/proof/check-ruby-gem.rb`.
+
+When it is present, `Honker::Database.new` finds and loads it
+automatically, so a platform gem needs no `extension_path:`.
+
+| Gem platform    | Bundled extension file |
+| --------------- | ---------------------- |
+| `x86_64-linux`  | `libhonker_ext.so`     |
+| `aarch64-linux` | `libhonker_ext.so`     |
+| `arm64-darwin`  | `libhonker_ext.dylib`  |
+
+The artifact name follows the target OS: `libhonker_ext.so` on Linux,
+`libhonker_ext.dylib` on macOS, and `honker_ext.dll` on Windows.
+
+The **generic gem** (used on every other platform, and for `github:`
+installs) ships no prebuilt extension. Instead it bundles the Rust crate
+source under `ext/honker/` and compiles the extension into this
+directory on install, which needs a [Rust toolchain](https://rustup.rs).

--- a/packages/honker-ruby/lib/honker/version.rb
+++ b/packages/honker-ruby/lib/honker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Honker
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/packages/honker-ruby/spec/extension_resolution_spec.rb
+++ b/packages/honker-ruby/spec/extension_resolution_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+#
+# Unit tests for Honker::ExtensionResolver, the lookup that lets
+# Honker::Database.new resolve the bundled SQLite extension without an
+# explicit extension_path.
+#
+# Run: bundle exec ruby -Ilib spec/extension_resolution_spec.rb
+
+require "tmpdir"
+require "minitest/autorun"
+require "honker"
+
+class ExtensionResolverTest < Minitest::Test
+  def test_explicit_path_is_returned_unchanged
+    resolver = Honker::ExtensionResolver.new(env: nil)
+    assert_equal(
+      "/somewhere/libhonker_ext.so",
+      resolver.resolve("/somewhere/libhonker_ext.so"),
+    )
+  end
+
+  def test_explicit_path_beats_a_set_env_var
+    resolver = Honker::ExtensionResolver.new(env: "/env/libhonker_ext.so")
+    assert_equal(
+      "/explicit/libhonker_ext.so",
+      resolver.resolve("/explicit/libhonker_ext.so"),
+    )
+  end
+
+  def test_env_path_is_used_when_it_exists
+    Dir.mktmpdir do |dir|
+      ext = File.join(dir, "libhonker_ext.so")
+      File.write(ext, "")
+      resolver = Honker::ExtensionResolver.new(env: ext)
+      assert_equal ext, resolver.resolve
+    end
+  end
+
+  def test_missing_env_path_raises
+    resolver = Honker::ExtensionResolver.new(env: "/no/such/ext.so")
+    error = assert_raises(Honker::Error) { resolver.resolve }
+    assert_includes error.message, "HONKER_EXTENSION_PATH"
+  end
+
+  def test_empty_env_falls_through_to_the_bundled_extension
+    Dir.mktmpdir do |dir|
+      ext = File.join(dir, "libhonker_ext.so")
+      File.write(ext, "")
+      resolver = Honker::ExtensionResolver.new(env: "", bundled: ext)
+      assert_equal ext, resolver.resolve
+    end
+  end
+
+  def test_uses_the_bundled_extension_when_no_override_is_given
+    Dir.mktmpdir do |dir|
+      ext = File.join(dir, "libhonker_ext.so")
+      File.write(ext, "")
+      resolver = Honker::ExtensionResolver.new(env: nil, bundled: ext)
+      assert_equal ext, resolver.resolve
+    end
+  end
+
+  def test_missing_bundled_extension_raises
+    resolver = Honker::ExtensionResolver.new(env: nil, bundled: "/no/such/ext.so")
+    error = assert_raises(Honker::Error) { resolver.resolve }
+    assert_includes error.message, "not found"
+  end
+
+  def test_database_consults_the_resolver_when_extension_path_omitted
+    consulted = Class.new(StandardError)
+    resolver = Object.new
+    resolver.define_singleton_method(:resolve) { |_extension_path| raise consulted }
+
+    Dir.mktmpdir do |dir|
+      assert_raises(consulted) do
+        Honker::Database.new(File.join(dir, "app.db"), extension_resolver: resolver)
+      end
+    end
+  end
+end

--- a/scripts/copy-ruby-extension.sh
+++ b/scripts/copy-ruby-extension.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="$ROOT/target/release"
+DEST_DIR="$ROOT/packages/honker-ruby/lib/honker"
+
+case "$(uname -s)" in
+  Darwin)
+    EXT_NAME="libhonker_ext.dylib"
+    ;;
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    EXT_NAME="honker_ext.dll"
+    ;;
+  *)
+    EXT_NAME="libhonker_ext.so"
+    ;;
+esac
+
+SRC="$SRC_DIR/$EXT_NAME"
+if [[ ! -f "$SRC" ]]; then
+  echo "honker extension not found at $SRC" >&2
+  echo "run: cargo build --release -p honker-extension" >&2
+  exit 1
+fi
+
+# Drop any stale extension before copying the current one. DEST_DIR is
+# the gem's source directory, so remove only the artifact names, never
+# the directory itself.
+rm -f "$DEST_DIR/libhonker_ext.so" "$DEST_DIR/libhonker_ext.dylib" "$DEST_DIR/honker_ext.dll"
+cp "$SRC" "$DEST_DIR/$EXT_NAME"
+echo "copied $SRC -> $DEST_DIR/$EXT_NAME"

--- a/scripts/copy-ruby-sources.sh
+++ b/scripts/copy-ruby-sources.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="$ROOT/packages/honker-ruby/ext/honker"
+
+# The generic (source) gem compiles the extension on install, so it
+# ships the honker-extension and honker-core crate source. This vendors
+# them into ext/honker/; the copies are gitignored and refreshed at gem
+# build time, mirroring copy-ruby-extension.sh for the prebuilt binary.
+for crate in honker-extension honker-core; do
+  rm -rf "${DEST:?}/$crate"
+  mkdir -p "$DEST/$crate"
+  cp -R "$ROOT/$crate/." "$DEST/$crate/"
+  rm -rf "$DEST/$crate/target"
+done
+
+# Make the vendored extension crate its own workspace root so cargo does
+# not attach it to an enclosing Cargo.toml when the gem is built from
+# inside this repo.
+printf '\n[workspace]\n' >> "$DEST/honker-extension/Cargo.toml"
+
+echo "vendored honker-extension and honker-core into $DEST"

--- a/scripts/proof/check-ruby-gem.rb
+++ b/scripts/proof/check-ruby-gem.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Release proof for honker gems.
+#
+#   check-ruby-gem.rb GEM [GEM ...]             # platform gem checks
+#   check-ruby-gem.rb --generic GEM [GEM ...]   # generic gem checks
+#
+# A platform gem must be platform-specific and bundle the SQLite
+# loadable extension. The generic gem must instead ship the Rust crate
+# source and declare an extension that compiles it on install.
+
+require "rubygems/package"
+
+def bundles_extension?(package)
+  package.contents.any? do |name|
+    name.match?(%r{\Alib/honker/(?:lib)?honker_ext\.(?:so|dylib|dll)\z})
+  end
+end
+
+def check_platform_gem(path)
+  package = Gem::Package.new(path)
+  if package.spec.platform == Gem::Platform::RUBY
+    abort "ruby gem is not platform-specific: #{path}"
+  end
+  abort "ruby gem is missing bundled SQLite extension: #{path}" unless bundles_extension?(package)
+end
+
+def check_generic_gem(path)
+  package = Gem::Package.new(path)
+  unless package.spec.platform == Gem::Platform::RUBY
+    abort "generic ruby gem must not be platform-specific: #{path}"
+  end
+  abort "generic ruby gem must not bundle an extension: #{path}" if bundles_extension?(package)
+
+  if package.spec.extensions.empty?
+    abort "generic ruby gem must declare an extension to compile on install: #{path}"
+  end
+
+  contents = package.contents
+  unless contents.include?("ext/honker/extconf.rb")
+    abort "generic ruby gem is missing ext/honker/extconf.rb: #{path}"
+  end
+  unless contents.any? { |name| name.start_with?("ext/honker/honker-extension/") }
+    abort "generic ruby gem is missing the vendored Rust crate source: #{path}"
+  end
+end
+
+def main
+  args = ARGV.dup
+  generic = args.delete("--generic")
+  abort "usage: check-ruby-gem.rb [--generic] GEM [GEM ...]" if args.empty?
+
+  args.each do |path|
+    generic ? check_generic_gem(path) : check_platform_gem(path)
+  end
+end
+
+main if $PROGRAM_NAME == __FILE__

--- a/scripts/proof/package-install-smoke.sh
+++ b/scripts/proof/package-install-smoke.sh
@@ -107,27 +107,16 @@ JS
 )
 
 echo "== ruby gem install =="
+scripts/copy-ruby-extension.sh
+RUBY_GEM_PLATFORM="$("$RUBY_BIN" -e 'p = Gem::Platform.local; print [p.cpu, p.os].join("-")')"
 (
   cd "$ROOT/packages/honker-ruby"
-  "$RUBY_BIN" -S gem build honker.gemspec --output "$TMP/honker.gem"
+  HONKER_GEM_PLATFORM="$RUBY_GEM_PLATFORM" \
+    "$RUBY_BIN" -S gem build honker.gemspec --output "$TMP/honker.gem"
 )
+"$RUBY_BIN" "$ROOT/scripts/proof/check-ruby-gem.rb" "$TMP/honker.gem"
 GEM_HOME="$TMP/gems" GEM_PATH="$TMP/gems" "$RUBY_BIN" -S gem install "$TMP/honker.gem" >/dev/null
-GEM_HOME="$TMP/gems" GEM_PATH="$TMP/gems" HONKER_EXTENSION_PATH="$EXT" "$RUBY_BIN" <<'RB'
-require "tmpdir"
-require "honker"
-
-Dir.mktmpdir("honker-ruby-proof-") do |dir|
-  db = Honker::Database.new(File.join(dir, "app.db"), extension_path: ENV.fetch("HONKER_EXTENSION_PATH"))
-  q = db.queue("emails")
-  id = q.enqueue({to: "alice@example.com"})
-  job = q.claim_one("worker-1")
-  raise "claim failed" unless job && job.id == id
-  raise "payload mismatch" unless job.payload["to"] == "alice@example.com"
-  raise "ack failed" unless job.ack
-  db.close
-end
-puts "ruby package smoke ok"
-RB
+GEM_HOME="$TMP/gems" GEM_PATH="$TMP/gems" "$RUBY_BIN" "$ROOT/scripts/proof/ruby-gem-smoke.rb"
 
 echo "== dotnet nuget install =="
 RID="linux-x64"

--- a/scripts/proof/ruby-gem-smoke.rb
+++ b/scripts/proof/ruby-gem-smoke.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Release proof: install-and-run check for the honker gem. Assumes the
+# gem is already installed; exercises a queue round-trip through the
+# bundled SQLite extension (no HONKER_EXTENSION_PATH, no extension_path:
+# argument), so it fails if the gem did not bundle a working extension.
+
+require "tmpdir"
+require "honker"
+
+Dir.mktmpdir("honker-ruby-proof-") do |dir|
+  db = Honker::Database.new(File.join(dir, "app.db"))
+  q = db.queue("emails")
+  id = q.enqueue({ to: "alice@example.com" })
+  job = q.claim_one("worker-1")
+  raise "claim failed" unless job && job.id == id
+  raise "payload mismatch" unless job.payload["to"] == "alice@example.com"
+  raise "ack failed" unless job.ack
+  db.close
+end
+
+puts "ruby gem smoke ok"

--- a/scripts/verify-ruby-gem-local.sh
+++ b/scripts/verify-ruby-gem-local.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local pre-push check for the honker Ruby gem. Not run by CI; it is a
+# developer convenience that reproduces in one command what CI checks
+# across ci.yml (specs) and release-ruby.yml (gem build, proof, smoke).
+#
+# Builds and installs both the precompiled platform gem and the
+# compile-on-install generic gem, runs a queue round-trip smoke test
+# against each, and runs the specs.
+#
+#   scripts/verify-ruby-gem-local.sh            host checks
+#   scripts/verify-ruby-gem-local.sh --docker   also a Linux build in Docker
+#
+# Needs ruby, gem, bundle, and cargo on PATH; docker too for --docker.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUBY_PKG="$ROOT/packages/honker-ruby"
+WITH_DOCKER=0
+[[ "${1:-}" == "--docker" ]] && WITH_DOCKER=1
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$ROOT"
+
+echo "== build extension =="
+cargo build --release -p honker-extension
+
+echo
+echo "== platform gem =="
+scripts/copy-ruby-extension.sh
+platform="$(ruby -e 'p = Gem::Platform.local; print [p.cpu, p.os].join("-")')"
+( cd "$RUBY_PKG" && HONKER_GEM_PLATFORM="$platform" \
+    gem build honker.gemspec --output "$TMP/platform.gem" )
+ruby scripts/proof/check-ruby-gem.rb "$TMP/platform.gem"
+GEM_HOME="$TMP/platform-home" GEM_PATH="$TMP/platform-home" \
+  gem install --no-document "$TMP/platform.gem"
+GEM_HOME="$TMP/platform-home" GEM_PATH="$TMP/platform-home" \
+  ruby scripts/proof/ruby-gem-smoke.rb
+
+echo
+echo "== generic gem (compiles on install) =="
+scripts/copy-ruby-sources.sh
+( cd "$RUBY_PKG" && gem build honker.gemspec --output "$TMP/generic.gem" )
+ruby scripts/proof/check-ruby-gem.rb --generic "$TMP/generic.gem"
+GEM_HOME="$TMP/generic-home" GEM_PATH="$TMP/generic-home" \
+  gem install --no-document "$TMP/generic.gem"
+GEM_HOME="$TMP/generic-home" GEM_PATH="$TMP/generic-home" \
+  ruby scripts/proof/ruby-gem-smoke.rb
+
+echo
+echo "== specs =="
+(
+  cd "$RUBY_PKG"
+  bundle install --quiet
+  for spec in honker_spec smoke_spec parity_spec extension_resolution_spec; do
+    echo "  -- $spec --"
+    bundle exec ruby -Ilib "spec/$spec.rb"
+  done
+)
+
+if [[ "$WITH_DOCKER" == "1" ]]; then
+  echo
+  echo "== docker: generic gem compiles on install (linux/amd64) =="
+  docker run --rm --platform linux/amd64 -v "$ROOT:/work" -w /work rust:latest \
+    bash -euo pipefail -c '
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update -qq
+      apt-get install -y -qq --no-install-recommends ruby ruby-dev make >/dev/null
+      scripts/copy-ruby-sources.sh >/dev/null
+      cd packages/honker-ruby
+      gem build honker.gemspec --output /tmp/honker.gem >/dev/null
+      ruby ../../scripts/proof/check-ruby-gem.rb --generic /tmp/honker.gem
+      gem install --no-document /tmp/honker.gem >/dev/null
+      ruby ../../scripts/proof/ruby-gem-smoke.rb
+    '
+
+  echo
+  echo "== docker: install without Rust fails cleanly (linux/amd64) =="
+  no_rust_out="$(docker run --rm --platform linux/amd64 \
+    -v "$TMP/generic.gem:/tmp/honker.gem:ro" ruby:3.3 \
+    bash -c 'gem install --no-document /tmp/honker.gem' 2>&1 || true)"
+  if echo "$no_rust_out" | grep -q "Rust toolchain"; then
+    echo "  install failed with the expected Rust-toolchain error"
+  else
+    echo "  ERROR: expected the missing-Rust error message; got:" >&2
+    echo "$no_rust_out" >&2
+    exit 1
+  fi
+fi
+
+echo
+echo "ruby gem verification ok"


### PR DESCRIPTION
First of all, thanks for creating Honker! I'm a core team member of [Hanakai](https://hanakai.org/hanami), which includes the web framework Hanami. We don't pull in any Rails dependencies so this give us some great parity with the Solid* gems from Rails. Happy to help see this project succeed!

This mirrors PR #53 (Python wheel packaging) for the Ruby binding. The `honker` gem, now 0.2.0, ships the SQLite loadable extension itself, so `Honker::Database.new` resolves it automatically and `extension_path:` is optional.

Heavily used Claude for this. Tested it to the extent possible without being able to run GitHub actions and do a real release.

## Summary

- Precompiled platform gems for x86_64 Linux, aarch64 Linux, and Apple Silicon macOS bundle the prebuilt extension in `lib/honker/` (where sqlite and nokogiri put it, the convention in ruby gems). These are the three most popular platforms, so they're the highest priority.
- The generic gem (every other platform, and `github:` installs) compiles the extension from bundled Rust source on install, the way sqlite and nokogiri do. A Rust toolchain is required for that path.
- New `release-ruby.yml` workflow builds, smoke-tests, and publishes every gem.
- New `Honker::ExtensionResolver`; `extension_path:` is now an optional keyword. `Honker::Error` is now defined (it was referenced by `CoreWatcher#wait` but never declared, a latent `NameError`).
- Declares the `fiddle` runtime dependency (no longer a default gem in Ruby 3.5+) and sets `rubygems_mfa_required`.

## Design notes and trade-offs

- **Platform gems, not one fat gem.** One precompiled gem per OS/arch; RubyGems picks the match automatically. Costs more release artifacts, but each install is instant with nothing to compile.
- **Three precompiled targets.** Windows and Intel macOS are intentionally not precompiled (Windows cannot be verified locally; both are lower-traffic); those users get the generic gem instead.
- **The generic gem compiles on install** instead of shipping nothing. Trade-off: a source install needs a Rust toolchain. `extconf.rb` does a pre-flight check and fails with a clear, actionable message when `cargo` is missing. The payoff: `gem install` works on every platform, and `github:` works.
- **`extension_path:` is now optional**, resolved in order: an explicit argument, then `HONKER_EXTENSION_PATH`, then the bundled extension. Backward compatible; an explicit path still works.
- **Release-workflow actions are SHA-pinned.** The workflow holds the RubyGems publish secret, and the repo's zizmor lint requires pinning for any workflow except `ci.yml`.

## Scripts
| When | Script | Purpose |
| --- | --- | --- |
| **CI / stage** | `scripts/copy-ruby-extension.sh` | Stages the extension (built ahead of time by `cargo build --release -p honker-extension` on the matching CI runner) into `lib/honker/` for a platform gem. |
| **CI / stage** | `scripts/copy-ruby-sources.sh` | Vendors the `honker-extension` and `honker-core` crate source into `ext/honker/` for the generic gem. |
| **CI / verify** | `scripts/proof/check-ruby-gem.rb` | Release proof: a platform gem bundles the extension; `--generic` checks the source gem ships the crate source and a compile step. |
| **CI / verify** | `scripts/proof/ruby-gem-smoke.rb` | Opens a DB and runs an enqueue/claim/ack round-trip against an installed gem. |
| **Install** | `packages/honker-ruby/ext/honker/extconf.rb` | Compiles the extension from the vendored crate source whenever the generic gem is installed: in `release-ruby.yml`'s smoke step, in `verify-ruby-gem-local.sh`, and on end-user machines. |
| **Local** | `scripts/verify-ruby-gem-local.sh` | Full pre-push check: builds, installs, and smoke-tests both gems (the current platform pre-built version and the compiling from source one), then runs the specs (`--docker` adds Linux checks). |

Happy to respond to feedback, but also feel free to take things from here and tweak at your will. No offense taken :)




Workflow triggers:

- `release-ruby.yml` runs on `rb-v*` tags or manual dispatch.
- `ci.yml` runs the Ruby specs on every PR.
- `package-proof.yml` and `scary-nightly.yml` run `package-install-smoke.sh` on a weekly/nightly schedule.

## Verification

- macOS: platform gem and generic (compile-on-install) gem built, installed, and smoke-tested; all specs pass.
- Docker `linux/amd64` and `linux/arm64`: the Linux platform gems built and smoke-tested.
- Docker `linux/amd64`: the generic gem compiled on install and passed the smoke test; installing without a Rust toolchain failed cleanly with the actionable error.
- `github:`-style install verified via a local `git:` source with `glob: "packages/honker-ruby/honker.gemspec"`.
- `scripts/verify-ruby-gem-local.sh --docker` is green.
