### PR TITLE
Add Ruby DB helpers and railtie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,7 @@ jobs:
           bundle exec ruby -Ilib spec/honker_spec.rb
           bundle exec ruby -Ilib spec/smoke_spec.rb
           bundle exec ruby -Ilib spec/parity_spec.rb
+          bundle exec ruby -Ilib spec/extension_resolution_spec.rb
       - name: Elixir
         working-directory: packages/honker-ex
         env:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -1,0 +1,101 @@
+name: Release · RubyGems
+
+on:
+  push:
+    tags:
+      - "rb-v*"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Upload built gems to RubyGems"
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  platform-gems:
+    name: ruby gem · ${{ matrix.gem_platform }}
+    timeout-minutes: 20
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # Native builds on a matching runner for each precompiled gem.
+      # Windows, Intel macOS, and musl are intentionally not built here;
+      # those users install the generic gem (see the generic-gem job).
+      matrix:
+        include:
+          - os: ubuntu-latest
+            gem_platform: x86_64-linux
+          - os: ubuntu-24.04-arm
+            gem_platform: aarch64-linux
+          - os: macos-latest
+            gem_platform: arm64-darwin
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f  # v1.306.0
+        with:
+          ruby-version: "3.4"
+
+      - name: Build platform gem
+        shell: bash
+        env:
+          HONKER_GEM_PLATFORM: ${{ matrix.gem_platform }}
+        run: |
+          cargo build --release -p honker-extension
+          scripts/copy-ruby-extension.sh
+          cd packages/honker-ruby
+          gem build honker.gemspec --output "$RUNNER_TEMP/honker.gem"
+          ruby ../../scripts/proof/check-ruby-gem.rb "$RUNNER_TEMP/honker.gem"
+
+      - name: Smoke-test the gem
+        shell: bash
+        run: |
+          gem install "$RUNNER_TEMP/honker.gem"
+          ruby scripts/proof/ruby-gem-smoke.rb
+
+      - name: Upload gem to RubyGems
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref_name, 'rb-v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') }}
+        shell: bash
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: gem push "$RUNNER_TEMP/honker.gem"
+
+  generic-gem:
+    name: ruby gem · generic
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f  # v1.306.0
+        with:
+          ruby-version: "3.4"
+
+      - name: Build generic gem
+        shell: bash
+        run: |
+          scripts/copy-ruby-sources.sh
+          cd packages/honker-ruby
+          gem build honker.gemspec --output "$RUNNER_TEMP/honker.gem"
+          ruby ../../scripts/proof/check-ruby-gem.rb --generic "$RUNNER_TEMP/honker.gem"
+
+      - name: Smoke-test the gem (compiles on install)
+        shell: bash
+        run: |
+          gem install "$RUNNER_TEMP/honker.gem"
+          ruby scripts/proof/ruby-gem-smoke.rb
+
+      - name: Upload gem to RubyGems
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref_name, 'rb-v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') }}
+        shell: bash
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: gem push "$RUNNER_TEMP/honker.gem"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## 2026-05-23 — Ruby 0.3.0
+
+- Ruby `honker`: 0.3.0
+- New `Honker::Railtie` runs `honker_bootstrap()` against
+  `ActiveRecord::Base.connection` in `config.after_initialize`, so Rails
+  apps no longer need a hand-written initializer. Loaded conditionally,
+  so Rails remains a non-dependency.
+- New module-level helpers collapse the extension-load + bootstrap
+  ceremony every ORM integration was copy-pasting: `Honker.extension_path`,
+  `Honker.load_extension`, `Honker.bootstrap`, `Honker.setup`, and
+  `Honker.sequel_after_connect` (a ready-made proc for Sequel/Rom/Hanami
+  `after_connect:`).
+
 ## 2026-05-20 - Ruby 0.2.0
 
 - Ruby `honker`: 0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 2026-05-20 - Ruby 0.2.0
+
+- Ruby `honker`: 0.2.0
+- Ruby gems now bundle the Honker SQLite loadable extension. Precompiled
+  gems ship the native library for x86_64 Linux, arm64 Linux, and Apple
+  Silicon macOS, so `Honker::Database.new` resolves it automatically and
+  `extension_path:` is now optional. On every other platform, and for
+  `github:` installs, the generic gem compiles the extension from
+  bundled Rust source on install (a Rust toolchain is required).
+- New `Release · RubyGems` workflow builds and smoke-tests those gems;
+  the release proof rejects platform gems missing the bundled extension.
+
 ## 2026-05-20 — Python 0.2.5
 
 - Python `honker`: 0.2.5

--- a/packages/honker-ruby/.gitignore
+++ b/packages/honker-ruby/.gitignore
@@ -2,4 +2,10 @@
 Gemfile.lock
 pkg/
 tmp/
+lib/honker/libhonker_ext.*
+lib/honker/honker_ext.dll
+ext/honker/honker-extension/
+ext/honker/honker-core/
+ext/honker/target/
+ext/honker/Makefile
 .DS_Store

--- a/packages/honker-ruby/Gemfile
+++ b/packages/honker-ruby/Gemfile
@@ -5,4 +5,8 @@ gemspec
 group :development, :test do
   gem "minitest", "~> 5.0"
   gem "rake", "~> 13.0"
+  # Exercises the Railtie in spec/railtie_spec.rb. Not a runtime
+  # dependency — the gem only loads Honker::Railtie when Rails is
+  # already defined in the host application.
+  gem "railties", "~> 7.0", require: false
 end

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -135,6 +135,74 @@ the underlying `sqlite3` gem connection your ORM is already using and
 load the Honker extension into that handle, so `honker_enqueue(...)`
 and friends are callable from inside one of its transactions.
 
+### Rails / ActiveRecord
+
+Point ActiveRecord at the bundled extension via `database.yml`:
+
+```yaml
+# config/database.yml
+production:
+  adapter: sqlite3
+  database: app.sqlite3
+  extensions:
+    - <%= Honker.extension_path %>
+```
+
+```ruby
+# Gemfile
+gem "honker"
+```
+
+That's it. `Honker::Railtie` runs `Honker.bootstrap` against
+`ActiveRecord::Base.connection` in `config.after_initialize`, so no
+initializer is required.
+
+Multi-database apps still need to call `Honker.bootstrap(some_other_conn)`
+themselves for non-primary connections.
+
+### Sequel (and ROM / Hanami::DB)
+
+`Honker.sequel_after_connect` returns the right `after_connect:` proc,
+so each new connection in the pool gets the extension loaded and the
+schema bootstrapped:
+
+```ruby
+require "sequel"
+require "honker"
+
+DB = Sequel.connect(
+  "sqlite://app.sqlite3",
+  after_connect: Honker.sequel_after_connect,
+)
+
+DB.synchronize do |conn|
+  conn.execute("SELECT honker_enqueue('emails', '{}', NULL, NULL, 0, 3, NULL)")
+end
+```
+
+To bootstrap once from a migration instead of on every connect, pass
+`bootstrap: false`:
+
+```ruby
+DB = Sequel.connect(
+  "sqlite://app.sqlite3",
+  after_connect: Honker.sequel_after_connect(bootstrap: false),
+)
+```
+
+### Setup helpers
+
+Both recipes above are built from the same module-level helpers, which
+wrap the extension-load and `honker_bootstrap()` ceremony:
+
+```ruby
+Honker.extension_path                  # => bundled path (or HONKER_EXTENSION_PATH override)
+Honker.load_extension(conn)            # enable_load_extension(true) → load → enable_load_extension(false)
+Honker.bootstrap(conn)                 # SELECT honker_bootstrap()
+Honker.setup(conn)                     # load_extension then bootstrap
+Honker.sequel_after_connect            # proc { |conn| Honker.setup(conn) } for Sequel/Rom/Hanami
+```
+
 See the per-ORM walkthroughs at
 [honker.dev/guides/orm/ruby](https://honker.dev/guides/orm/ruby/).
 

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -13,7 +13,24 @@ Full docs:
 gem "honker"
 ```
 
-You also need the Honker SQLite extension from the main repo.
+How the SQLite extension reaches the gem depends on your platform:
+
+- **Precompiled** (x86_64 Linux, arm64 Linux, and Apple Silicon macOS):
+  the extension is pre-built and included in the gem.
+- **Every other platform**: the generic gem builds the extension after
+  install with `rustc` (from [rustup.rs](https://rustup.rs)).
+
+### Installing from git
+
+`honker` lives in a subdirectory of a polyglot monorepo, so a `github:`
+dependency needs Bundler's `glob:` option to point at the gemspec. The
+git checkout has no prebuilt extension either, so it builds on install
+and needs `rustc`:
+
+```ruby
+gem "honker", github: "russellromney/honker",
+    glob: "packages/honker-ruby/honker.gemspec"
+```
 
 ## Watcher backends
 
@@ -28,7 +45,7 @@ the matching feature.
 ```ruby
 require "honker"
 
-db = Honker::Database.new("app.db", extension_path: "./libhonker_ext.dylib")
+db = Honker::Database.new("app.db")
 q = db.queue("emails")
 
 q.enqueue({to: "alice@example.com"})

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -9,28 +9,134 @@ Full docs:
 
 ## Install
 
+Add it to your `Gemfile`:
+
 ```ruby
+# Gemfile
 gem "honker"
 ```
 
-How the SQLite extension reaches the gem depends on your platform:
+then `bundle install`. Or install it directly:
 
-- **Precompiled** (x86_64 Linux, arm64 Linux, and Apple Silicon macOS):
-  the extension is pre-built and included in the gem.
-- **Every other platform**: the generic gem builds the extension after
-  install with `rustc` (from [rustup.rs](https://rustup.rs)).
+```sh
+gem install honker
+```
+
+Honker is a thin Ruby wrapper around a SQLite loadable extension
+written in Rust. How that extension reaches your gem install depends on
+your platform, with a fallback to compile the extension for other
+platforms.
+
+Most platforms (x86_64 and arm64 for Linux, arm64 for macOS) get a
+platform gem with the extension already built and bundled inside it:
+
+| Platform            | Triple          |
+| ------------------- | --------------- |
+| x86_64 Linux        | `x86_64-linux`  |
+| arm64 Linux         | `aarch64-linux` |
+| Apple Silicon macOS | `arm64-darwin`  |
+
+```sh
+gem install honker
+# Fetching honker-0.2.0-arm64-darwin.gem
+```
+
+`Honker::Database.new("app.db")` then finds the bundled extension
+automatically.
+
+### Where the bundled extension lives
+
+It is shipped inside the gem under `lib/honker/`, with a filename that
+follows the host OS's native shared-library convention:
+
+| Host OS | Extension file                   | Why this name                                |
+| ------- | -------------------------------- | -------------------------------------------- |
+| Linux   | `lib/honker/libhonker_ext.so`    | `lib` prefix, `.so` (shared object)          |
+| macOS   | `lib/honker/libhonker_ext.dylib` | `lib` prefix, `.dylib` (dynamic library)     |
+| Windows | `lib/honker/honker_ext.dll`      | no `lib` prefix, `.dll` (dynamic-link lib)   |
+
+`Honker::Database.new` checks the host OS at load time and resolves to
+the matching filename, so you usually do not need to think about it.
+You only see the difference if you build the extension yourself or set
+`HONKER_EXTENSION_PATH`, in which case the file you point at must match
+the OS the Ruby process is running on.
+
+To find the installed copy:
+
+```sh
+gem which honker            # => …/gems/honker-0.2.0-arm64-darwin/lib/honker.rb
+ls "$(dirname "$(gem which honker)")/honker"
+# libhonker_ext.dylib  ...
+```
+
+### Overriding the extension path
+
+To point at a different copy of the extension (a local dev build, a
+sidecar mounted into a container, a system path) pass `extension_path:`
+or set `HONKER_EXTENSION_PATH`; both override the bundled file.
+
+```ruby
+Honker::Database.new("app.db", extension_path: "./libhonker_ext.dylib")
+```
+
+```sh
+HONKER_EXTENSION_PATH=/opt/honker/libhonker_ext.so ruby app.rb
+```
+
+### Source gem (compiles on install, needs Rust)
+
+Every other platform (Intel macOS, Windows, anything else) gets the
+generic gem, which ships the Rust crate source and compiles the
+extension during `gem install`. Install [`rustc` and `cargo`](https://rustup.rs)
+first; otherwise the install fails with a clear message pointing at
+rustup.
+
+```sh
+gem install honker
+# Fetching honker-0.2.0.gem
+# Building native extensions. This could take a while...
+# honker: building the SQLite extension with cargo
+```
+
+The compiled artifact lands in the same `lib/honker/` directory as the
+prebuilt gems, so `Honker::Database.new` finds it the same way.
 
 ### Installing from git
 
 `honker` lives in a subdirectory of a polyglot monorepo, so a `github:`
-dependency needs Bundler's `glob:` option to point at the gemspec. The
-git checkout has no prebuilt extension either, so it builds on install
-and needs `rustc`:
+dependency needs Bundler's `glob:` option to point at the gemspec. A
+git checkout has no prebuilt extension, so it always takes the
+compile-on-install path and needs `rustc`:
 
 ```ruby
-gem "honker", github: "russellromney/honker",
-    glob: "packages/honker-ruby/honker.gemspec"
+# Gemfile
+gem "honker",
+    github: "russellromney/honker",
+    glob:   "packages/honker-ruby/honker.gemspec"
 ```
+
+To pin to a branch, tag, or commit, add `branch:`, `tag:`, or `ref:`:
+
+```ruby
+# Gemfile
+gem "honker",
+    github: "russellromney/honker",
+    glob:   "packages/honker-ruby/honker.gemspec",
+    branch: "main"
+```
+
+## Using Honker alongside an ORM
+
+`honker-ruby` opens its own `SQLite3::Database` handle (via the
+[`sqlite3`](https://rubygems.org/gems/sqlite3) gem) and loads the
+extension into it. To share a single SQLite file (and a single
+transaction) with Rails/ActiveRecord, Sequel, ROM, or Hanami::DB, get
+the underlying `sqlite3` gem connection your ORM is already using and
+load the Honker extension into that handle, so `honker_enqueue(...)`
+and friends are callable from inside one of its transactions.
+
+See the per-ORM walkthroughs at
+[honker.dev/guides/orm/ruby](https://honker.dev/guides/orm/ruby/).
 
 ## Watcher backends
 

--- a/packages/honker-ruby/examples/atomic.rb
+++ b/packages/honker-ruby/examples/atomic.rb
@@ -6,24 +6,20 @@
 # write; to make the job atomic with your INSERT, drive both from
 # a single transaction on the underlying sqlite3 gem connection.
 #
-#   ruby -Ilib examples/atomic.rb
+# From a checkout, build the extension and point Honker at it:
+#   cargo build --release -p honker-extension
+#   HONKER_EXTENSION_PATH=target/release/libhonker_ext.so ruby examples/atomic.rb
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "honker"
 require "tmpdir"
-
-EXT_PATH = ENV["HONKER_EXTENSION_PATH"] ||
-           File.expand_path(
-             "../../../target/release/libhonker_ext.dylib",
-             __dir__,
-           )
 
 def count(raw, sql)
   raw.get_first_row(sql).first
 end
 
 Dir.mktmpdir("honker-") do |dir|
-  db = Honker::Database.new(File.join(dir, "app.db"), extension_path: EXT_PATH)
+  db = Honker::Database.new(File.join(dir, "app.db"))
   raw = db.db
 
   raw.execute(

--- a/packages/honker-ruby/examples/basic.rb
+++ b/packages/honker-ruby/examples/basic.rb
@@ -2,18 +2,14 @@
 #
 # Basic example: enqueue a few jobs, claim them, ack each.
 #
-#   ruby examples/basic.rb
+# From a checkout, build the extension and point Honker at it:
+#   cargo build --release -p honker-extension
+#   HONKER_EXTENSION_PATH=target/release/libhonker_ext.so ruby examples/basic.rb
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "honker"
 
-EXT_PATH = ENV["HONKER_EXTENSION_PATH"] ||
-           File.expand_path(
-             "../../../target/release/libhonker_extension.dylib",
-             __dir__,
-           )
-
-db = Honker::Database.new("demo.db", extension_path: EXT_PATH)
+db = Honker::Database.new("demo.db")
 q  = db.queue("emails")
 
 3.times do |i|

--- a/packages/honker-ruby/ext/honker/extconf.rb
+++ b/packages/honker-ruby/ext/honker/extconf.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+#
+# Builds the Honker SQLite loadable extension when the generic (source)
+# gem is installed. Precompiled platform gems ship the extension and do
+# not run this. A Rust toolchain is required; see https://rustup.rs.
+#
+# RubyGems runs this script and then `make`. It does the cargo build
+# itself, drops the artifact in lib/honker/, and writes a no-op Makefile.
+
+require "rbconfig"
+require "fileutils"
+
+ext_dir = __dir__
+
+manifest = [
+  File.join(ext_dir, "honker-extension", "Cargo.toml"),                 # vendored in the gem
+  File.expand_path("../../../../honker-extension/Cargo.toml", ext_dir), # repo checkout (github:)
+].find { |path| File.file?(path) }
+
+if manifest.nil?
+  abort "honker: honker-extension crate source not found; cannot build the extension"
+end
+
+cargo_found = system("cargo", "--version", out: File::NULL, err: File::NULL)
+unless cargo_found
+  abort <<~MSG
+    honker: cannot build the SQLite extension because the Rust toolchain
+    (cargo) was not found on PATH.
+
+    This is the honker source gem; it compiles the extension on install.
+    To fix this, either:
+      * install Rust from https://rustup.rs and reinstall honker, or
+      * use a precompiled platform gem (published for x86_64 Linux,
+        arm64 Linux, and Apple Silicon macOS).
+  MSG
+end
+
+ext_name =
+  case RbConfig::CONFIG.fetch("host_os")
+  when /mswin|mingw|cygwin/ then "honker_ext.dll"
+  when /darwin/ then "libhonker_ext.dylib"
+  else "libhonker_ext.so"
+  end
+
+target_dir = File.join(ext_dir, "target")
+
+puts "honker: building the SQLite extension with cargo"
+system(
+  { "CARGO_TARGET_DIR" => target_dir },
+  "cargo", "build", "--release", "--manifest-path", manifest,
+  exception: true,
+)
+
+artifact = File.join(target_dir, "release", ext_name)
+abort "honker: cargo build did not produce #{artifact}" unless File.file?(artifact)
+
+dest_dir = File.expand_path("../../lib/honker", ext_dir)
+FileUtils.mkdir_p(dest_dir)
+FileUtils.cp(artifact, File.join(dest_dir, ext_name))
+FileUtils.rm_rf(target_dir)
+puts "honker: extension ready at lib/honker/#{ext_name}"
+
+# RubyGems runs `make` after this script; the build is already done, so
+# the Makefile only needs targets that succeed as no-ops.
+File.write(File.join(ext_dir, "Makefile"), <<~MAKEFILE)
+  all:
+  clean:
+  install:
+MAKEFILE

--- a/packages/honker-ruby/honker.gemspec
+++ b/packages/honker-ruby/honker.gemspec
@@ -21,10 +21,33 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"]    = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/russellromney/honker"
   spec.metadata["documentation_uri"] = "https://honker.dev/"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.files = Dir.glob("lib/**/*") + %w[honker.gemspec README.md LICENSE LICENSE-MIT LICENSE-APACHE]
+  # HONKER_GEM_PLATFORM is set by the release workflow when building a
+  # precompiled platform gem: it bundles the prebuilt extension next to
+  # the Ruby source in lib/honker/. Without it `gem build` produces the
+  # generic gem, which ships the Rust crate source and compiles the
+  # extension on install (see ext/honker/extconf.rb).
+  gem_platform = ENV.fetch("HONKER_GEM_PLATFORM", nil)
+  generic_gem = gem_platform.nil? || gem_platform.empty?
+  spec.platform = gem_platform unless generic_gem
+
+  extension_files = Dir.glob("lib/honker/{libhonker_ext.*,honker_ext.dll}")
+  ruby_files = Dir.glob("lib/**/*") - extension_files
+  base_files = ruby_files +
+    %w[honker.gemspec README.md LICENSE LICENSE-MIT LICENSE-APACHE]
+
+  if generic_gem
+    spec.extensions = ["ext/honker/extconf.rb"]
+    spec.files = base_files + Dir.glob("ext/**/*").select { |f| File.file?(f) }
+  else
+    spec.files = base_files + extension_files
+  end
   spec.require_paths = ["lib"]
 
+  # CoreWatcher calls into the extension over Fiddle. Declared
+  # explicitly because fiddle stopped being a default gem in Ruby 3.5.
+  spec.add_dependency "fiddle", "~> 1.0"
   # Honker loads the SQLite extension directly, so the Ruby sqlite3
   # binding must expose Database#enable_load_extension/#load_extension.
   # sqlite3 2.0.4 is the first line compatible with our Ruby >= 3.0 floor

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -27,6 +27,7 @@ require_relative "honker/transaction"
 require_relative "honker/stream"
 require_relative "honker/scheduler"
 require_relative "honker/lock"
+require_relative "honker/railtie" if defined?(::Rails::Railtie)
 
 module Honker
   # Honker's error class, raised by ExtensionResolver and CoreWatcher.
@@ -73,6 +74,41 @@ module Honker
       else "libhonker_ext.so"
       end
     end
+  end
+
+  # Resolve the bundled (or overridden) extension path without naming
+  # ExtensionResolver — useful for `database.yml` ERB and tooling.
+  def self.extension_path(override = nil)
+    ExtensionResolver.new.resolve(override)
+  end
+
+  # Load the Honker extension onto a raw SQLite3::Database. Encapsulates
+  # the enable_load_extension(true)/load/enable_load_extension(false)
+  # sequence so the toggle-off can't be forgotten.
+  def self.load_extension(sqlite_conn, extension_path: nil)
+    resolved = ExtensionResolver.new.resolve(extension_path)
+    sqlite_conn.enable_load_extension(true)
+    sqlite_conn.load_extension(resolved)
+    sqlite_conn.enable_load_extension(false)
+  end
+
+  # Run honker_bootstrap() on the connection. Idempotent. Separated from
+  # load_extension so production users can opt to bootstrap from a
+  # migration instead of every connect.
+  def self.bootstrap(sqlite_conn)
+    sqlite_conn.execute("SELECT honker_bootstrap()")
+  end
+
+  # Convenience: load the extension then bootstrap. The one-liner most
+  # ORM integrations reach for.
+  def self.setup(sqlite_conn, extension_path: nil, bootstrap: true)
+    load_extension(sqlite_conn, extension_path: extension_path)
+    self.bootstrap(sqlite_conn) if bootstrap
+  end
+
+  # Returns a Proc suitable for Sequel/Rom/Hanami `after_connect:`.
+  def self.sequel_after_connect(extension_path: nil, bootstrap: true)
+    proc { |conn| setup(conn, extension_path: extension_path, bootstrap: bootstrap) }
   end
 
   class CoreWatcher

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -19,6 +19,7 @@
 
 require "json"
 require "fiddle"
+require "rbconfig"
 require "sqlite3"
 
 require_relative "honker/version"
@@ -28,6 +29,52 @@ require_relative "honker/scheduler"
 require_relative "honker/lock"
 
 module Honker
+  # Honker's error class, raised by ExtensionResolver and CoreWatcher.
+  class Error < StandardError; end
+
+  # Resolves the path to the Honker SQLite loadable extension. Platform
+  # gems ship it bundled in lib/honker/; an explicit path and the
+  # HONKER_EXTENSION_PATH override take precedence.
+  class ExtensionResolver
+    def initialize(env: ENV.fetch("HONKER_EXTENSION_PATH", nil), bundled: nil)
+      @env = env
+      @bundled = bundled || File.expand_path("honker/#{extension_filename}", __dir__)
+    end
+
+    # Returns the extension path: an explicit `extension_path`, else
+    # HONKER_EXTENSION_PATH, else the bundled extension. Raises
+    # Honker::Error when HONKER_EXTENSION_PATH or the bundled extension
+    # is missing.
+    def resolve(extension_path = nil)
+      return extension_path unless extension_path.nil?
+      return env_extension unless env.nil? || env.empty?
+
+      path = bundled
+      return path if File.file?(path)
+
+      raise Error, "Honker SQLite extension not found at #{path}; " \
+                   "set HONKER_EXTENSION_PATH or pass extension_path:"
+    end
+
+    private
+
+    attr_reader :env, :bundled
+
+    def env_extension
+      return env if File.file?(env)
+
+      raise Error, "HONKER_EXTENSION_PATH does not exist: #{env}"
+    end
+
+    def extension_filename
+      case RbConfig::CONFIG.fetch("host_os")
+      when /mswin|mingw|cygwin/ then "honker_ext.dll"
+      when /darwin/ then "libhonker_ext.dylib"
+      else "libhonker_ext.so"
+      end
+    end
+  end
+
   class CoreWatcher
     def initialize(db_path, extension_path, backend)
       @lib = Fiddle.dlopen(extension_path)
@@ -86,21 +133,23 @@ module Honker
   class Database
     attr_reader :db
 
-    def initialize(path, extension_path:, watcher_backend: nil)
+    def initialize(path, extension_path: nil, watcher_backend: nil,
+                   extension_resolver: ExtensionResolver.new)
       unless watcher_backend.nil? || watcher_backend.is_a?(String)
         raise ArgumentError, "unknown watcher backend"
       end
 
+      resolved_extension = extension_resolver.resolve(extension_path)
       @db = SQLite3::Database.new(path)
       @local_update_seq = 0
       @db.busy_timeout = 5000
       @db.execute("PRAGMA mmap_size = 0")
       @db.enable_load_extension(true)
-      @db.load_extension(extension_path)
+      @db.load_extension(resolved_extension)
       @db.enable_load_extension(false)
       @db.execute_batch(DEFAULT_PRAGMAS)
       @db.execute("SELECT honker_bootstrap()")
-      @watcher = CoreWatcher.new(path, extension_path, watcher_backend)
+      @watcher = CoreWatcher.new(path, resolved_extension, watcher_backend)
     end
 
     def close

--- a/packages/honker-ruby/lib/honker/README.md
+++ b/packages/honker-ruby/lib/honker/README.md
@@ -1,0 +1,28 @@
+# lib/honker
+
+Ruby source for the `honker` gem.
+
+## The bundled SQLite extension
+
+Released **platform gems** also ship the prebuilt Honker SQLite loadable
+extension in this directory. It is not checked into the source
+repository: it is a build artifact, gitignored, copied in at release
+time by `scripts/copy-ruby-extension.sh` and verified by
+`scripts/proof/check-ruby-gem.rb`.
+
+When it is present, `Honker::Database.new` finds and loads it
+automatically, so a platform gem needs no `extension_path:`.
+
+| Gem platform    | Bundled extension file |
+| --------------- | ---------------------- |
+| `x86_64-linux`  | `libhonker_ext.so`     |
+| `aarch64-linux` | `libhonker_ext.so`     |
+| `arm64-darwin`  | `libhonker_ext.dylib`  |
+
+The artifact name follows the target OS: `libhonker_ext.so` on Linux,
+`libhonker_ext.dylib` on macOS, and `honker_ext.dll` on Windows.
+
+The **generic gem** (used on every other platform, and for `github:`
+installs) ships no prebuilt extension. Instead it bundles the Rust crate
+source under `ext/honker/` and compiles the extension into this
+directory on install, which needs a [Rust toolchain](https://rustup.rs).

--- a/packages/honker-ruby/lib/honker/railtie.rb
+++ b/packages/honker-ruby/lib/honker/railtie.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails/railtie"
+
+module Honker
+  class Railtie < ::Rails::Railtie
+    config.after_initialize do
+      Honker.bootstrap(ActiveRecord::Base.connection)
+    end
+  end
+end

--- a/packages/honker-ruby/lib/honker/version.rb
+++ b/packages/honker-ruby/lib/honker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Honker
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/packages/honker-ruby/lib/honker/version.rb
+++ b/packages/honker-ruby/lib/honker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Honker
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/packages/honker-ruby/spec/extension_resolution_spec.rb
+++ b/packages/honker-ruby/spec/extension_resolution_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+#
+# Unit tests for Honker::ExtensionResolver, the lookup that lets
+# Honker::Database.new resolve the bundled SQLite extension without an
+# explicit extension_path.
+#
+# Run: bundle exec ruby -Ilib spec/extension_resolution_spec.rb
+
+require "tmpdir"
+require "minitest/autorun"
+require "honker"
+
+class ExtensionResolverTest < Minitest::Test
+  def test_explicit_path_is_returned_unchanged
+    resolver = Honker::ExtensionResolver.new(env: nil)
+    assert_equal(
+      "/somewhere/libhonker_ext.so",
+      resolver.resolve("/somewhere/libhonker_ext.so"),
+    )
+  end
+
+  def test_explicit_path_beats_a_set_env_var
+    resolver = Honker::ExtensionResolver.new(env: "/env/libhonker_ext.so")
+    assert_equal(
+      "/explicit/libhonker_ext.so",
+      resolver.resolve("/explicit/libhonker_ext.so"),
+    )
+  end
+
+  def test_env_path_is_used_when_it_exists
+    Dir.mktmpdir do |dir|
+      ext = File.join(dir, "libhonker_ext.so")
+      File.write(ext, "")
+      resolver = Honker::ExtensionResolver.new(env: ext)
+      assert_equal ext, resolver.resolve
+    end
+  end
+
+  def test_missing_env_path_raises
+    resolver = Honker::ExtensionResolver.new(env: "/no/such/ext.so")
+    error = assert_raises(Honker::Error) { resolver.resolve }
+    assert_includes error.message, "HONKER_EXTENSION_PATH"
+  end
+
+  def test_empty_env_falls_through_to_the_bundled_extension
+    Dir.mktmpdir do |dir|
+      ext = File.join(dir, "libhonker_ext.so")
+      File.write(ext, "")
+      resolver = Honker::ExtensionResolver.new(env: "", bundled: ext)
+      assert_equal ext, resolver.resolve
+    end
+  end
+
+  def test_uses_the_bundled_extension_when_no_override_is_given
+    Dir.mktmpdir do |dir|
+      ext = File.join(dir, "libhonker_ext.so")
+      File.write(ext, "")
+      resolver = Honker::ExtensionResolver.new(env: nil, bundled: ext)
+      assert_equal ext, resolver.resolve
+    end
+  end
+
+  def test_missing_bundled_extension_raises
+    resolver = Honker::ExtensionResolver.new(env: nil, bundled: "/no/such/ext.so")
+    error = assert_raises(Honker::Error) { resolver.resolve }
+    assert_includes error.message, "not found"
+  end
+
+  def test_database_consults_the_resolver_when_extension_path_omitted
+    consulted = Class.new(StandardError)
+    resolver = Object.new
+    resolver.define_singleton_method(:resolve) { |_extension_path| raise consulted }
+
+    Dir.mktmpdir do |dir|
+      assert_raises(consulted) do
+        Honker::Database.new(File.join(dir, "app.db"), extension_resolver: resolver)
+      end
+    end
+  end
+end

--- a/packages/honker-ruby/spec/railtie_spec.rb
+++ b/packages/honker-ruby/spec/railtie_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+#
+# Tests for Honker::Railtie. Skipped entirely when railties is not
+# installed in the dev/test gemset — Rails is not a runtime dependency
+# of honker.
+#
+# Run: bundle exec ruby -Ilib spec/railtie_spec.rb
+
+require "tmpdir"
+require "minitest/autorun"
+
+begin
+  require "rails/railtie"
+rescue LoadError
+  warn "skipping spec/railtie_spec.rb: railties not installed"
+  return
+end
+
+require "honker"
+
+class HonkerRailtieTest < Minitest::Test
+  HONKER_LIB = File.expand_path("../lib", __dir__)
+
+  def test_requiring_honker_with_rails_loaded_defines_the_railtie
+    assert defined?(Honker::Railtie), "Honker::Railtie should be loaded when Rails is defined"
+    assert_operator Honker::Railtie, :<, ::Rails::Railtie
+  end
+
+  def test_requiring_honker_without_rails_does_not_define_the_railtie
+    script = <<~RUBY
+      $LOAD_PATH.unshift(#{HONKER_LIB.inspect})
+      require "honker"
+      puts(defined?(Honker::Railtie) ? "defined" : "undefined")
+    RUBY
+    out = IO.popen([RbConfig.ruby, "-e", script], &:read)
+    assert_equal "undefined", out.strip
+  end
+
+  def test_after_initialize_hook_bootstraps_active_record_primary_connection
+    fake_connection = Object.new
+    stub_ar_base = Module.new
+    stub_ar_base.define_singleton_method(:connection) { fake_connection }
+    stub_ar = Module.new
+    stub_ar.const_set(:Base, stub_ar_base)
+    Object.const_set(:ActiveRecord, stub_ar) unless defined?(::ActiveRecord)
+
+    received = []
+    begin
+      Honker.stub :bootstrap, ->(conn) { received << conn } do
+        ActiveSupport.run_load_hooks(:after_initialize, Object.new)
+      end
+    ensure
+      Object.send(:remove_const, :ActiveRecord) if ::ActiveRecord.equal?(stub_ar)
+    end
+
+    assert_equal [fake_connection], received
+  end
+end

--- a/packages/honker-ruby/spec/setup_helpers_spec.rb
+++ b/packages/honker-ruby/spec/setup_helpers_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+#
+# Unit tests for the Honker module-level setup helpers
+# (Honker.extension_path, .load_extension, .bootstrap, .setup,
+# .sequel_after_connect) that collapse the extension-load + bootstrap
+# ceremony every Ruby ORM integration was copy-pasting.
+#
+# Run: bundle exec ruby -Ilib spec/setup_helpers_spec.rb
+
+require "tmpdir"
+require "minitest/autorun"
+require "honker"
+
+REPO_ROOT = File.expand_path("../../..", __dir__) unless defined?(REPO_ROOT)
+
+unless defined?(find_extension)
+  def find_extension
+    %w[
+      target/release/libhonker_ext.dylib
+      target/release/libhonker_ext.so
+      target/release/libhonker_extension.dylib
+      target/release/libhonker_extension.so
+    ].each do |rel|
+      p = File.join(REPO_ROOT, rel)
+      return p if File.exist?(p)
+    end
+    nil
+  end
+end
+
+unless defined?(require_load_extension_support!)
+  def require_load_extension_support!
+    return if SQLite3::Database.new(":memory:").respond_to?(:enable_load_extension)
+
+    message = "sqlite3 gem lacks loadable-extension support"
+    if ENV["HONKER_REQUIRE_RUBY_EXTENSION_LOADING"] == "1"
+      flunk message
+    end
+    skip message
+  end
+end
+
+class HonkerSetupHelpersTest < Minitest::Test
+  # Records every method call so tests can assert ordering and arguments
+  # without needing a real SQLite handle.
+  class FakeConn
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def enable_load_extension(flag)
+      @calls << [:enable_load_extension, flag]
+    end
+
+    def load_extension(path)
+      @calls << [:load_extension, path]
+    end
+
+    def execute(sql)
+      @calls << [:execute, sql]
+    end
+  end
+
+  # Resolver double that records every override it sees and returns a
+  # canned path (or a path derived from the override, for forward-through
+  # tests).
+  def fake_resolver(&block)
+    block ||= ->(_override) { "/resolved/lib.so" }
+    received = []
+    resolver = Object.new
+    resolver.define_singleton_method(:resolve) do |override = nil|
+      received << override
+      block.call(override)
+    end
+    [resolver, received]
+  end
+
+  def test_extension_path_with_no_args_delegates_to_resolver_with_nil
+    resolver, received = fake_resolver
+    Honker::ExtensionResolver.stub :new, resolver do
+      assert_equal "/resolved/lib.so", Honker.extension_path
+    end
+    assert_equal [nil], received
+  end
+
+  def test_extension_path_forwards_explicit_override_to_resolver
+    resolver, received = fake_resolver { |override| override }
+    Honker::ExtensionResolver.stub :new, resolver do
+      assert_equal "/explicit", Honker.extension_path("/explicit")
+    end
+    assert_equal ["/explicit"], received
+  end
+
+  def test_load_extension_toggles_enable_around_load
+    conn = FakeConn.new
+    Honker.load_extension(conn, extension_path: "/somewhere/ext.so")
+    assert_equal(
+      [
+        [:enable_load_extension, true],
+        [:load_extension, "/somewhere/ext.so"],
+        [:enable_load_extension, false],
+      ],
+      conn.calls,
+    )
+  end
+
+  def test_load_extension_passes_override_through_resolver
+    resolver, received = fake_resolver { |override| "resolved:#{override}" }
+    conn = FakeConn.new
+    Honker::ExtensionResolver.stub :new, resolver do
+      Honker.load_extension(conn, extension_path: "/x")
+    end
+    assert_equal ["/x"], received
+    assert_equal [:load_extension, "resolved:/x"], conn.calls[1]
+  end
+
+  def test_bootstrap_runs_honker_bootstrap_sql
+    conn = FakeConn.new
+    Honker.bootstrap(conn)
+    assert_equal [[:execute, "SELECT honker_bootstrap()"]], conn.calls
+  end
+
+  def test_setup_calls_load_extension_then_bootstrap_in_order
+    conn = FakeConn.new
+    resolver, = fake_resolver { |_| "/ext.so" }
+    Honker::ExtensionResolver.stub :new, resolver do
+      Honker.setup(conn)
+    end
+    assert_equal(
+      [
+        [:enable_load_extension, true],
+        [:load_extension, "/ext.so"],
+        [:enable_load_extension, false],
+        [:execute, "SELECT honker_bootstrap()"],
+      ],
+      conn.calls,
+    )
+  end
+
+  def test_setup_with_bootstrap_false_skips_bootstrap
+    conn = FakeConn.new
+    resolver, = fake_resolver { |_| "/ext.so" }
+    Honker::ExtensionResolver.stub :new, resolver do
+      Honker.setup(conn, bootstrap: false)
+    end
+    refute_includes conn.calls.map(&:first), :execute
+  end
+
+  def test_sequel_after_connect_returns_a_proc_that_calls_setup
+    conn = FakeConn.new
+    resolver, = fake_resolver { |_| "/ext.so" }
+    after_connect = Honker::ExtensionResolver.stub :new, resolver do
+      proc_ = Honker.sequel_after_connect
+      proc_.call(conn)
+      proc_
+    end
+    assert_kind_of Proc, after_connect
+    assert_equal :load_extension, conn.calls[1].first
+    assert_equal [:execute, "SELECT honker_bootstrap()"], conn.calls.last
+  end
+
+  def test_sequel_after_connect_forwards_bootstrap_false
+    conn = FakeConn.new
+    resolver, = fake_resolver { |_| "/ext.so" }
+    Honker::ExtensionResolver.stub :new, resolver do
+      Honker.sequel_after_connect(bootstrap: false).call(conn)
+    end
+    refute_includes conn.calls.map(&:first), :execute
+  end
+
+  def test_setup_on_real_sqlite_bootstraps_the_schema
+    ext = find_extension
+    skip "honker extension not built — run `cargo build -p honker-extension --release`" unless ext
+    require_load_extension_support!
+
+    Dir.mktmpdir do |dir|
+      conn = SQLite3::Database.new(File.join(dir, "real.db"))
+      Honker.setup(conn, extension_path: ext)
+      rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = '_honker_live'",
+      )
+      refute_empty rows, "Honker.setup should bootstrap the _honker_live table"
+    ensure
+      conn&.close
+    end
+  end
+end

--- a/scripts/copy-ruby-extension.sh
+++ b/scripts/copy-ruby-extension.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="$ROOT/target/release"
+DEST_DIR="$ROOT/packages/honker-ruby/lib/honker"
+
+case "$(uname -s)" in
+  Darwin)
+    EXT_NAME="libhonker_ext.dylib"
+    ;;
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    EXT_NAME="honker_ext.dll"
+    ;;
+  *)
+    EXT_NAME="libhonker_ext.so"
+    ;;
+esac
+
+SRC="$SRC_DIR/$EXT_NAME"
+if [[ ! -f "$SRC" ]]; then
+  echo "honker extension not found at $SRC" >&2
+  echo "run: cargo build --release -p honker-extension" >&2
+  exit 1
+fi
+
+# Drop any stale extension before copying the current one. DEST_DIR is
+# the gem's source directory, so remove only the artifact names, never
+# the directory itself.
+rm -f "$DEST_DIR/libhonker_ext.so" "$DEST_DIR/libhonker_ext.dylib" "$DEST_DIR/honker_ext.dll"
+cp "$SRC" "$DEST_DIR/$EXT_NAME"
+echo "copied $SRC -> $DEST_DIR/$EXT_NAME"

--- a/scripts/copy-ruby-sources.sh
+++ b/scripts/copy-ruby-sources.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="$ROOT/packages/honker-ruby/ext/honker"
+
+# The generic (source) gem compiles the extension on install, so it
+# ships the honker-extension and honker-core crate source. This vendors
+# them into ext/honker/; the copies are gitignored and refreshed at gem
+# build time, mirroring copy-ruby-extension.sh for the prebuilt binary.
+for crate in honker-extension honker-core; do
+  rm -rf "${DEST:?}/$crate"
+  mkdir -p "$DEST/$crate"
+  cp -R "$ROOT/$crate/." "$DEST/$crate/"
+  rm -rf "$DEST/$crate/target"
+done
+
+# Make the vendored extension crate its own workspace root so cargo does
+# not attach it to an enclosing Cargo.toml when the gem is built from
+# inside this repo.
+printf '\n[workspace]\n' >> "$DEST/honker-extension/Cargo.toml"
+
+echo "vendored honker-extension and honker-core into $DEST"

--- a/scripts/proof/check-ruby-gem.rb
+++ b/scripts/proof/check-ruby-gem.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Release proof for honker gems.
+#
+#   check-ruby-gem.rb GEM [GEM ...]             # platform gem checks
+#   check-ruby-gem.rb --generic GEM [GEM ...]   # generic gem checks
+#
+# A platform gem must be platform-specific and bundle the SQLite
+# loadable extension. The generic gem must instead ship the Rust crate
+# source and declare an extension that compiles it on install.
+
+require "rubygems/package"
+
+def bundles_extension?(package)
+  package.contents.any? do |name|
+    name.match?(%r{\Alib/honker/(?:lib)?honker_ext\.(?:so|dylib|dll)\z})
+  end
+end
+
+def check_platform_gem(path)
+  package = Gem::Package.new(path)
+  if package.spec.platform == Gem::Platform::RUBY
+    abort "ruby gem is not platform-specific: #{path}"
+  end
+  abort "ruby gem is missing bundled SQLite extension: #{path}" unless bundles_extension?(package)
+end
+
+def check_generic_gem(path)
+  package = Gem::Package.new(path)
+  unless package.spec.platform == Gem::Platform::RUBY
+    abort "generic ruby gem must not be platform-specific: #{path}"
+  end
+  abort "generic ruby gem must not bundle an extension: #{path}" if bundles_extension?(package)
+
+  if package.spec.extensions.empty?
+    abort "generic ruby gem must declare an extension to compile on install: #{path}"
+  end
+
+  contents = package.contents
+  unless contents.include?("ext/honker/extconf.rb")
+    abort "generic ruby gem is missing ext/honker/extconf.rb: #{path}"
+  end
+  unless contents.any? { |name| name.start_with?("ext/honker/honker-extension/") }
+    abort "generic ruby gem is missing the vendored Rust crate source: #{path}"
+  end
+end
+
+def main
+  args = ARGV.dup
+  generic = args.delete("--generic")
+  abort "usage: check-ruby-gem.rb [--generic] GEM [GEM ...]" if args.empty?
+
+  args.each do |path|
+    generic ? check_generic_gem(path) : check_platform_gem(path)
+  end
+end
+
+main if $PROGRAM_NAME == __FILE__

--- a/scripts/proof/package-install-smoke.sh
+++ b/scripts/proof/package-install-smoke.sh
@@ -107,27 +107,16 @@ JS
 )
 
 echo "== ruby gem install =="
+scripts/copy-ruby-extension.sh
+RUBY_GEM_PLATFORM="$("$RUBY_BIN" -e 'p = Gem::Platform.local; print [p.cpu, p.os].join("-")')"
 (
   cd "$ROOT/packages/honker-ruby"
-  "$RUBY_BIN" -S gem build honker.gemspec --output "$TMP/honker.gem"
+  HONKER_GEM_PLATFORM="$RUBY_GEM_PLATFORM" \
+    "$RUBY_BIN" -S gem build honker.gemspec --output "$TMP/honker.gem"
 )
+"$RUBY_BIN" "$ROOT/scripts/proof/check-ruby-gem.rb" "$TMP/honker.gem"
 GEM_HOME="$TMP/gems" GEM_PATH="$TMP/gems" "$RUBY_BIN" -S gem install "$TMP/honker.gem" >/dev/null
-GEM_HOME="$TMP/gems" GEM_PATH="$TMP/gems" HONKER_EXTENSION_PATH="$EXT" "$RUBY_BIN" <<'RB'
-require "tmpdir"
-require "honker"
-
-Dir.mktmpdir("honker-ruby-proof-") do |dir|
-  db = Honker::Database.new(File.join(dir, "app.db"), extension_path: ENV.fetch("HONKER_EXTENSION_PATH"))
-  q = db.queue("emails")
-  id = q.enqueue({to: "alice@example.com"})
-  job = q.claim_one("worker-1")
-  raise "claim failed" unless job && job.id == id
-  raise "payload mismatch" unless job.payload["to"] == "alice@example.com"
-  raise "ack failed" unless job.ack
-  db.close
-end
-puts "ruby package smoke ok"
-RB
+GEM_HOME="$TMP/gems" GEM_PATH="$TMP/gems" "$RUBY_BIN" "$ROOT/scripts/proof/ruby-gem-smoke.rb"
 
 echo "== dotnet nuget install =="
 RID="linux-x64"

--- a/scripts/proof/ruby-gem-smoke.rb
+++ b/scripts/proof/ruby-gem-smoke.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Release proof: install-and-run check for the honker gem. Assumes the
+# gem is already installed; exercises a queue round-trip through the
+# bundled SQLite extension (no HONKER_EXTENSION_PATH, no extension_path:
+# argument), so it fails if the gem did not bundle a working extension.
+
+require "tmpdir"
+require "honker"
+
+Dir.mktmpdir("honker-ruby-proof-") do |dir|
+  db = Honker::Database.new(File.join(dir, "app.db"))
+  q = db.queue("emails")
+  id = q.enqueue({ to: "alice@example.com" })
+  job = q.claim_one("worker-1")
+  raise "claim failed" unless job && job.id == id
+  raise "payload mismatch" unless job.payload["to"] == "alice@example.com"
+  raise "ack failed" unless job.ack
+  db.close
+end
+
+puts "ruby gem smoke ok"

--- a/scripts/verify-ruby-gem-local.sh
+++ b/scripts/verify-ruby-gem-local.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local pre-push check for the honker Ruby gem. Not run by CI; it is a
+# developer convenience that reproduces in one command what CI checks
+# across ci.yml (specs) and release-ruby.yml (gem build, proof, smoke).
+#
+# Builds and installs both the precompiled platform gem and the
+# compile-on-install generic gem, runs a queue round-trip smoke test
+# against each, and runs the specs.
+#
+#   scripts/verify-ruby-gem-local.sh            host checks
+#   scripts/verify-ruby-gem-local.sh --docker   also a Linux build in Docker
+#
+# Needs ruby, gem, bundle, and cargo on PATH; docker too for --docker.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUBY_PKG="$ROOT/packages/honker-ruby"
+WITH_DOCKER=0
+[[ "${1:-}" == "--docker" ]] && WITH_DOCKER=1
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$ROOT"
+
+echo "== build extension =="
+cargo build --release -p honker-extension
+
+echo
+echo "== platform gem =="
+scripts/copy-ruby-extension.sh
+platform="$(ruby -e 'p = Gem::Platform.local; print [p.cpu, p.os].join("-")')"
+( cd "$RUBY_PKG" && HONKER_GEM_PLATFORM="$platform" \
+    gem build honker.gemspec --output "$TMP/platform.gem" )
+ruby scripts/proof/check-ruby-gem.rb "$TMP/platform.gem"
+GEM_HOME="$TMP/platform-home" GEM_PATH="$TMP/platform-home" \
+  gem install --no-document "$TMP/platform.gem"
+GEM_HOME="$TMP/platform-home" GEM_PATH="$TMP/platform-home" \
+  ruby scripts/proof/ruby-gem-smoke.rb
+
+echo
+echo "== generic gem (compiles on install) =="
+scripts/copy-ruby-sources.sh
+( cd "$RUBY_PKG" && gem build honker.gemspec --output "$TMP/generic.gem" )
+ruby scripts/proof/check-ruby-gem.rb --generic "$TMP/generic.gem"
+GEM_HOME="$TMP/generic-home" GEM_PATH="$TMP/generic-home" \
+  gem install --no-document "$TMP/generic.gem"
+GEM_HOME="$TMP/generic-home" GEM_PATH="$TMP/generic-home" \
+  ruby scripts/proof/ruby-gem-smoke.rb
+
+echo
+echo "== specs =="
+(
+  cd "$RUBY_PKG"
+  bundle install --quiet
+  for spec in honker_spec smoke_spec parity_spec extension_resolution_spec; do
+    echo "  -- $spec --"
+    bundle exec ruby -Ilib "spec/$spec.rb"
+  done
+)
+
+if [[ "$WITH_DOCKER" == "1" ]]; then
+  echo
+  echo "== docker: generic gem compiles on install (linux/amd64) =="
+  docker run --rm --platform linux/amd64 -v "$ROOT:/work" -w /work rust:latest \
+    bash -euo pipefail -c '
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update -qq
+      apt-get install -y -qq --no-install-recommends ruby ruby-dev make >/dev/null
+      scripts/copy-ruby-sources.sh >/dev/null
+      cd packages/honker-ruby
+      gem build honker.gemspec --output /tmp/honker.gem >/dev/null
+      ruby ../../scripts/proof/check-ruby-gem.rb --generic /tmp/honker.gem
+      gem install --no-document /tmp/honker.gem >/dev/null
+      ruby ../../scripts/proof/ruby-gem-smoke.rb
+    '
+
+  echo
+  echo "== docker: install without Rust fails cleanly (linux/amd64) =="
+  no_rust_out="$(docker run --rm --platform linux/amd64 \
+    -v "$TMP/generic.gem:/tmp/honker.gem:ro" ruby:3.3 \
+    bash -c 'gem install --no-document /tmp/honker.gem' 2>&1 || true)"
+  if echo "$no_rust_out" | grep -q "Rust toolchain"; then
+    echo "  install failed with the expected Rust-toolchain error"
+  else
+    echo "  ERROR: expected the missing-Rust error message; got:" >&2
+    echo "$no_rust_out" >&2
+    exit 1
+  fi
+fi
+
+echo
+echo "ruby gem verification ok"

--- a/scripts/verify-ruby-gem-local.sh
+++ b/scripts/verify-ruby-gem-local.sh
@@ -53,7 +53,7 @@ echo "== specs =="
 (
   cd "$RUBY_PKG"
   bundle install --quiet
-  for spec in honker_spec smoke_spec parity_spec extension_resolution_spec; do
+  for spec in honker_spec smoke_spec parity_spec extension_resolution_spec setup_helpers_spec railtie_spec; do
     echo "  -- $spec --"
     bundle exec ruby -Ilib "spec/$spec.rb"
   done


### PR DESCRIPTION
Stacked on top of #57, please merge that first (can rebase this if there are changes). I bumped the version here from that one 0.2.0 to 0.3.0, but they could both easily live in a single release as 0.2.0.

I considered adding this work to #57 but smaller, independently reviewable changes are better.

You can view this PR's diff from that branch here: https://github.com/cllns/honker/pull/1 It's **+381 / -2** instead of this PR which is **+1,122 -40** combining changes from both PR's

## Summary

Every non-`Honker::Database` Ruby integration was copy-pasting the same four-line ceremony to share a SQLite handle with an ORM/DB layer:

```ruby
conn.enable_load_extension(true)
conn.load_extension(Honker::ExtensionResolver.new.resolve)
conn.enable_load_extension(false)
conn.execute("SELECT honker_bootstrap()")
```

This PR collapses that into a small set of module-level helpers and a Railtie for Rails apps.

## New API
- `Honker.setup(conn, extension_path: nil, bootstrap: true)`
    - the one-liner most callers will reach for.
- `Honker.extension_path(override = nil)`
    - thin convenience over `ExtensionResolver`, suitable for `database.yml` ERB.
- `Honker.load_extension(conn, extension_path: nil)`
    - toggles `enable_load_extension` true → load → false so the toggle-off can't be forgotten.
- `Honker.bootstrap(conn)`
    - runs `SELECT honker_bootstrap()`. Split out so production users can opt to bootstrap from a migration instead.
- `Honker.sequel_after_connect(extension_path: nil, bootstrap: true)`
    - returns a `proc { |conn| Honker.setup(conn, ...) }` for Sequel/Rom/Hanami `after_connect:`.
- `Honker::Railtie`
    - runs `Honker.bootstrap(ActiveRecord::Base.connection)` in `config.after_initialize`. Loaded only when `Rails::Railtie` is defined, so Rails stays a non-dependency.

All existing API (`Honker::Database`, `ExtensionResolver`, `Honker::Error`) is unchanged; the helpers are additive.


## How it looks in an app

**Rails / ActiveRecord** — point `database.yml` at the bundled extension; the Railtie handles `honker_bootstrap()` on boot, so no initializer is needed:

```yaml
# config/database.yml
production:
  adapter: sqlite3
  database: app.sqlite3
  extensions:
    - <%= Honker.extension_path %>
```

```ruby
# Gemfile
gem "honker"
```

That's it — `require "honker"` (Bundler does this for you) defines the Railtie, which runs `Honker.bootstrap(ActiveRecord::Base.connection)` in `config.after_initialize`. 
Multi-DB apps still call `Honker.bootstrap(other_conn)` themselves for non-primary connections.
There's no way to opt-out but I think that's fine.

**Sequel (and ROM / Hanami::DB)** — pass the ready-made proc to `after_connect:`, and each new pooled connection gets the extension loaded and the schema bootstrapped:

```ruby
require "sequel"
require "honker"

DB = Sequel.connect(
  "sqlite://app.sqlite3",
  after_connect: Honker.sequel_after_connect,
)
```

To bootstrap once from a migration instead of every connect, pass `bootstrap: false`:

```ruby
DB = Sequel.connect(
  "sqlite://app.sqlite3",
  after_connect: Honker.sequel_after_connect(bootstrap: false),
)
```

## Test plan

- [x] `spec/setup_helpers_spec.rb` — 10 tests (9 unit with a recording fake conn, 1 real-SQLite integration that asserts `_honker_live` lands after `Honker.setup`).
- [x] `spec/railtie_spec.rb` — 3 tests: Railtie is loaded when Rails is present, Railtie is NOT defined in a subprocess that requires honker without rails, and the `after_initialize` hook bootstraps `ActiveRecord::Base.connection`.
- [x] `scripts/verify-ruby-gem-local.sh` runs both new specs and stays green end-to-end (platform + generic gem build, proof, smoke).

## Not in this PR

- honker.dev guide updates (`guides/orm/ruby`, `languages/ruby`) live in the `honker-site` repo and ship separately. **I will update these later, once this PR is merged**.
- A real `Sequel.extension :honker` — Rom/Hanami users still need `after_connect:` because the `Sequel::Database` is constructed before user code can call `extension`. Happy to add this later if desired, but the setup process is simple enough for now.
- Multi-DB Railtie wiring — the Railtie only bootstraps the primary connection; multi-DB apps still call `Honker.bootstrap(other_conn)` themselves. Documented in the README.


Again, happy to address any feedback, or feel free to take it and adapt as you wish!