### PR TITLE
Simplify docs and configure watcher poll interval

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -44,19 +44,19 @@ Backend contract:
 - no binding may silently fall back to polling for an explicit
   experimental request
 
-| Binding | Backend option | Experimental status |
-| --- | --- | --- |
-| Python | `honker.open(..., watcher_backend=...)` | source builds with matching Cargo features |
-| Node | `open(path, maxReaders?, watcherBackend?)` | source builds with matching Cargo features |
-| Rust wrapper | `OpenOptions::watcher_backend(...)` | matching Cargo features |
-| Go | `OpenWithOptions(..., OpenOptions{WatcherBackend: ...})` | depends on loaded extension features |
-| Bun | `open(..., { watcherBackend })` | depends on loaded extension features |
-| C++ | `Database(path, ext_path, watcher_backend)` | depends on loaded extension features |
-| .NET | `OpenOptions.WatcherBackend` | depends on bundled/loaded extension features |
-| Ruby | `watcher_backend:` | depends on loaded extension features |
-| Elixir | `watcher_backend:` | depends on loaded extension features |
-| JVM | `OpenOptions.watcherBackend(...)` | stable `AUTO`/`PRAGMA_DATA_VERSION`; explicit experimental `MMAP_SHM` and `KERNEL_EVENTS` |
-| Kotlin | JVM `OpenOptions` | wraps JVM behavior |
+| Binding | Backend option | Watcher interval option | Experimental status |
+| --- | --- | --- | --- |
+| Python | `honker.open(..., watcher_backend=...)` | `watcher_poll_interval_ms=` | source builds with matching Cargo features |
+| Node | `open(path, { watcherBackend })` | `watcherPollIntervalMs` | source builds with matching Cargo features |
+| Rust wrapper | `OpenOptions::watcher_backend(...)` | `OpenOptions::watcher_poll_interval(...)` | matching Cargo features |
+| Go | `OpenOptions{WatcherBackend: ...}` | `WatcherPollInterval` | depends on loaded extension features |
+| Bun | `open(..., { watcherBackend })` | `watcherPollIntervalMs` | depends on loaded extension features |
+| C++ | `Database(path, ext_path, watcher_backend)` | fourth constructor arg, milliseconds | depends on loaded extension features |
+| .NET | `OpenOptions.WatcherBackend` | `OpenOptions.UpdatePollInterval` | depends on bundled/loaded extension features |
+| Ruby | `watcher_backend:` | `watcher_poll_interval_ms:` | depends on loaded extension features |
+| Elixir | `watcher_backend:` | `watcher_poll_interval_ms:` | depends on loaded extension features |
+| JVM | `OpenOptions.watcherBackend(...)` | `WatcherOptions.pollInterval(...)` | stable `AUTO`/`PRAGMA_DATA_VERSION`; explicit experimental `MMAP_SHM` and `KERNEL_EVENTS` |
+| Kotlin | JVM `OpenOptions` | JVM `WatcherOptions` | wraps JVM behavior |
 
 ## What CI Proves
 

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -1,102 +1,80 @@
-# Honker Bindings
+# Honker Binding Support
 
-This matrix describes wake behavior for maintained bindings. Table /
-SQL compatibility is separate, but every maintained binding now routes
-blocking wake waits through `honker-core` or the equivalent shared JVM
-watcher.
+This is the current binding truth table: packaged status, API coverage,
+and wake behavior. SQL table compatibility is shared across all bindings
+because the schema is defined in Rust and installed by the SQLite
+extension.
 
-| Binding | Wake implementation | Backend option | `kernel` / `shm` status |
-| --- | --- | --- | --- |
-| Python | `honker-core::SharedUpdateWatcher` | `honker.open(..., watcher_backend=...)` | Supported in source builds with matching Cargo features; hard error when unavailable |
-| Node | `honker-core::SharedUpdateWatcher` | `open(path, maxReaders?, watcherBackend?)` | Supported in source builds with matching Cargo features; hard error when unavailable |
-| Rust wrapper | `honker-core::SharedUpdateWatcher` | `OpenOptions::watcher_backend(...)` | Supported when compiled with matching Cargo features; hard error when unavailable |
-| Go | Extension C ABI -> `honker-core::SharedUpdateWatcher` | `OpenWithOptions(..., OpenOptions{WatcherBackend: ...})` | Supported when the loaded extension is built with matching features; hard error when unavailable |
-| Bun | Extension C ABI -> `honker-core::SharedUpdateWatcher` | `open(..., { watcherBackend })` | Supported when the loaded extension is built with matching features; hard error when unavailable |
-| C++ | Extension C ABI -> `honker-core::SharedUpdateWatcher` | `Database(path, ext_path, watcher_backend)` | Supported when the loaded extension is built with matching features; hard error when unavailable |
-| .NET | Extension C ABI -> `honker-core::SharedUpdateWatcher` | `OpenOptions.WatcherBackend` | Supported when the loaded extension is built with matching features; hard error when unavailable |
-| Ruby | Extension C ABI -> `honker-core::SharedUpdateWatcher` | `watcher_backend:` | Supported when the loaded extension is built with matching features; hard error when unavailable |
-| Elixir | Extension SQL watcher handles -> `honker-core::SharedUpdateWatcher` | `watcher_backend:` | Supported when the loaded extension is built with matching features; hard error when unavailable |
-| JVM `dev.honker:honker` | Shared JVM watcher | `OpenOptions.watcherBackend(...)` | Stable `AUTO`/`PRAGMA_DATA_VERSION`; explicit experimental `MMAP_SHM` and `KERNEL_EVENTS` |
-| Kotlin `dev.honker:honker-kotlin` | Shared JVM watcher wrapper | JVM `OpenOptions` | Wraps JVM watcher semantics |
+## API Parity
 
-Core API parity:
+| Binding | Package proof | Queue | Streams | Notify/listen | Scheduler | Outbox | Wake path |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| SQLite extension | load smoke | SQL | SQL | notify SQL only | SQL | SQL | host language watches/reads |
+| Python `honker` | yes | yes | yes | yes | yes | yes | shared Rust watcher |
+| Node `@russellthehippo/honker-node` | yes | yes | yes | yes | yes | yes | shared Rust watcher |
+| Ruby `honker` | yes | yes | yes | notify yes, listen no | yes | yes | extension C ABI |
+| .NET `Honker` | yes | yes | yes | yes | yes | yes | extension C ABI |
+| Rust `honker` | CI | yes | yes | yes | yes | yes | shared Rust watcher |
+| Go | CI | yes | yes | yes | yes | yes | extension C ABI |
+| Bun `@russellthehippo/honker-bun` | CI | yes | yes | yes | yes | yes | extension C ABI |
+| Elixir `honker` | CI | yes | yes | notify yes, listen no | yes | yes | extension SQL handles |
+| C++ | CI | yes | yes | yes | yes | yes | extension C ABI |
+| JVM `dev.honker:honker` | local + clean consumer | yes | yes | yes | yes | yes | shared JVM watcher |
+| Kotlin `dev.honker:honker-kotlin` | local + clean consumer | wrapper | Flow wrapper | wrapper | wrapper | wrapper | JVM wrapper |
 
-| Binding | Package proof | Queue | Streams | Notify/listen | Scheduler | Wake behavior |
-|---|---:|---:|---:|---:|---:|---|
-| SQLite extension | load smoke | SQL | SQL | notify SQL only | SQL | host language must watch/read |
-| Python `honker` | yes | yes | yes | yes | yes | shared Rust `UpdateWatcher` |
-| Node `@russellthehippo/honker-node` | yes | yes | yes | yes | yes | shared Rust `UpdateWatcher` |
-| .NET `Honker` | yes | yes | yes | yes | yes | shared Rust watcher through extension C ABI |
-| Rust `honker` | CI | yes | yes | yes | yes | shared Rust `UpdateWatcher` |
-| Go | CI | yes | yes | yes | yes | shared Rust watcher through extension C ABI |
-| Bun `@russellthehippo/honker-bun` | CI | yes | yes | yes | yes | shared Rust watcher through extension C ABI |
-| C++ | CI | yes | yes | yes | yes | shared Rust watcher through extension C ABI |
-| JVM `dev.honker:honker` | local + clean consumer | yes | yes | yes | yes | shared JVM watcher |
-| Kotlin `dev.honker:honker-kotlin` | local + clean consumer | wrapper | Flow wrapper | wrapper | wrapper | wraps shared JVM watcher |
-| Ruby `honker` | yes | yes | yes | notify yes, listen no | yes | shared Rust watcher through extension C ABI |
-| Elixir `honker` | CI | yes | yes | notify yes, listen no | yes | shared Rust watcher through extension SQL handles |
+## Watcher Backends
 
-| Binding | Transactional outbox | Proof |
+The stable backend is `PRAGMA data_version`. It is the default across
+maintained bindings and is the only backend assumed by published binary
+packages unless a package explicitly says otherwise.
+
+Experimental source-build backends:
+
+- `kernel`: filesystem events over the database/WAL/SHM paths
+- `shm`: mmap reads of SQLite's WAL shared-memory index
+
+Backend contract:
+
+- omitted backend, `"polling"`, and `"poll"` select the default stable
+  behavior
+- backend names are exact; case and whitespace are not normalized
+- unknown backend names are errors everywhere
+- explicit experimental backend requests must fail loudly when support is
+  unavailable
+- no binding may silently fall back to polling for an explicit
+  experimental request
+
+| Binding | Backend option | Experimental status |
 | --- | --- | --- |
-| Python | `db.outbox(...)` | `tests/test_parity.py` / watcher e2e suites |
-| Node | `db.outbox(...)` | `packages/honker-node/test/parity.test.js` |
-| Rust wrapper | `db.outbox(...)` | `packages/honker-rs/tests/surface.rs` |
-| Go | `db.Outbox(...)` | `packages/honker-go/honker_test.go` |
-| Bun | `db.outbox(...)` | `packages/honker-bun/test/parity.test.ts` |
-| C++ | `db.outbox(...)` | `packages/honker-cpp/test/test_parity.cpp` |
-| .NET | `db.Outbox(...)` | `packages/honker-dotnet/tests/Honker.Tests/BindingTests.cs` |
-| Ruby | `db.outbox(...)` | `packages/honker-ruby/spec/parity_spec.rb` |
-| Elixir | `Honker.outbox(...)` | `packages/honker-ex/test/parity_test.exs` |
-| JVM | `db.outbox(...)` | `packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java` |
-| Kotlin | JVM wrapper | `packages/honker-kotlin/src/test/kotlin/dev/honker/kotlin/HonkerKotlinTest.kt` |
-
-Contract:
-
-- Omitted backend, `"polling"`, and `"poll"` select polling/default
-  behavior. Backend names are exact; case and whitespace are not
-  normalized.
-- Unknown backend names are errors everywhere.
-- Explicit experimental backend requests must never silently fall back
-  to polling.
-- A binding may claim `kernel` / `shm` support only when it routes wake
-  waits through a shared watcher and has backend-isolation tests that
-  cannot pass via fallback polling.
+| Python | `honker.open(..., watcher_backend=...)` | source builds with matching Cargo features |
+| Node | `open(path, maxReaders?, watcherBackend?)` | source builds with matching Cargo features |
+| Rust wrapper | `OpenOptions::watcher_backend(...)` | matching Cargo features |
+| Go | `OpenWithOptions(..., OpenOptions{WatcherBackend: ...})` | depends on loaded extension features |
+| Bun | `open(..., { watcherBackend })` | depends on loaded extension features |
+| C++ | `Database(path, ext_path, watcher_backend)` | depends on loaded extension features |
+| .NET | `OpenOptions.WatcherBackend` | depends on bundled/loaded extension features |
+| Ruby | `watcher_backend:` | depends on loaded extension features |
+| Elixir | `watcher_backend:` | depends on loaded extension features |
+| JVM | `OpenOptions.watcherBackend(...)` | stable `AUTO`/`PRAGMA_DATA_VERSION`; explicit experimental `MMAP_SHM` and `KERNEL_EVENTS` |
+| Kotlin | JVM `OpenOptions` | wraps JVM behavior |
 
 ## What CI Proves
 
-- PR CI runs Rust core/extension on Linux, macOS, and Windows.
-- PR CI runs Python on Linux, macOS, and Windows.
-- PR CI runs Node on Linux, macOS, and Windows.
-- PR CI runs .NET on Linux, macOS, and Windows.
-- The aggregate Linux binding smoke runs Rust wrapper, Go, .NET
-  Python interop, C++, Bun, Ruby, Elixir, and Ruby <-> Python interop.
-- The packaged-install proof workflow builds and installs Python,
-  Node, Ruby, and .NET packages into clean throwaway consumers.
-- JVM and Kotlin bindings have local Maven proof plus a clean Maven
-  consumer proof that runs from outside the repo using the packaged
-  native resource.
-- JVM wake proof mirrors the Python race/resource shape: long-fallback
-  listener/worker/stream/result waits, cross-process worker/listener/stream
-  wake, concurrent claim uniqueness, delayed deadlines, and listener
-  churn/resource cleanup.
-- JVM watcher proof includes stable `AUTO`/`PRAGMA_DATA_VERSION`,
-  explicit experimental `MMAP_SHM` and `KERNEL_EVENTS`, backend selection
-  tests, and cross-process proofs. fcntl is intentionally not a backend
-  because the repo proof shows it misses idle cross-connection updates
-  without an intervening read transaction.
-- JVM/Kotlin ergonomics proof includes typed JSON wrappers,
-  `CompletableFuture` waits, Kotlin notification/job/event flows, and
-  codec-based typed helpers from a clean Maven consumer.
+- Rust core and extension on Linux, macOS, and Windows
+- Python, Node, and .NET on Linux, macOS, and Windows
+- Linux binding smoke for Rust wrapper, Go, .NET Python interop, C++,
+  Bun, Ruby, Elixir, and Ruby/Python interop
+- Packaged-install proof for Python, Node, Ruby, and .NET in clean
+  throwaway consumers
+- JVM and Kotlin local Maven proof plus clean consumer proof outside the
+  repo
+- Representative cross-language wake and table-behavior proofs
+- JVM watcher parity for stable `AUTO`/`PRAGMA_DATA_VERSION` and explicit
+  experimental `MMAP_SHM` / `KERNEL_EVENTS`
 
-## What Is Not Proven Yet
+## Not Proven Yet
 
-- Published registry installs after release. The proof workflow uses
-  locally-built artifacts, which catches packaging shape but not registry
-  permissions or CDN weirdness.
-- Every possible cross-language pair. CI proves representative pairs
-  and shared table behavior. It does not run N x N interop.
-- Long soak on every OS. The scary nightly workflow soaks Linux; PR CI
-  stays shorter.
-- Ruby and Elixir do not yet have the same async listener API as
-  Python/Node/.NET/Rust/Go/Bun/C++.
-- JVM/Kotlin packages do not yet have published Maven Central proof.
+- Every possible cross-language pair; CI covers representative pairs
+- Long soak on every OS; scary nightly soaks Linux
+- Ruby and Elixir async listen parity with Python/Node/.NET/Rust/Go/Bun/C++
+- Published Maven Central proof for JVM/Kotlin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "honker-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "honker-extension"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "honker-core",
  "rusqlite",

--- a/README.md
+++ b/README.md
@@ -2,14 +2,27 @@
   <img src="assets/honker-logo.png" width="120" alt="" /><br/>honker
 </h1>
 
-`honker` is a SQLite extension and set of language bindings for durable
-queues, streams, pub/sub, and time-trigger scheduling. It gives a local
-SQLite database Postgres-style `NOTIFY`/`LISTEN` behavior without Redis,
-Celery, a broker, or a daemon.
+`honker` is a SQLite extension + language bindings that add
+Postgres-style `NOTIFY`/`LISTEN` semantics to SQLite, with built-in
+durable pub/sub, task queue, and event streams, without client polling
+or a daemon/broker. Any language that can
+`SELECT load_extension('honker')` gets the same features.
 
-If SQLite is your primary datastore, honker keeps side effects in the
-same file. Business writes and queue/event/notification writes commit
-together, and rollback drops both.
+`honker` replaces queue-table polling with a single-digit-microsecond
+`PRAGMA data_version` read. The default watcher checks every 1 ms,
+giving push-like semantics and single-digit-millisecond cross-process
+delivery; raise the watcher interval when lower idle CPU matters more
+than lowest-latency wakeups.
+
+If SQLite is your primary datastore, the queue should live in the same
+file. `INSERT INTO orders` and `queue.enqueue(...)` can commit in the
+same transaction. Rollback drops both.
+
+See [honker.dev](https://honker.dev) for guides and API details, and
+[Binding support](BINDINGS.md) for what each binding supports.
+
+[Simon Willison highlighted honker](https://simonwillison.net/2026/Apr/24/honker/)
+as a SQLite implementation of the transactional outbox pattern.
 
 > Alpha software. Better than experimental, not beta-quality yet.
 
@@ -54,33 +67,66 @@ multi-writer replication, or distributed locking across machines.
 
 ## Why
 
-The usual way to add background work to a SQLite app is to add a second
-datastore: Redis, a queue service, or Postgres. That works, but it also
-adds backup, deployment, and dual-write failure modes.
+SQLite is increasingly the database for shipped projects. Those projects
+eventually need pub/sub and a task queue. The usual answer is "add Redis
++ Celery." That works, but it introduces a second datastore with its own
+backup story, a dual-write problem between your business table and the
+queue, and a broker to run.
 
-Honker stores work in ordinary SQLite tables. Queue sends, stream
-publishes, and notifications happen inside your existing transaction.
-Every binding uses the same schema and extension, so one language can
-enqueue work and another can claim it.
+Honker takes the approach that if SQLite is the primary datastore, the
+queue should live in the same file. The queue is just rows in a table
+with a partial index. Every binding uses the same schema and extension,
+so one language can enqueue work and another can claim it.
 
-## Wake Behavior
+## Design
 
-SQLite has no server-side push channel, so honker uses a small shared
-watcher. The stable backend reads `PRAGMA data_version` every millisecond;
-when the counter changes, listeners re-read indexed SQLite state.
+Honker is built around three pieces:
 
-This intentionally wakes more listeners than strictly necessary. A
-wasted wake is one cheap indexed query; a missed wake is a correctness
-bug. The stable semantics are:
+- ephemeral pub/sub with `notify()` / `listen()`
+- durable streams with per-consumer offsets
+- at-least-once queues with visibility timeouts and retries
+
+All three are INSERTs inside your transaction. Put `queue.enqueue(...)`,
+`stream.publish(...)`, or `notify(...)` beside the write that created the
+work. Commit lands both rows. Rollback drops both rows.
+
+SQLite has no server-side push channel, so honker uses a shared watcher.
+The stable backend reads `PRAGMA data_version` every millisecond; when
+the counter changes, listeners re-read indexed SQLite state.
+
+If you use your app's existing SQLite file, honker wakes workers on
+every commit to that file. Most wakes will not find work for a given
+queue or channel. That overtriggering is on purpose: one indexed SELECT
+is cheap, while a missed wake is a correctness bug. The stable semantics
+are:
 
 - wake on committed updates
 - ignore rolled-back work
 - re-read SQLite state after every wake
 - use file-backed SQLite databases, not `:memory:`
 
-Experimental source-build backends also exist for kernel file events and
-WAL shared-memory reads. See [Binding support](BINDINGS.md) for which
+Optional source-build backends also exist for kernel file events and WAL
+shared-memory reads. See [Binding support](BINDINGS.md) for which
 bindings expose backend options and what CI proves.
+
+Honker is single-machine and file-backed. SQLite's locking model is
+designed for one host writing one database file; two servers writing the
+same `.db` over NFS is not a Honker deployment strategy.
+
+## Prior Art
+
+[`pg_notify`](https://www.postgresql.org/docs/current/sql-notify.html)
+gives Postgres fast triggers, but no retry or visibility timeout.
+[pg-boss](https://github.com/timgit/pg-boss) and
+[Oban](https://hexdocs.pm/oban/) are the Postgres-side gold standards
+we're chasing on SQLite. [Huey](https://github.com/coleifer/huey) is an
+excellent SQLite-backed Python task queue. If you already run Postgres,
+use the Postgres tools, as they are excellent.
+
+The transactional outbox idea also owes a lot to Brandur Leach's
+[Transactionally Staged Job Drains in Postgres](https://brandur.org/job-drain):
+write the job row in the same transaction as the business row, then let
+a worker deliver it after commit.
 
 ## Bindings
 
@@ -91,7 +137,8 @@ bindings expose backend options and what CI proves.
 | Ruby | `gem install honker` | Native gem with precompiled platforms where available |
 | .NET / C# | `dotnet add package Honker` | NuGet package with bundled runtime assets |
 | Rust | `honker`, `honker-core`, `honker-extension` | Core engine and Rust wrapper |
-| Go, Bun, Elixir, C++, JVM, Kotlin | in `packages/` | Maintained in-tree bindings |
+| Elixir | Hex package `honker` | Extension-backed Elixir binding |
+| Go, Bun, C++, JVM, Kotlin | in `packages/` | Maintained in-tree bindings |
 | SQLite | `honker-extension` | Loadable extension for any SQLite 3.9+ client |
 
 The detailed parity table lives in [BINDINGS.md](BINDINGS.md).
@@ -104,14 +151,55 @@ Any SQLite client that can load extensions can use honker directly:
 ```sql
 .load ./libhonker_ext
 SELECT honker_bootstrap();
+INSERT INTO _honker_live (queue, payload) VALUES ('emails', '{"to":"alice"}');
+SELECT honker_claim_batch('emails', 'worker-1', 32, 300);    -- JSON array
+SELECT honker_ack_batch('[1,2,3]', 'worker-1');              -- DELETEs; returns count
+SELECT honker_sweep_expired('emails');                       -- count moved to dead
+SELECT honker_lock_acquire('backup', 'me', 60);              -- 1 = got it, 0 = held
+SELECT honker_lock_release('backup', 'me');                  -- 1 = released
+SELECT honker_rate_limit_try('api', 10, 60);                 -- 1 = under, 0 = at limit
+SELECT honker_rate_limit_sweep(3600);                        -- drop windows >1h old
+SELECT honker_cron_next_after('0 3 * * *', unixepoch());     -- 5-field cron
+SELECT honker_cron_next_after('*/2 * * * * *', unixepoch()); -- 6-field cron
+SELECT honker_cron_next_after('@every 5s', unixepoch());     -- interval schedule
+SELECT honker_scheduler_register('nightly', 'backups',
+  '0 3 * * *', '"go"', 0, NULL);                             -- periodic task
+SELECT honker_scheduler_tick(unixepoch());                   -- JSON: fires due
+SELECT honker_scheduler_soonest();                           -- min next_fire_at
+SELECT honker_queue_next_claim_at('emails');                 -- next run/reclaim deadline
+SELECT honker_stream_publish('orders', 'k', '{"id":42}');    -- returns offset
+SELECT honker_stream_read_since('orders', 0, 1000);          -- JSON array
+SELECT honker_stream_save_offset('worker', 'orders', 42);    -- monotonic upsert
+SELECT honker_stream_get_offset('worker', 'orders');         -- offset or 0
+SELECT honker_result_save(42, '{"ok":true}', 3600);          -- save w/ 1h TTL
+SELECT honker_result_get(42);                                -- value or NULL
+SELECT honker_result_sweep();                                -- prune expired
 SELECT notify('orders', '{"id":42}');
 SELECT honker_enqueue('emails', '{"to":"alice@example.com"}', NULL, NULL, 0, 3, NULL);
-SELECT honker_claim_batch('emails', 'worker-1', 32, 300);
 ```
 
 The extension shares tables with the language bindings, so a Python
 worker can claim jobs written by SQL, Node, Ruby, Go, or any other
 binding.
+
+## Architecture
+
+- One `PRAGMA data_version` watcher per `Database`; the default
+  Rust-backed watcher cadence is 1 ms and can be raised
+- Counter change fans out a wake to each listener/worker/subscriber
+- Subscribers re-read SQLite state with indexed SELECTs
+- 100 subscribers still share one watcher
+- Idle listeners run zero queue/notification SELECTs
+
+Queue claim is one `UPDATE ... RETURNING` through a partial index:
+`(queue, priority DESC, run_at, id) WHERE state IN ('pending','processing')`.
+Ack is one `DELETE`. Retry-exhausted jobs move to `_honker_dead`, so
+claim speed depends on pending/processing jobs, not old queue history.
+
+The language bindings default to WAL because it gives concurrent readers
+with one writer and efficient fsync batching. Other journal modes still
+work. Correctness and cross-process wake do not depend on WAL; the wake
+path is SQLite's own `data_version` counter.
 
 ## ORMs And Frameworks
 
@@ -125,8 +213,9 @@ ORM guide at [honker.dev/guides/orm](https://honker.dev/guides/orm/).
 
 ## Performance
 
-On a modern laptop, honker handles thousands of messages per second with
-cross-process wake latency bounded by the 1 ms watcher cadence. Measure
+On a modern laptop, honker handles thousands of messages per second.
+Cross-process wake latency is set by the watcher cadence, which defaults
+to 1 ms. Measure
 on your hardware with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,86 +2,18 @@
   <img src="assets/honker-logo.png" width="120" alt="" /><br/>honker
 </h1>
 
-`honker` is a SQLite extension + language bindings that add Postgres-style `NOTIFY`/`LISTEN` semantics to SQLite, with built-in durable pub/sub, task queue, and event streams, without client polling or a daemon/broker. Any language that can `SELECT load_extension('honker')` gets the same features.
+`honker` is a SQLite extension and set of language bindings for durable
+queues, streams, pub/sub, and time-trigger scheduling. It gives a local
+SQLite database Postgres-style `NOTIFY`/`LISTEN` behavior without Redis,
+Celery, a broker, or a daemon.
 
-`honker` works by replacing application-level polling with a single-digit-µs `PRAGMA data_version` read on the database every 1ms, achieving push-like semantics and cross-process notifications with single-digit-millisecond delivery.
+If SQLite is your primary datastore, honker keeps side effects in the
+same file. Business writes and queue/event/notification writes commit
+together, and rollback drops both.
 
-Some bindings expose experimental watcher backends, such as mmap of
-`<db>-shm` in WAL mode or kernel file events. AUTO backend modes stay
-conservative and use `PRAGMA data_version`. The stable semantics stay
-the same: wake on committed updates, ignore rolled-back work, and
-re-read SQLite state after every wake.
+> Alpha software. Better than experimental, not beta-quality yet.
 
-> Alpha software. Better than experimental but not beta-quality yet. 
-
-SQLite is increasingly the database for shipped projects. Those inevitably require pubsub and a task queue. The usual answer is "add Redis + Celery." That works, but it introduces a second datastore with its own backup story, a dual-write problem between your business table and the queue, and the operational overhead of running a broker.
-
-honker takes the approach that if SQLite is the primary datastore, the queue should live in the same file. That means `INSERT INTO orders` and `queue.enqueue(...)` commit in the same transaction. Rollback drops both. The queue is just rows in a table with a partial index.
-
-Prior art:  [`pg_notify`](https://www.postgresql.org/docs/current/sql-notify.html) (fast triggers, no retry/visibility), [Huey](https://github.com/coleifer/huey) (SQLite-backed Python), [pg-boss](https://github.com/timgit/pg-boss) and [Oban](https://github.com/sorentwo/oban) (the Postgres-side gold standards we're chasing on SQLite). If you already run Postgres, use those, as they are excellent.
-
-honker ships as a [Rust crate](https://crates.io/crates/honker) (`honker`, plus `honker-core`/`honker-extension`), a [SQLite loadable extension](#sqlite-extension-any-sqlite-39-client), and language packages: Python (`honker`), Node (`@russellthehippo/honker-node`), Bun (`@russellthehippo/honker-bun`), Ruby (`honker`), Go, Elixir, C++, .NET / C#, and JVM / Kotlin packages. The on-disk layout is defined once in Rust; every binding is a thin wrapper around the loadable extension.
-
-See [Binding support](BINDINGS.md) for the current truth table: which
-bindings have typed queue/stream/listen/scheduler APIs, which ones have
-packaged-install proof, and what CI actually proves.
-
-## At a glance
-
-```python
-import honker
-
-db = honker.open("app.db")
-emails = db.queue("emails")
-
-# Enqueue
-emails.enqueue({"to": "alice@example.com"})
-
-# Consume (worker process)
-async for job in emails.claim("worker-1"):
-    send(job.payload)
-    job.ack()
-```
-
-Any enqueue can be atomic with a business write. Rollback drops both.
-
-```python
-with db.transaction() as tx:
-    tx.execute("INSERT INTO orders (user_id) VALUES (?)", [42])
-    emails.enqueue({"to": "alice@example.com"}, tx=tx)
-```
-
-## Features
-
-Today:
-
-- Notify/listen across processes on one `.db` file
-- Work queues with retries, priority, delayed jobs, and a dead-letter table
-- Any send can be atomic with your business write (commit together or roll back together)
-- Single-digit millisecond cross-process reaction time, no polling
-- Handler timeouts, declarative retries with exponential backoff
-- Delayed jobs, task expiration, named locks, rate-limiting
-- Time-trigger scheduling with a leader-elected scheduler:
-  5-field cron, 6-field cron, and `@every <n><unit>`. Schedules are
-  addressable rows you can `pause`, `resume`, `update`, `list`, and
-  `unschedule` from any process or binding.
-- Cancel a pending or in-flight job by id (`queue.cancel(id)`); read
-  any job's row via `queue.get_job(id)`.
-- Opt-in task result storage (`enqueue` returns an id, worker persists the
-  return value, caller awaits `queue.wait_result(id)`)
-- Durable streams with per-consumer offsets and configurable flush interval
-- SQLite loadable extension so any SQLite client can read the same tables
-- Bindings: Python, Node.js, Rust, Go, Ruby, Bun, Elixir, .NET / C#,
-  Java/JVM, and Kotlin
-- Works inside an ORM-owned SQLite connection. SQLAlchemy, SQLModel,
-  Django, Drizzle, Kysely, sqlx, GORM, ActiveRecord, Ecto, Hibernate,
-  jOOQ, MyBatis, Exposed ([guide](https://honker.dev/guides/orm/))
-
-Deliberately not built: task pipelines/chains/groups/chords, multi-writer replication, workflow orchestration with DAGs.
-
-## Quick start 
-
-### Python: queue (durable at-least-once work)
+## Quick Start
 
 ```bash
 pip install honker
@@ -89,501 +21,147 @@ pip install honker
 
 ```python
 import honker
+
 db = honker.open("app.db")
 emails = db.queue("emails")
 
 with db.transaction() as tx:
     tx.execute("INSERT INTO orders (user_id) VALUES (?)", [42])
-    emails.enqueue({"to": "alice@example.com"}, tx=tx)   # atomic with order
+    emails.enqueue({"to": "alice@example.com"}, tx=tx)
 
-# Then in a worker, do: 
-async for job in emails.claim("worker-1"):               # wakes on updates or due deadlines
-    try:
-        send(job.payload); job.ack()
-    except Exception as e:
-        job.retry(delay_s=60, error=str(e))
+async for job in emails.claim("worker-1"):
+    send_email(job.payload)
+    job.ack()
 ```
 
-`claim()` is an async iterator. Each iteration is one `claim_batch(worker_id, 1)`. Wakes on any database update, or when the next claim-relevant deadline arrives (`run_at` for delayed jobs, or `claim_expires_at` for reclaims). Falls back to a 5 s paranoia poll only if the update watcher can't fire. For batched work, call `claim_batch(worker_id, n)` explicitly and ack with `queue.ack_batch(ids, worker_id)`. Defaults: visibility 300 s.
+The enqueue is atomic with the order insert. A worker in another process
+wakes when the transaction commits.
 
-### Python: tasks (Huey-style decorators)
+## What It Does
 
-If you want a function call to turn into an enqueued job without wrapping `queue.enqueue` by hand:
+- Notify/listen across processes on one SQLite `.db` file
+- Durable at-least-once queues with retries, delayed jobs, priority,
+  visibility timeouts, dead-letter rows, and task result storage
+- Durable streams with per-consumer offsets
+- Time-trigger scheduling with cron and `@every <duration>` expressions
+- Named locks, rate limits, and transactional outbox helpers
+- SQL functions through a SQLite loadable extension
+- Thin bindings for Python, Node.js, Rust, Go, Ruby, Bun, Elixir, C++,
+  .NET / C#, Java/JVM, and Kotlin
 
-```python
-@emails.task(retries=3, timeout_s=30)
-def send_email(to: str, subject: str) -> dict:
-    ...
-    return {"sent_at": time.time()}
+Deliberately not included: workflow DAGs, task chains/groups/chords,
+multi-writer replication, or distributed locking across machines.
 
-# Caller
-r = send_email("alice@example.com", "Hi")   # enqueues, returns a TaskResult
-print(r.get(timeout=10))                    # blocks until worker runs it
-```
+## Why
 
-Worker side, either in-process or as its own process:
+The usual way to add background work to a SQLite app is to add a second
+datastore: Redis, a queue service, or Postgres. That works, but it also
+adds backup, deployment, and dual-write failure modes.
 
-```bash
-python -m honker worker myapp.tasks:db --queue=emails --concurrency=4
-```
+Honker stores work in ordinary SQLite tables. Queue sends, stream
+publishes, and notifications happen inside your existing transaction.
+Every binding uses the same schema and extension, so one language can
+enqueue work and another can claim it.
 
-Auto-name is `{module}.{qualname}` (Huey/Celery convention). Explicit names with `@emails.task(name="...")` are recommended in prod so renames don't orphan pending jobs. Periodic tasks use `@emails.periodic_task(crontab("0 3 * * *"))`. Full details in [`packages/honker/examples/tasks.py`](packages/honker/examples/tasks.py).
+## Wake Behavior
 
-### Python: stream (durable pub/sub)
+SQLite has no server-side push channel, so honker uses a small shared
+watcher. The stable backend reads `PRAGMA data_version` every millisecond;
+when the counter changes, listeners re-read indexed SQLite state.
 
-```python
-stream = db.stream("user-events")
+This intentionally wakes more listeners than strictly necessary. A
+wasted wake is one cheap indexed query; a missed wake is a correctness
+bug. The stable semantics are:
 
-with db.transaction() as tx:
-    tx.execute("UPDATE users SET name=? WHERE id=?", [name, uid])
-    stream.publish({"user_id": uid, "change": "name"}, tx=tx)
+- wake on committed updates
+- ignore rolled-back work
+- re-read SQLite state after every wake
+- use file-backed SQLite databases, not `:memory:`
 
-async for event in stream.subscribe(consumer="dashboard"):
-    await push_to_browser(event)
-```
+Experimental source-build backends also exist for kernel file events and
+WAL shared-memory reads. See [Binding support](BINDINGS.md) for which
+bindings expose backend options and what CI proves.
 
-Each named consumer tracks its own offset in the `_honker_stream_consumers` table. `subscribe` replays rows past the saved offset, then transitions to live delivery on commit wake. The iterator auto-saves offset at most every 1000 events or every 1 second (whichever first) so a high-throughput stream doesn't hammer the single-writer slot. Override with `save_every_n=` / `save_every_s=`, or set both to 0 to disable auto-save and call `stream.save_offset(consumer, offset, tx=tx)` yourself (atomic with whatever you just did in that tx). At-least-once: a crash re-delivers in-flight events up to the last flushed offset.
+## Bindings
 
-### Python: notify (ephemeral pub/sub)
+| Ecosystem | Package / path | Notes |
+| --- | --- | --- |
+| Python | `pip install honker` | Batteries-included package; includes the Python API and loadable extension in release wheels |
+| Node.js | `npm install @russellthehippo/honker-node` | Native Node binding |
+| Ruby | `gem install honker` | Native gem with precompiled platforms where available |
+| .NET / C# | `dotnet add package Honker` | NuGet package with bundled runtime assets |
+| Rust | `honker`, `honker-core`, `honker-extension` | Core engine and Rust wrapper |
+| Go, Bun, Elixir, C++, JVM, Kotlin | in `packages/` | Maintained in-tree bindings |
+| SQLite | `honker-extension` | Loadable extension for any SQLite 3.9+ client |
 
-```python
-async for n in db.listen("orders"):
-    print(n.channel, n.payload)
+The detailed parity table lives in [BINDINGS.md](BINDINGS.md).
+Language-specific install and API notes live in each package README.
 
-with db.transaction() as tx:
-    tx.execute("INSERT INTO orders (id, total) VALUES (?, ?)", [42, 99.99])
-    tx.notify("orders", {"id": 42})
-```
+## SQL Extension
 
-Listeners attach at current `MAX(id)`; history is not replayed. Use `db.stream()` if you need durable replay. The notifications table is not auto-pruned. Call `db.prune_notifications(older_than_s=…, max_keep=…)` from a scheduled task. Task payloads have to be valid JSON so a Python writer and Node reader can share a channel.
-
-### Node.js
-
-```js
-const { open } = require('@russellthehippo/honker-node');
-const db = open('app.db');
-
-// Atomic: business write + notify commit together
-const tx = db.transaction();
-tx.execute('INSERT INTO orders (id) VALUES (?)', [42]);
-tx.notify('orders', { id: 42 });
-tx.commit();
-
-// updateEvents wakes on any commit to the db.
-const ev = db.updateEvents();
-let lastSeen = 0;
-while (running) {
-  await ev.next();
-  const rows = db.query(
-    'SELECT id, payload FROM _honker_notifications WHERE id > ? ORDER BY id',
-    [lastSeen],
-  );
-  for (const row of rows) {
-    handle(JSON.parse(row.payload));
-    lastSeen = row.id;
-  }
-}
-```
-
-Current cross-language direct proof runs on every platform:
-Python -> Node wake through Node `updateEvents()`, and Node -> Python
-listener wake through Python `listen()`.
-
-### Java / JVM
-
-```java
-import dev.honker.*;
-
-try (Database db = Honker.open("app.db")) {
-    Queue emails = db.queue("emails");
-    long id = emails.enqueue("{\"to\":\"alice@example.com\"}");
-
-    Job job = emails.claimOne("worker-1").orElseThrow();
-    sendEmail(job.payloadJson());
-    job.ack();
-
-    emails.saveResult(id, "{\"ok\":true}");
-    emails.waitResultAsync(id, WaitOptions.timeout(Duration.ofSeconds(10)))
-        .thenAccept(this::handleResult);
-}
-```
-
-The JVM binding keeps JSON-library choice out of the core jar. Bring
-Jackson, Gson, Moshi, JSON-B, or a hand-written mapper by implementing
-`JsonCodec<T>`:
-
-```java
-JsonCodec<Email> emailJson = new JsonCodec<>() {
-    public String encode(Email value) {
-        try {
-            return mapper.writeValueAsString(value);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public Email decode(String json) {
-        try {
-            return mapper.readValue(json, Email.class);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-};
-
-try (Database db = Honker.open("app.db")) {
-    TypedQueue<Email> emails = db.queue("emails").typed(emailJson);
-    emails.enqueue(new Email("alice@example.com"));
-
-    TypedJob<Email> job = emails.claimOne("worker-1").orElseThrow();
-    sendEmail(job.payload());
-    job.ack();
-}
-```
-
-Java handles are `AutoCloseable`, and worker/listener/subscriber
-options accept executors so application frameworks can own thread
-pools and shutdown.
-
-### Kotlin
-
-```kotlin
-honker("app.db").use { db ->
-    val emails = db.queue("emails")
-    emails.enqueueJson("""{"to":"alice@example.com"}""")
-
-    emails.asFlow("worker-1").collect { job ->
-        sendEmail(job.payloadJson())
-        job.ack()
-    }
-}
-```
-
-Kotlin adds coroutine-friendly wrappers without duplicating the JVM
-runtime:
-
-```kotlin
-db.listen("orders")
-    .asFlow()
-    .collect { notification -> println(notification.payloadJson) }
-
-db.stream("user-events")
-    .asFlow()
-    .collect { event -> push(event.payloadJson) }
-
-val result = task.enqueueJson().await(Duration.ofSeconds(10))
-```
-
-Typed helpers use the same `JsonCodec<T>` seam:
-
-```kotlin
-val emailJson = object : JsonCodec<Email> {
-    override fun encode(value: Email) = mapper.writeValueAsString(value)
-    override fun decode(json: String) = mapper.readValue(json, Email::class.java)
-}
-
-db.queue("emails").enqueue(Email("alice@example.com"), emailJson)
-val job = db.queue("emails").asFlow("worker-1").first()
-sendEmail(job.decode(emailJson))
-job.ack()
-```
-
-### SQLite extension (any SQLite 3.9+ client)
+Any SQLite client that can load extensions can use honker directly:
 
 ```sql
 .load ./libhonker_ext
 SELECT honker_bootstrap();
-INSERT INTO _honker_live (queue, payload) VALUES ('emails', '{"to":"alice"}');
-SELECT honker_claim_batch('emails', 'worker-1', 32, 300);    -- JSON array
-SELECT honker_ack_batch('[1,2,3]', 'worker-1');              -- DELETEs; returns count
-SELECT honker_sweep_expired('emails');                       -- count moved to dead
-SELECT honker_lock_acquire('backup', 'me', 60);              -- 1 = got it, 0 = held
-SELECT honker_lock_release('backup', 'me');                  -- 1 = released
-SELECT honker_rate_limit_try('api', 10, 60);                 -- 1 = under, 0 = at limit
-SELECT honker_rate_limit_sweep(3600);                        -- drop windows >1h old
-SELECT honker_cron_next_after('0 3 * * *', unixepoch());     -- 5-field cron
-SELECT honker_cron_next_after('*/2 * * * * *', unixepoch()); -- 6-field cron
-SELECT honker_cron_next_after('@every 5s', unixepoch());     -- interval schedule
-SELECT honker_scheduler_register('nightly', 'backups',
-  '0 3 * * *', '"go"', 0, NULL);                         -- register periodic task
-SELECT honker_scheduler_register('fast', 'backups',
-  '@every 5s', '"go"', 0, NULL);                         -- interval schedule
-SELECT honker_scheduler_tick(unixepoch());                   -- JSON: fires due
-SELECT honker_scheduler_soonest();                           -- min next_fire_at
-SELECT honker_scheduler_unregister('nightly');               -- 1 = deleted
-SELECT honker_queue_next_claim_at('emails');                 -- next run_at / reclaim deadline
-SELECT honker_stream_publish('orders', 'k', '{"id":42}');    -- returns offset
-SELECT honker_stream_read_since('orders', 0, 1000);          -- JSON array
-SELECT honker_stream_save_offset('worker', 'orders', 42);    -- monotonic upsert
-SELECT honker_stream_get_offset('worker', 'orders');         -- offset or 0
-SELECT honker_result_save(42, '{"ok":true}', 3600);          -- save w/ 1h TTL
-SELECT honker_result_get(42);                                -- value or NULL
-SELECT honker_result_sweep();                                -- prune expired
 SELECT notify('orders', '{"id":42}');
+SELECT honker_enqueue('emails', '{"to":"alice@example.com"}', NULL, NULL, 0, 3, NULL);
+SELECT honker_claim_batch('emails', 'worker-1', 32, 300);
 ```
 
-The extension shares `_honker_live`, `_honker_dead`, and `_honker_notifications` with the Python binding, so a Python worker can claim jobs any other language pushed via the extension. Schema compatibility is pinned by `tests/test_extension_interop.py`.
+The extension shares tables with the language bindings, so a Python
+worker can claim jobs written by SQL, Node, Ruby, Go, or any other
+binding.
 
-## Design
+## ORMs And Frameworks
 
-This repo includes the `honker` SQLite loadable extension and bindings
-for Python, Node, Rust, Go, Ruby, Bun, Elixir, C++, .NET / C#,
-Java/JVM, and Kotlin.
+Honker does not ship framework plugins. Load the extension on your
+framework or ORM connection, run `honker_bootstrap()`, and call SQL
+functions inside the ORM's transaction.
 
-For most applications, [SQLite alone is sufficient](https://www.epicweb.dev/why-you-should-probably-be-using-sqlite). There are already great libraries that leverage SQLite for durable messaging. [Huey](https://github.com/coleifer/huey) is the one honker draws the most from. This project is inspired by it and seeks to do something similar across languages and frameworks by moving package logic into a SQLite extension.
-
-For Postgres-backed apps, [`pg_notify`](https://www.postgresql.org/docs/current/sql-notify.html) + [pg-boss](https://github.com/timgit/pg-boss) or [Oban](https://hexdocs.pm/oban/) is the equivalent. This library is for apps where SQLite is the primary datastore.
-
-The extension has three primitives that tie it together: ephemeral pub/sub (`notify()`), durable pub/sub with per-consumer offsets (`stream()`), at-least-once work queue (`queue()`). All three are INSERTs inside your transaction, which lets a task "send" be atomic with your business write, and rollback drops everything.
-
-The explicit goal is to do `NOTIFY`/`LISTEN` semantics without application-level polling, to achieve single-digit ms reaction time. If you use your app's existing SQLite file containing business logic, it will notify workers on every commit to the database. This means that most triggers will not result in anything happening: instead, workers just read the message/queue with no result. This "overtriggering" is on purpose and is the tradeoff for push-like semantics and fast reaction time.
-
-### WAL is the recommended default
-
-The language bindings default to `journal_mode = WAL` because it gives concurrent readers with one writer and efficient fsync batching (`wal_autocheckpoint = 10000`). Other journal modes (DELETE, TRUNCATE, MEMORY) still work. The wake path is `PRAGMA data_version`, which increments on every commit in every journal mode and is visible across processes. What you lose in non-WAL modes is WAL's concurrent-read-while-writing property; correctness and cross-process wake do not depend on WAL.
-
-- One `.db` is the entire system (plus `.db-wal` / `.db-shm` sidecars if you've opted into WAL). You get every benefit of SQLite (embedded, local, durable, snapshot-able) that your app already uses.
-- Claim is one `UPDATE … RETURNING` via a partial index; ack is one `DELETE`. One writer at a time no matter the journal mode; concurrent readers come with WAL.
-- We poll `PRAGMA data_version` every 1 ms to detect commits from any connection in any journal mode. The counter increments on every commit and on checkpoint, so WAL truncation, journal-file comings-and-goings, and exact-size collisions are all handled correctly.
-- SQLite has no wire protocol. Consumers must initiate reads; server-push is impossible. Wake signal = counter increment → `SELECT`.
-- Transactions are cheap, so jobs, events, and notifications are rows in the caller's open `with db.transaction()` block in an "outbox"-type pattern.
-- We use `PRAGMA data_version` instead of `stat(2)` on the WAL file or kernel watchers (`FSEvents`/`inotify`/`kqueue`). `data_version` is a monotonic counter incremented by SQLite on every commit by any connection: it handles WAL truncation, clock skew, and rolled-back transactions correctly. Kernel watchers drop same-process writes on macOS, and `stat(2)` on `(size, mtime)` misses commits when the WAL is truncated then grows back to the same size. `PRAGMA data_version` works identically on Linux/macOS/Windows at ~1 ms granularity for negligible CPU. Cost: ~3.5 µs per query, ~3.5 ms/sec total at 1 kHz.
-- Single machine, single writer. SQLite's locking is designed for a single host. Two servers writing one `.db` over NFS will corrupt it. Shard by file, or switch to Postgres.
-
-### In-memory databases are not supported
-
-Honker does not support SQLite in-memory database filenames such as `:memory:`, `file::memory:?cache=shared`, or `file:<name>?mode=memory&cache=shared`. Bare `:memory:` creates a separate database per connection, which would split Honker's writer, readers, and update watcher across different databases. SQLite's shared-memory URI forms can share state across multiple connections, but only inside one process, so they do not exercise Honker's cross-process worker/listener contract.
-
-For tests and feature environments, use a temporary file-backed `.db`. It is still cheap and disposable, but it preserves the same SQLite locking, wake, crash/reopen, and multi-process semantics that Honker relies on in production.
-
-## Architecture
-
-### Wake path
-
-- One PRAGMA-poll thread per `Database`, queries `data_version` every 1 ms
-- Counter change → fan out a tick to each subscriber's bounded channel
-- Each subscriber runs `SELECT … WHERE id > last_seen` against a partial index, yields rows, returns to wait
-- 100 subscribers = 1 poll thread
-- Idle listeners run zero SQL queries
-
-Idle cost is a single `PRAGMA data_version` query per millisecond per database. Listener count scales for free because the wake signal is a SQLite counter read instead of a polling query.
-
-`SharedUpdateWatcher` (in `honker-core`) owns the poll thread and fans out to N subscribers via bounded `SyncSender<()>` channels keyed by subscriber id. Each `db.update_events()` call registers a subscriber and returns a handle whose `Drop` auto-unsubscribes, so a dropped listener causes the bridge thread's `rx.recv() -> Err` and exits cleanly.
-
-### Wake backend (advanced)
-
-Polling is the default. It's the only backend shipped in published wheels. Two opt-in alternatives exist behind Cargo features for source builds: kernel filesystem events, and an mmap read of SQLite's WAL index. Builds without the requested feature reject `kernel` / `shm` explicitly instead of silently substituting polling. Both experimental backends can give lower idle CPU or faster wakes, but they can also miss wakes or fire wakes you didn't ask for. All three watch for the database file being swapped under them; if that happens they shut down loudly — every subscriber sees an error from `update_events()` instead of hanging.
-
-Binding support is tracked in [BINDINGS.md](BINDINGS.md). All maintained
-bindings route blocking wake waits through the same `honker-core`
-watcher, either in-process or through the shared extension ABI.
-
-One thing changed for everyone, no opt-in needed: the polling backend now keeps its connection through transient `SQLITE_BUSY` / `SQLITE_LOCKED` errors during commits. Before, it would drop and reconnect, which could miss wakes on non-WAL journal modes (DELETE / TRUNCATE / PERSIST). Now it just retries the next tick.
-
-Full reference — when to pick which, source-build flags, recovery patterns, what we haven't tested yet — at [docs › Watcher backends](https://honker.dev/reference/watcher-backends/).
-
-### Queue schema
-
-- `_honker_live`: pending + processing rows
-- Partial index: `(queue, priority DESC, run_at, id) WHERE state IN ('pending','processing')`
-- Claim = one `UPDATE … RETURNING` via that index
-- Ack = one `DELETE`
-- Retry-exhausted → `_honker_dead` (never scanned by claim path)
-
-Partial-index on state means the claim hot path is bounded by the *working-set* size rather than the *history* size. A queue with 100k dead rows claims as fast as a queue with zero.
-
-### Claim iterator
-
-- `async for job in q.claim(id)` yields one job at a time via `claim_batch(id, 1)`
-- `Job.ack()` is one `DELETE` in its own transaction. Return is an honest bool: `True` iff the claim was still valid, `False` if the visibility window elapsed and another worker reclaimed.
-- Wakes on database update from any process, or when the next `run_at` /
-  reclaim deadline arrives; a 5 s paranoia poll is the only fallback.
-
-For batched work, call `claim_batch(worker_id, n)` directly and ack with `queue.ack_batch(ids, worker_id)`. The library doesn't hide batching behind the iterator. The per-tx cost and the at-most-once visibility semantics are easier to reason about when the API doesn't try to be clever.
-
-### Transactional coupling
-
-- `notify()` is a SQL scalar function registered on the writer connection
-- INSERTs into `_honker_notifications` under the caller's open tx
-- `queue.enqueue(…, tx=tx)` and `stream.publish(…, tx=tx)` do the same
-- Rollback drops the job/event/notification with the rest of the tx
-
-This is the transactional outbox pattern, by default, without a library to install. Business write and side-effect enqueue commit or roll back together. There is no separate dispatch table and no separate dispatcher process: the side-effect row *is* the committed row, and any process watching the db picks it up within ~1 ms.
-
-### Over-triggering quickly is better than over-triggering from polling
-
-- A `data_version` change wakes *every* subscriber on that `Database`, not just the ones whose channel committed
-- Each wasted wake = one indexed SELECT (microseconds)
-- A missed wake = a silent correctness bug
-
-The library prefers waking ten listeners that don't care over missing one that does. Channel filtering happens in the `SELECT` path instead of the trigger notification. [Many small queries are efficient in SQLite](https://www.sqlite.org/np1queryprob.html).
-
-### Retention
-
-- Queue jobs persist until ack; retry-exhausted rows move to `_honker_dead`
-- Stream events persist; each named consumer tracks its own offset
-- Notify is fire-and-forget and not auto-pruned
-
-The caller chooses retention per primitive. `db.prune_notifications(older_than_s=…, max_keep=…)` is a tool you invoke. This keeps retention policy visible in the caller's code instead of inherited from a library default.
-
-## Crash recovery
-
-- Rollback drops jobs/events/notifications with your business write (SQLite ACID).
-- SIGKILL mid-tx is safe. SQLite's atomic-commit rollback on next open leaves no stale state (WAL or rollback journal, depending on mode). Verified in `tests/test_crash_recovery.py` (subprocess killed pre-COMMIT, `PRAGMA integrity_check == 'ok'`, fresh notifies still flow).
-- If a worker crashes mid-job, the claim expires after `visibility_timeout_s` (default 300 s) and another worker reclaims. `attempts` increments. After `max_attempts` (default 3), the row moves to `_honker_dead`.
-- Listeners offline during a prune miss the pruned events. For durable replay, use `db.stream()`, which tracks per-consumer offsets.
-
-## Wiring into your web framework
-
-Honker ships no framework plugins. API is small and the integration is a few lines of glue:
-
-```python
-# FastAPI: enqueue in a request, run workers via lifespan.
-@app.on_event("startup")
-async def _start_workers():
-    async def worker_loop():
-        async for job in db.queue("emails").claim("worker"):
-            await honker._worker.run_task(
-                job, send_email, timeout=30, retries=3, backoff=2.0
-            )
-    app.state._worker = asyncio.create_task(worker_loop())
-
-@app.post("/orders")
-async def create_order(order: dict):
-    with db.transaction() as tx:
-        tx.execute("INSERT INTO orders (user_id) VALUES (?)", [order["user_id"]])
-        db.queue("emails").enqueue({"to": order["email"]}, tx=tx)
-    return {"ok": True}
-```
-
-SSE endpoints are ~30 lines of `async def stream(...): yield f"data: ...\n\n"` over `db.listen(channel)` or `db.stream(name).subscribe(...)`. For Django/Flask, run the worker as a dedicated CLI process (same pattern as Celery/RQ).
-
-### Using an ORM (SQLAlchemy, Django, Drizzle, Hibernate, jOOQ, Exposed, …)
-
-Load `libhonker_ext` on your ORM's connection and call the SQL functions inside the ORM's own transaction. The enqueue commits atomically with your business write.
-
-```python
-# SQLAlchemy
-@event.listens_for(engine, "connect")
-def _load_honker(conn, _):
-    honker.load_extension(conn)
-    conn.execute("SELECT honker_bootstrap()")
-
-with Session(engine) as s, s.begin():
-    s.add(Order(user_id=42))
-    s.execute(text("SELECT honker_enqueue(:q, :p, NULL, NULL, 0, 3, NULL)"),
-              {"q": "emails", "p": '{"to":"alice@example.com"}'})
-```
-
-For JVM ORMs, use the ORM-owned JDBC connection inside the ORM
-transaction. Configure sqlite-jdbc with extension loading enabled, load
-the extension once per connection, then enqueue with SQL where the
-business write happens.
-
-```java
-// Hibernate / JPA
-entityManager.unwrap(Session.class).doWork(conn -> {
-    try (PreparedStatement stmt = conn.prepareStatement(
-        "SELECT honker_enqueue(?, ?, NULL, NULL, 0, 3, NULL)"
-    )) {
-        stmt.setString(1, "emails");
-        stmt.setString(2, "{\"to\":\"alice@example.com\"}");
-        stmt.executeQuery().close();
-    }
-});
-```
-
-```kotlin
-// jOOQ
-ctx.transaction { cfg ->
-    val tx = DSL.using(cfg)
-    tx.insertInto(ORDERS).set(ORDERS.USER_ID, 42).execute()
-    tx.fetchValue(
-        "SELECT honker_enqueue(?, ?, NULL, NULL, 0, 3, NULL)",
-        "emails",
-        """{"to":"alice@example.com"}""",
-    )
-}
-```
-
-```kotlin
-// Exposed
-transaction {
-    Orders.insert { it[userId] = 42 }
-    exec(
-        "SELECT honker_enqueue('emails', '{\"to\":\"alice@example.com\"}', NULL, NULL, 0, 3, NULL)"
-    )
-}
-```
-
-Workers run as a separate process using `honker.open("app.db")` or
-`Honker.open("app.db")`. The commit watcher wakes on commits from any
-connection to the file. See [Using with an ORM](https://honker.dev/guides/orm/)
-for Django, SQLModel, Drizzle, Kysely, sqlx, GORM, ActiveRecord, Ecto,
-a typed-payload `TypedQueue[T]` wrapper pattern for SQLModel/Pydantic,
-and the Prisma caveat.
+That works with SQLAlchemy, SQLModel, Django, Drizzle, Kysely, sqlx,
+GORM, ActiveRecord, Ecto, Hibernate, jOOQ, MyBatis, and Exposed. See the
+ORM guide at [honker.dev/guides/orm](https://honker.dev/guides/orm/).
 
 ## Performance
 
-Handles thousands of messages per second on a modern laptop, with cross-process wake latency bounded by the 1 ms poll cadence (~1–2 ms median on M-series). Run `bench/wake_latency_bench.py` and `bench/real_bench.py` to measure on your hardware.
+On a modern laptop, honker handles thousands of messages per second with
+cross-process wake latency bounded by the 1 ms watcher cadence. Measure
+on your hardware with:
+
+```bash
+python bench/wake_latency_bench.py --samples 500
+python bench/real_bench.py --workers 4 --enqueuers 2 --seconds 15
+```
 
 ## Development
 
-Layout:
-
-```
-honker-core/              # Rust rlib shared across all bindings (in-tree, published on crates.io)
-honker-extension/         # SQLite loadable extension (cdylib, published on crates.io)
-packages/
-  honker/                 # Python package (PyO3 cdylib + Queue/Stream/Outbox/Scheduler)
-  honker-node/            # napi-rs Node.js binding
-  honker-rs/              # ergonomic Rust wrapper
-  honker-go/              # Go binding
-  honker-ruby/            # Ruby binding
-  honker-bun/             # Bun binding
-  honker-ex/              # Elixir binding
-  honker-cpp/             # C++ binding
-  honker-dotnet/          # .NET / C# binding
-  honker-jvm/             # JVM / Java-compatible binding
-  honker-kotlin/          # Kotlin convenience wrapper
-tests/                    # integration tests (cross-package)
-bench/                    # benches
-site/                     # honker.dev (Astro)                [git submodule]
-```
-
-The maintained language bindings live in-tree so one feature can update
-core behavior, docs, tests, and binding surfaces together. The core
-engine is still Rust (`honker-core` + `honker-extension`); the language
-packages are first-class wrappers published independently to their
-ecosystems. `site/` remains a separate docs-site submodule.
-
 ```bash
-make test                   # default: rust + python + node (fast, ~10s)
-make test-python-slow       # soak + real-time cron tests (~2 min)
-make test-jvm               # JVM binding tests
-make test-kotlin            # JVM + Kotlin wrapper tests
-make test-jvm-consumer       # clean Maven consumer + packaged native proof
-make test-all               # everything including slow marks
-
-make build                  # PyO3 maturin develop + loadable extension
-
-python bench/wake_latency_bench.py --samples 500
-python bench/real_bench.py --workers 4 --enqueuers 2 --seconds 15
-python bench/ext_bench.py
+make test              # Rust + Python + Node fast path
+make test-all          # broader suite, including slower tests
+make build             # build Python package + loadable extension
+cargo build --release -p honker-extension
 ```
 
-### Coverage
+Repo layout:
 
-One-time: `make install-coverage-deps` (installs `coverage.py` + `cargo-llvm-cov`).
-
-```bash
-make coverage               # both HTML reports into coverage/
-make coverage-python        # honker python paths
-make coverage-rust          # honker-core Rust unit tests
+```text
+honker-core/          # shared Rust engine
+honker-extension/     # SQLite loadable extension
+packages/             # language bindings
+tests/                # cross-package integration tests
+bench/                # benchmarks
 ```
 
-Python coverage reflects the full honker test suite (~92% of `packages/honker/`). Rust coverage reflects only `cargo test`. Many `honker_ops.rs` paths (`honker_enqueue`, `honker_claim_batch`, etc.) are only exercised via the Python test suite and won't show up in the Rust report. Combined cross-language coverage is non-trivial (LLVM profile-data merging across PyO3 boundaries) and is deferred.
+## Docs
+
+- [Binding support](BINDINGS.md)
+- [Python examples](packages/honker/examples/README.md)
+- [Benchmarks](bench/README.md)
+- [Roadmap](ROADMAP.md)
+- [Changelog](CHANGELOG.md)
+- [honker.dev](https://honker.dev)
 
 ## License
 
-Apache 2.0. See [LICENSE](LICENSE).
+Apache-2.0 OR MIT. See [LICENSE](LICENSE).

--- a/honker-core/Cargo.toml
+++ b/honker-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honker-core"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "Shared Rust foundation for Honker bindings (SQLite loadable extension, PyO3, napi-rs, and friends). Not intended for direct use."
 license = "MIT OR Apache-2.0"

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -990,24 +990,14 @@ pub fn rate_limit_try(
         rusqlite::params![per],
         |r| r.get(0),
     )?;
-    let current: i64 = conn
-        .query_row(
-            "SELECT COALESCE(MAX(count), 0) FROM _honker_rate_limits
-             WHERE name = ?1 AND window_start = ?2",
-            rusqlite::params![name, window_start],
-            |r| r.get(0),
-        )
-        .unwrap_or(0);
-    if current >= limit {
-        return Ok(0);
-    }
-    conn.execute(
+    let changed = conn.execute(
         "INSERT INTO _honker_rate_limits (name, window_start, count)
          VALUES (?1, ?2, 1)
-         ON CONFLICT(name, window_start) DO UPDATE SET count = count + 1",
-        rusqlite::params![name, window_start],
+         ON CONFLICT(name, window_start) DO UPDATE SET count = count + 1
+         WHERE count < ?3",
+        rusqlite::params![name, window_start, limit],
     )?;
-    Ok(1)
+    Ok(if changed > 0 { 1 } else { 0 })
 }
 
 pub fn rate_limit_sweep(conn: &Connection, older_than_s: i64) -> rusqlite::Result<i64> {
@@ -1269,10 +1259,8 @@ pub fn scheduler_update(
     if !exists {
         return Ok(0);
     }
-    let any_field = cron_expr.is_some()
-        || payload.is_some()
-        || priority.is_some()
-        || expires_s.is_some();
+    let any_field =
+        cron_expr.is_some() || payload.is_some() || priority.is_some() || expires_s.is_some();
     if !any_field {
         // No fields to change. Don't wake the leader for a no-op.
         return Ok(0);
@@ -1316,8 +1304,10 @@ pub fn scheduler_update(
         Ok(())
     })();
     if result.is_err() {
-        let _ = conn.execute_batch("ROLLBACK TO SAVEPOINT honker_sched_update; \
-                                    RELEASE SAVEPOINT honker_sched_update");
+        let _ = conn.execute_batch(
+            "ROLLBACK TO SAVEPOINT honker_sched_update; \
+                                    RELEASE SAVEPOINT honker_sched_update",
+        );
         result?;
     }
     conn.execute_batch("RELEASE SAVEPOINT honker_sched_update")?;

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -24,7 +24,7 @@
 //!     acquire, non-blocking try_acquire, and release.
 //!   - [`Readers`] — bounded pool of reader connections that open
 //!     lazily up to a max.
-//!   - [`UpdateWatcher`] — 1 ms PRAGMA-polling thread that fires a
+//!   - [`UpdateWatcher`] — PRAGMA-polling thread that fires a
 //!     callback on every database commit. Uses `PRAGMA data_version`
 //!     for precise change detection, with a periodic stat identity check
 //!     to detect file replacement. Bindings wrap this to surface wake
@@ -59,13 +59,13 @@ use std::time::{Duration, Instant};
 
 /// Which backend drives the update-detection loop.
 ///
-/// `Polling` is the default: 1 ms `PRAGMA data_version` loop, proven
+/// `Polling` is the default: `PRAGMA data_version` loop, proven
 /// correct across all platforms. The optional backends are **experimental**
 /// — they must first prove equivalence to the polling path before
 /// being relied on for correctness.
 #[derive(Debug, Clone, Default)]
 pub enum WatcherBackend {
-    /// Default: 1 ms `PRAGMA data_version` polling loop.
+    /// Default: `PRAGMA data_version` polling loop.
     #[default]
     Polling,
     /// OS kernel filesystem notifications (experimental).
@@ -89,11 +89,40 @@ pub enum WatcherBackend {
     ShmFastPath,
 }
 
+pub const DEFAULT_WATCHER_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
 /// Configuration passed to [`UpdateWatcher::spawn_with_config`] and
 /// [`SharedUpdateWatcher::new_with_config`].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct WatcherConfig {
     pub backend: WatcherBackend,
+    pub poll_interval: Duration,
+}
+
+impl Default for WatcherConfig {
+    fn default() -> Self {
+        Self {
+            backend: WatcherBackend::default(),
+            poll_interval: DEFAULT_WATCHER_POLL_INTERVAL,
+        }
+    }
+}
+
+impl WatcherConfig {
+    pub fn with_backend(backend: WatcherBackend) -> Self {
+        Self {
+            backend,
+            ..Self::default()
+        }
+    }
+
+    pub fn with_poll_interval(mut self, poll_interval: Duration) -> Result<Self, String> {
+        if poll_interval.is_zero() {
+            return Err("watcher poll interval must be positive".to_string());
+        }
+        self.poll_interval = poll_interval;
+        Ok(self)
+    }
 }
 
 impl WatcherBackend {
@@ -680,9 +709,9 @@ fn is_transient_lock_error(e: &rusqlite::Error) -> bool {
 ///
 /// Three-layer defensive architecture:
 ///
-/// 1. **Fast path (every 1 ms):** `PRAGMA data_version`. Compare the
+/// 1. **Fast path:** `PRAGMA data_version`. Compare the
 ///    integer to last seen value. Notify on change. (~3.5 µs/call.)
-/// 2. **Error recovery (every 1 ms on failure):** If the query fails,
+/// 2. **Error recovery:** If the query fails,
 ///    reconnect the SQLite connection and force one wake.
 /// 3. **Identity check (about every 100 ms):** `stat(db_path)` to compare
 ///    `(dev, ino)`. If the file was replaced, panic with a clear
@@ -692,6 +721,7 @@ pub(crate) fn run_poll_loop<F>(
     on_change: F,
     stop: Arc<AtomicBool>,
     ready: std::sync::mpsc::SyncSender<()>,
+    poll_interval: Duration,
 ) where
     F: Fn(),
 {
@@ -724,7 +754,7 @@ pub(crate) fn run_poll_loop<F>(
     drop(ready);
 
     while !stop.load(Ordering::Acquire) {
-        std::thread::sleep(Duration::from_millis(1));
+        std::thread::sleep(poll_interval);
 
         // Path 1: PRAGMA data_version (fast path)
         if let Some(ref c) = conn {
@@ -836,7 +866,9 @@ impl UpdateWatcher {
         let handle = std::thread::Builder::new()
             .name("honker-update-poll".into())
             .spawn(move || match config.backend {
-                WatcherBackend::Polling => run_poll_loop(db_path, on_change, stop_t, ready_tx),
+                WatcherBackend::Polling => {
+                    run_poll_loop(db_path, on_change, stop_t, ready_tx, config.poll_interval)
+                }
                 #[cfg(feature = "kernel-watcher")]
                 WatcherBackend::KernelWatch => {
                     kernel_watcher::run_kernel_watch_loop(db_path, on_change, stop_t, ready_tx);
@@ -2329,6 +2361,7 @@ while True:
             },
             WatcherConfig {
                 backend: WatcherBackend::KernelWatch,
+                ..WatcherConfig::default()
             },
         );
 
@@ -2407,6 +2440,7 @@ while True:
             },
             WatcherConfig {
                 backend: WatcherBackend::ShmFastPath,
+                ..WatcherConfig::default()
             },
         );
 
@@ -2487,7 +2521,7 @@ while True:
             move || {
                 count_t.fetch_add(1, AO::Relaxed);
             },
-            WatcherConfig { backend },
+            WatcherConfig::with_backend(backend),
         );
 
         // Drain init wakes (covers shm + kernel setup) before baseline.
@@ -2704,7 +2738,7 @@ while True:
                     .expect("wake_times mutex poisoned")
                     .push(std::time::Instant::now());
             },
-            WatcherConfig { backend },
+            WatcherConfig::with_backend(backend),
         );
 
         // Drain initialization wakes.
@@ -2768,7 +2802,10 @@ while True:
         ignore = "notify/kqueue can drop the watcher thread under CI load; functional kernel watcher tests still run"
     )]
     #[cfg(feature = "kernel-watcher")]
-    #[cfg_attr(target_os = "macos", ignore = "kqueue under CI load may deliver zero wakes")]
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "kqueue under CI load may deliver zero wakes"
+    )]
     fn kernel_watcher_wake_latency_is_event_driven() {
         let tmp = std::env::temp_dir().join(format!(
             "honker-kw-lat-{}-{}",
@@ -2872,6 +2909,7 @@ while True:
             || {},
             WatcherConfig {
                 backend: WatcherBackend::KernelWatch,
+                ..WatcherConfig::default()
             },
         );
 
@@ -2929,6 +2967,14 @@ while True:
             WatcherBackend::parse(Some("polling")),
             Ok(WatcherBackend::Polling)
         ));
+    }
+
+    #[test]
+    fn watcher_config_rejects_zero_poll_interval() {
+        let err = WatcherConfig::default()
+            .with_poll_interval(Duration::from_millis(0))
+            .unwrap_err();
+        assert_eq!(err, "watcher poll interval must be positive");
     }
 
     #[test]
@@ -3062,8 +3108,11 @@ while True:
             f.write_all(&buf).unwrap();
         }
 
-        let watcher =
-            UpdateWatcher::spawn_with_config(tmp.clone(), || {}, WatcherConfig { backend });
+        let watcher = UpdateWatcher::spawn_with_config(
+            tmp.clone(),
+            || {},
+            WatcherConfig::with_backend(backend),
+        );
         // Generous initial wait so the watcher has snapshotted the
         // initial inode under CI scheduling pressure.
         std::thread::sleep(Duration::from_millis(300));

--- a/honker-extension/Cargo.toml
+++ b/honker-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honker-extension"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "SQLite loadable extension for Honker. Adds honker_* SQL functions (queues, streams, scheduler, pub/sub) to any SQLite client."
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ crate-type = ["cdylib"]
 # Using both `path` and `version` lets Cargo publish this crate to
 # crates.io referencing the real honker-core = "0.2" while still
 # using the in-tree source for local builds.
-honker-core = { path = "../honker-core", version = "0.2.3", default-features = false }
+honker-core = { path = "../honker-core", version = "0.2.4", default-features = false }
 # "loadable_extension" feature makes rusqlite usable from inside a
 # sqlite3_extension_init entry point.
 rusqlite = { version = "0.39.0", features = ["functions", "hooks", "loadable_extension"] }

--- a/honker-extension/src/lib.rs
+++ b/honker-extension/src/lib.rs
@@ -69,12 +69,17 @@ static NEXT_SQL_WATCHER_ID: AtomicU64 = AtomicU64::new(1);
 fn open_watcher_handle(
     db_path: &str,
     backend: Option<&str>,
+    watcher_poll_interval_ms: Option<u64>,
 ) -> std::result::Result<HonkerWatcherHandle, String> {
     let backend = honker_core::WatcherBackend::parse(backend.filter(|s| !s.is_empty()))?;
     backend.probe(PathBuf::from(db_path).as_path())?;
+    let mut config = honker_core::WatcherConfig::with_backend(backend);
+    if let Some(ms) = watcher_poll_interval_ms {
+        config = config.with_poll_interval(Duration::from_millis(ms))?;
+    }
     let shared = Arc::new(honker_core::SharedUpdateWatcher::new_with_config(
         PathBuf::from(db_path),
-        honker_core::WatcherConfig { backend },
+        config,
     ));
     let (sub_id, rx) = shared.subscribe();
     Ok(HonkerWatcherHandle { shared, sub_id, rx })
@@ -88,9 +93,27 @@ fn attach_watcher_sql_functions(conn: &Connection) -> Result<()> {
         |ctx| {
             let db_path: String = ctx.get(0)?;
             let backend: Option<String> = ctx.get(1)?;
-            let handle = open_watcher_handle(&db_path, backend.as_deref()).map_err(|e| {
+            let handle = open_watcher_handle(&db_path, backend.as_deref(), None).map_err(|e| {
                 rusqlite::Error::UserFunctionError(Box::new(std::io::Error::other(e)))
             })?;
+            let id = NEXT_SQL_WATCHER_ID.fetch_add(1, Ordering::Relaxed);
+            SQL_WATCHERS.lock().unwrap().insert(id, handle);
+            Ok(id as i64)
+        },
+    )?;
+    conn.create_scalar_function(
+        "honker_update_watcher_open",
+        3,
+        FunctionFlags::SQLITE_UTF8,
+        |ctx| {
+            let db_path: String = ctx.get(0)?;
+            let backend: Option<String> = ctx.get(1)?;
+            let poll_interval_ms: Option<i64> = ctx.get(2)?;
+            let poll_interval_ms = poll_interval_ms.map(|ms| ms.max(0) as u64);
+            let handle = open_watcher_handle(&db_path, backend.as_deref(), poll_interval_ms)
+                .map_err(|e| {
+                    rusqlite::Error::UserFunctionError(Box::new(std::io::Error::other(e)))
+                })?;
             let id = NEXT_SQL_WATCHER_ID.fetch_add(1, Ordering::Relaxed);
             SQL_WATCHERS.lock().unwrap().insert(id, handle);
             Ok(id as i64)
@@ -266,7 +289,46 @@ pub unsafe extern "C" fn honker_watcher_open(
             .to_str()
             .map_err(|e| format!("invalid db_path UTF-8: {e}"))?;
         let backend = unsafe { cstr_to_string(backend) }?;
-        let handle = open_watcher_handle(path, backend.as_deref())?;
+        let handle = open_watcher_handle(path, backend.as_deref(), None)?;
+        Ok(Box::into_raw(Box::new(handle)))
+    })) {
+        Ok(Ok(ptr)) => ptr,
+        Ok(Err(err)) => {
+            unsafe { write_error(err_buf, err_buf_len, &err) };
+            ptr::null_mut()
+        }
+        Err(payload) => {
+            let err = panic_error(payload).to_string();
+            unsafe { write_error(err_buf, err_buf_len, &err) };
+            ptr::null_mut()
+        }
+    }
+}
+
+/// Open a core-backed update watcher over `db_path` with options.
+///
+/// `watcher_poll_interval_ms` must be positive. Use `honker_watcher_open`
+/// for the default 1 ms cadence.
+///
+/// # Safety
+/// All pointers must be valid NUL-terminated strings when non-null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn honker_watcher_open_v2(
+    db_path: *const c_char,
+    backend: *const c_char,
+    watcher_poll_interval_ms: u64,
+    err_buf: *mut c_char,
+    err_buf_len: usize,
+) -> *mut HonkerWatcherHandle {
+    match catch_unwind(AssertUnwindSafe(|| {
+        if db_path.is_null() {
+            return Err("db_path is null".to_string());
+        }
+        let path = unsafe { CStr::from_ptr(db_path) }
+            .to_str()
+            .map_err(|e| format!("invalid db_path UTF-8: {e}"))?;
+        let backend = unsafe { cstr_to_string(backend) }?;
+        let handle = open_watcher_handle(path, backend.as_deref(), Some(watcher_poll_interval_ms))?;
         Ok(Box::into_raw(Box::new(handle)))
     })) {
         Ok(Ok(ptr)) => ptr,

--- a/packages/honker-bun/package.json
+++ b/packages/honker-bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-bun",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Bun binding for Honker — durable queues, streams, pub/sub, and scheduler on SQLite.",
   "license": "MIT OR Apache-2.0",
   "homepage": "https://honker.dev",

--- a/packages/honker-bun/src/index.ts
+++ b/packages/honker-bun/src/index.ts
@@ -100,6 +100,11 @@ export interface OpenOptions {
    * when the extension was not built with the matching feature.
    */
   watcherBackend?: string | null;
+  /**
+   * Shared update watcher cadence in milliseconds. Default: 1.
+   * Raise it when lower idle CPU matters more than lowest-latency wakeups.
+   */
+  watcherPollIntervalMs?: number | null;
 }
 
 export interface ScheduledTask {
@@ -192,10 +197,15 @@ class CoreWatcher {
   private readonly handle: unknown;
   private closed = false;
 
-  constructor(dbPath: string, extensionPath: string, watcherBackend?: string | null) {
+  constructor(
+    dbPath: string,
+    extensionPath: string,
+    watcherBackend?: string | null,
+    watcherPollIntervalMs?: number | null,
+  ) {
     this.lib = dlopen(extensionPath, {
-      honker_watcher_open: {
-        args: [FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.u64],
+      honker_watcher_open_v2: {
+        args: [FFIType.ptr, FFIType.ptr, FFIType.u64, FFIType.ptr, FFIType.u64],
         returns: FFIType.ptr,
       },
       honker_watcher_wait: {
@@ -210,9 +220,14 @@ class CoreWatcher {
     const error = Buffer.alloc(1024);
     const dbPathBytes = cString(dbPath);
     const backendBytes = cString(watcherBackend ?? "");
-    this.handle = this.lib.symbols.honker_watcher_open(
+    const pollIntervalMs = watcherPollIntervalMs ?? 1;
+    if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+      throw new Error("watcherPollIntervalMs must be positive");
+    }
+    this.handle = this.lib.symbols.honker_watcher_open_v2(
       dbPathBytes,
       backendBytes,
+      BigInt(Math.ceil(pollIntervalMs)),
       error,
       BigInt(error.length),
     );
@@ -262,8 +277,14 @@ export class Database {
     dbPath: string,
     extensionPath: string,
     watcherBackend?: string | null,
+    watcherPollIntervalMs?: number | null,
   ) {
-    this._watcher = new CoreWatcher(dbPath, extensionPath, watcherBackend);
+    this._watcher = new CoreWatcher(
+      dbPath,
+      extensionPath,
+      watcherBackend,
+      watcherPollIntervalMs,
+    );
   }
 
   /** Get a handle to a named queue. */
@@ -423,7 +444,13 @@ export function open(
   raw.loadExtension(extensionPath);
   raw.exec(DEFAULT_PRAGMAS);
   raw.exec("SELECT honker_bootstrap()");
-  return new Database(raw, path, extensionPath, opts.watcherBackend);
+  return new Database(
+    raw,
+    path,
+    extensionPath,
+    opts.watcherBackend,
+    opts.watcherPollIntervalMs,
+  );
 }
 
 // ---------------------------------------------------------------------

--- a/packages/honker-bun/test/basic.test.ts
+++ b/packages/honker-bun/test/basic.test.ts
@@ -8,6 +8,10 @@ import { open } from "../src/index.ts";
 
 const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..");
 const EXT_CANDIDATES = [
+  "target/debug/libhonker_ext.dylib",
+  "target/debug/libhonker_ext.so",
+  "target/debug/libhonker_extension.dylib",
+  "target/debug/libhonker_extension.so",
   "target/release/libhonker_ext.dylib",
   "target/release/libhonker_ext.so",
   "target/release/libhonker_extension.dylib",
@@ -104,6 +108,31 @@ describe("honker-bun watcher backend option", () => {
         db.close();
         rmSync(dir, { recursive: true, force: true });
       }
+    }
+  });
+
+  test("custom watcherPollIntervalMs detects commits", async () => {
+    if (!extPath) return;
+    const dir = mkdtempSync(join(tmpdir(), "honker-bun-watch-interval-"));
+    const dbPath = join(dir, "t.db");
+    let db: ReturnType<typeof open> | null = null;
+    let writer: ReturnType<typeof open> | null = null;
+    try {
+      db = open(dbPath, extPath, { watcherPollIntervalMs: 25 });
+      const updates = db.updateEvents();
+      writer = open(dbPath, extPath);
+      writer.notify("interval", { ok: true });
+      await Promise.race([
+        updates.next(),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("custom watcher interval did not observe commit")), 1000),
+        ),
+      ]);
+      updates.close();
+    } finally {
+      writer?.close();
+      db?.close();
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/honker-bun/test/parity.test.ts
+++ b/packages/honker-bun/test/parity.test.ts
@@ -7,6 +7,10 @@ import { open, type Database } from "../src/index.ts";
 
 const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..");
 const EXT_CANDIDATES = [
+  "target/debug/libhonker_ext.dylib",
+  "target/debug/libhonker_ext.so",
+  "target/debug/libhonker_extension.dylib",
+  "target/debug/libhonker_extension.so",
   "target/release/libhonker_ext.dylib",
   "target/release/libhonker_ext.so",
   "target/release/libhonker_extension.dylib",

--- a/packages/honker-bun/test/phase_mantle.test.ts
+++ b/packages/honker-bun/test/phase_mantle.test.ts
@@ -9,6 +9,10 @@ import { open, Scheduler } from "../src/index.ts";
 
 const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..");
 const EXT_CANDIDATES = [
+  "target/debug/libhonker_ext.dylib",
+  "target/debug/libhonker_ext.so",
+  "target/debug/libhonker_extension.dylib",
+  "target/debug/libhonker_extension.so",
   "target/release/libhonker_ext.dylib",
   "target/release/libhonker_ext.so",
   "target/release/libhonker_extension.dylib",

--- a/packages/honker-bun/test/python_interop.test.ts
+++ b/packages/honker-bun/test/python_interop.test.ts
@@ -51,6 +51,8 @@ except OSError:
 function findExtension(): string | null {
   const candidates = [
     process.env.HONKER_EXT_PATH,
+    join(REPO_ROOT, "target/debug/libhonker_ext.dylib"),
+    join(REPO_ROOT, "target/debug/libhonker_ext.so"),
     join(REPO_ROOT, "target/release/libhonker_ext.dylib"),
     join(REPO_ROOT, "target/release/libhonker_ext.so"),
   ].filter(Boolean) as string[];

--- a/packages/honker-bun/test/watcher_backends_queue_e2e.test.ts
+++ b/packages/honker-bun/test/watcher_backends_queue_e2e.test.ts
@@ -9,6 +9,10 @@ import { open } from "../src/index.ts";
 
 const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..");
 const EXT_CANDIDATES = [
+  "target/debug/libhonker_ext.dylib",
+  "target/debug/libhonker_ext.so",
+  "target/debug/libhonker_extension.dylib",
+  "target/debug/libhonker_extension.so",
   "target/release/libhonker_ext.dylib",
   "target/release/libhonker_ext.so",
   "target/release/libhonker_extension.dylib",

--- a/packages/honker-cpp/include/honker.hpp
+++ b/packages/honker-cpp/include/honker.hpp
@@ -142,7 +142,7 @@ class Lock;
 class Notification;
 class Subscription;
 
-using watcher_open_fn = void* (*)(const char*, const char*, char*, uintptr_t);
+using watcher_open_fn = void* (*)(const char*, const char*, uint64_t, char*, uintptr_t);
 using watcher_wait_fn = int (*)(void*, uint64_t);
 using watcher_close_fn = void (*)(void*);
 
@@ -157,7 +157,11 @@ inline std::mutex& native_open_mutex() {
 
 class Database {
 public:
-    Database(std::string_view path, std::string_view ext_path, std::string_view watcher_backend = "") {
+    Database(
+        std::string_view path,
+        std::string_view ext_path,
+        std::string_view watcher_backend = "",
+        uint64_t watcher_poll_interval_ms = 1) {
         const std::string p{path};
         const std::string e{ext_path};
         std::lock_guard<std::mutex> open_lock(native_open_mutex());
@@ -167,6 +171,7 @@ public:
         path_ = p;
         ext_path_ = e;
         watcher_backend_ = std::string{watcher_backend};
+        watcher_poll_interval_ms_ = watcher_poll_interval_ms;
         try {
             open_core_watcher();
         } catch (...) {
@@ -181,6 +186,7 @@ public:
         : db_(other.db_), path_(std::move(other.path_)),
           ext_path_(std::move(other.ext_path_)),
           watcher_backend_(std::move(other.watcher_backend_)),
+          watcher_poll_interval_ms_(other.watcher_poll_interval_ms_),
           watcher_lib_(other.watcher_lib_),
           core_watcher_(other.core_watcher_),
           watcher_wait_(other.watcher_wait_),
@@ -200,6 +206,7 @@ public:
             path_ = std::move(other.path_);
             ext_path_ = std::move(other.ext_path_);
             watcher_backend_ = std::move(other.watcher_backend_);
+            watcher_poll_interval_ms_ = other.watcher_poll_interval_ms_;
             watcher_lib_ = other.watcher_lib_;
             core_watcher_ = other.core_watcher_;
             watcher_wait_ = other.watcher_wait_;
@@ -292,6 +299,7 @@ private:
     std::string path_;
     std::string ext_path_;
     std::string watcher_backend_;
+    uint64_t watcher_poll_interval_ms_ = 1;
     void* watcher_lib_ = nullptr;
     void* core_watcher_ = nullptr;
     watcher_wait_fn watcher_wait_ = nullptr;
@@ -1239,7 +1247,7 @@ inline void Database::open_core_watcher() {
         throw Error{"LoadLibrary failed for " + ext_path_};
     }
     auto open_fn = reinterpret_cast<watcher_open_fn>(
-        GetProcAddress(static_cast<HMODULE>(watcher_lib_), "honker_watcher_open"));
+        GetProcAddress(static_cast<HMODULE>(watcher_lib_), "honker_watcher_open_v2"));
     watcher_wait_ = reinterpret_cast<watcher_wait_fn>(
         GetProcAddress(static_cast<HMODULE>(watcher_lib_), "honker_watcher_wait"));
     watcher_close_ = reinterpret_cast<watcher_close_fn>(
@@ -1250,7 +1258,7 @@ inline void Database::open_core_watcher() {
         const char* msg = dlerror();
         throw Error{"dlopen failed for " + ext_path_ + ": " + (msg ? msg : "unknown error")};
     }
-    auto open_fn = reinterpret_cast<watcher_open_fn>(dlsym(watcher_lib_, "honker_watcher_open"));
+    auto open_fn = reinterpret_cast<watcher_open_fn>(dlsym(watcher_lib_, "honker_watcher_open_v2"));
     watcher_wait_ = reinterpret_cast<watcher_wait_fn>(dlsym(watcher_lib_, "honker_watcher_wait"));
     watcher_close_ = reinterpret_cast<watcher_close_fn>(dlsym(watcher_lib_, "honker_watcher_close"));
 #endif
@@ -1258,7 +1266,12 @@ inline void Database::open_core_watcher() {
         close_watcher_lib();
         throw Error{"Honker extension missing core watcher ABI symbols"};
     }
-    core_watcher_ = open_fn(path_.c_str(), watcher_backend_.c_str(), err, sizeof(err));
+    core_watcher_ = open_fn(
+        path_.c_str(),
+        watcher_backend_.c_str(),
+        watcher_poll_interval_ms_,
+        err,
+        sizeof(err));
     if (!core_watcher_) {
         close_watcher_lib();
         throw Error{std::string{"watcher_backend probe failed: "} + err};

--- a/packages/honker-cpp/test/test_basic.cpp
+++ b/packages/honker-cpp/test/test_basic.cpp
@@ -245,6 +245,18 @@ int main(int argc, char** argv) {
         clean_db(p);
     }
 
+    {
+        const auto p = tmp_db("watch-interval");
+        clean_db(p);
+        honker::Database db{p.string(), ext, "", 25};
+        auto sub = db.listen("interval");
+        honker::Database writer{p.string(), ext};
+        writer.notify("interval", R"({"ok":true})");
+        auto n = sub.recv(std::chrono::seconds(2));
+        assert(n.has_value() && "custom watcher poll interval should observe commit");
+        clean_db(p);
+    }
+
     for (const char* backend : {"", "kernel", "shm"}) {
         const std::string label = backend && *backend ? backend : "default";
 

--- a/packages/honker-dotnet/README.md
+++ b/packages/honker-dotnet/README.md
@@ -1,59 +1,60 @@
 # honker-dotnet
 
-Early .NET / C# binding for Honker.
+.NET / C# binding for [Honker](https://github.com/russellromney/honker):
+durable queues, streams, pub/sub, and time-trigger scheduling on SQLite.
 
-License:
+Full docs:
 
-- MIT or Apache-2.0
+- [Main repo](https://github.com/russellromney/honker)
+- [Docs](https://honker.dev)
 
-Install:
+## Install
 
 ```bash
 dotnet add package Honker
 ```
 
-Current shape:
-
-- thin wrapper over the SQLite loadable extension
-- `Database.Open(...)` loads `honker-extension` and runs
-  `honker_bootstrap()`
-- typed `Queue`, `Stream`, `Outbox`, `Scheduler`, `Job`, and lock wrappers
-- async claim / listen / subscribe / outbox worker loops with
-  `CancellationToken`
-- core-backed update wakes through the loaded Honker extension
-
-Watcher backend option:
-
-- `OpenOptions.WatcherBackend = "polling"` (or `"poll"`) selects the
-  default polling backend
-- experimental `"kernel"` / `"shm"` requests route through
-  `honker-core` via the loaded Honker extension and fail loudly if that
-  extension was not built with the matching feature
-
-Current status:
-
-- queue enqueue / claim / ack / retry / fail / heartbeat / results are wired
-- stream publish / read / subscribe / offset persistence are wired
-- notify / listen, advisory locks, transactional outbox, and rate limits are wired
-- scheduler add / remove / tick / soonest / run are wired
-- delayed-claim wake and `@every` schedule support are implemented in
-  the binding, but tests only exercise them when the underlying
-  extension build exposes the corresponding SQL functions
-
-Native loading:
-
-- `Database.Open(...)` first honors `OpenOptions.ExtensionPath`
-- then `HONKER_EXTENSION_PATH`
-- then it looks for the bundled native extension from the NuGet package
-  in the app output root or `runtimes/<rid>/native/`
-
-Bundled native RID coverage:
+The NuGet package bundles the Honker SQLite extension for:
 
 - `linux-x64`
 - `linux-arm64`
 - `osx-x64`
 - `osx-arm64`
 - `win-x64`
+
+## Quick start
+
+```csharp
+using Honker;
+
+using var db = Database.Open("app.db");
+var queue = db.Queue("emails");
+
+queue.Enqueue("""{"to":"alice@example.com"}""");
+
+var job = queue.ClaimOne("worker-1");
+if (job is not null)
+{
+    SendEmail(job.PayloadRaw);
+    job.Ack();
+}
+```
+
+## Native loading
+
+`Database.Open(...)` loads the Honker extension and runs
+`honker_bootstrap()`. Native discovery checks, in order:
+
+1. `OpenOptions.ExtensionPath`
+2. `HONKER_EXTENSION_PATH`
+3. the bundled NuGet runtime asset under `runtimes/<rid>/native/`
+
+## Watcher backends
+
+`OpenOptions.WatcherBackend = "polling"` (or `"poll"`) selects the
+default stable backend. Experimental `"kernel"` / `"shm"` requests route
+through `honker-core` via the loaded extension and fail loudly if that
+extension was not built with the matching feature.
 
 ## Local test
 
@@ -71,18 +72,7 @@ dotnet test packages/honker-dotnet/tests/Honker.Tests/Honker.Tests.csproj
 
 ## Release
 
-`release-dotnet.yml` builds native assets on matching runners, combines
-them into one NuGet package, smoke-tests a consumer app, and publishes
-on `dotnet-v*` tags.
-
-Typical local release flow:
-
-```bash
-cargo build --release -p honker-extension
-mkdir -p packages/honker-dotnet/src/Honker/package-assets/runtimes/<rid>/native
-cp target/release/<native-lib-name> packages/honker-dotnet/src/Honker/package-assets/runtimes/<rid>/native/
-dotnet pack packages/honker-dotnet/src/Honker/Honker.csproj -c Release -p:PackageVersion=<version> -o artifacts/honker-dotnet
-dotnet nuget push artifacts/honker-dotnet/*.nupkg --source https://api.nuget.org/v3/index.json --api-key <key>
-```
-
-That keeps NuGet credentials out of GitHub Actions.
+The `Release · NuGet` workflow builds native assets for each supported
+RID, packs the `.nupkg`, verifies the package contains every runtime
+asset, runs a clean consumer smoke test, and publishes on `dotnet-v*`
+tags.

--- a/packages/honker-dotnet/src/Honker/Database.cs
+++ b/packages/honker-dotnet/src/Honker/Database.cs
@@ -40,7 +40,11 @@ public sealed class Database : IDisposable
         connection.Open();
         var resolvedExtensionPath = System.IO.Path.GetFullPath(extensionPath);
         InstallConnection(connection, resolvedExtensionPath, bootstrap: true);
-        using (new UpdatePoller(System.IO.Path.GetFullPath(path), resolvedExtensionPath, options.WatcherBackend))
+        using (new UpdatePoller(
+            System.IO.Path.GetFullPath(path),
+            resolvedExtensionPath,
+            options.WatcherBackend,
+            options.UpdatePollInterval))
         {
             // Probe the requested core watcher backend at open time.
         }
@@ -242,7 +246,7 @@ public sealed class Database : IDisposable
 
     internal UpdatePoller CreatePoller()
     {
-        return new UpdatePoller(Path, _extensionPath, Options.WatcherBackend);
+        return new UpdatePoller(Path, _extensionPath, Options.WatcherBackend, Options.UpdatePollInterval);
     }
 
     internal SqliteConnection CreateReadConnection()

--- a/packages/honker-dotnet/src/Honker/Honker.csproj
+++ b/packages/honker-dotnet/src/Honker/Honker.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Honker</RootNamespace>
     <IsPackable>true</IsPackable>
     <PackageId>Honker</PackageId>
-    <Version>0.2.4</Version>
+    <Version>0.2.5</Version>
     <Authors>Russell Romney</Authors>
     <Description>SQLite queue, notify/listen, streams, scheduler, and outbox bindings for .NET via the Honker loadable extension.</Description>
     <PackageTags>sqlite;queue;pubsub;notify;listen;stream;outbox;scheduler</PackageTags>

--- a/packages/honker-dotnet/src/Honker/OpenOptions.cs
+++ b/packages/honker-dotnet/src/Honker/OpenOptions.cs
@@ -5,7 +5,7 @@ namespace Honker;
 public sealed class OpenOptions
 {
     public string? ExtensionPath { get; init; }
-    public TimeSpan UpdatePollInterval { get; init; } = TimeSpan.FromMilliseconds(5);
+    public TimeSpan UpdatePollInterval { get; init; } = TimeSpan.FromMilliseconds(1);
     /// <summary>
     /// Update-detection backend implemented by honker-core through the
     /// loaded Honker extension. Accepted aliases match the core contract:

--- a/packages/honker-dotnet/src/Honker/UpdatePoller.cs
+++ b/packages/honker-dotnet/src/Honker/UpdatePoller.cs
@@ -5,9 +5,10 @@ namespace Honker;
 
 internal sealed class UpdatePoller : IDisposable
 {
-    private delegate IntPtr WatcherOpen(
+    private delegate IntPtr WatcherOpenV2(
         [MarshalAs(UnmanagedType.LPUTF8Str)] string dbPath,
         [MarshalAs(UnmanagedType.LPUTF8Str)] string? backend,
+        ulong watcherPollIntervalMs,
         byte[] error,
         UIntPtr errorLen);
 
@@ -20,13 +21,17 @@ internal sealed class UpdatePoller : IDisposable
     private readonly WatcherClose _close;
     private bool _disposed;
 
-    public UpdatePoller(string dbPath, string extensionPath, string? watcherBackend)
+    public UpdatePoller(string dbPath, string extensionPath, string? watcherBackend, TimeSpan updatePollInterval)
     {
+        if (updatePollInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentException("UpdatePollInterval must be positive", nameof(updatePollInterval));
+        }
         _library = NativeLibrary.Load(extensionPath);
         try
         {
-            var open = Marshal.GetDelegateForFunctionPointer<WatcherOpen>(
-                NativeLibrary.GetExport(_library, "honker_watcher_open")
+            var open = Marshal.GetDelegateForFunctionPointer<WatcherOpenV2>(
+                NativeLibrary.GetExport(_library, "honker_watcher_open_v2")
             );
             _wait = Marshal.GetDelegateForFunctionPointer<WatcherWait>(
                 NativeLibrary.GetExport(_library, "honker_watcher_wait")
@@ -36,7 +41,8 @@ internal sealed class UpdatePoller : IDisposable
             );
 
             var error = new byte[1024];
-            _watcher = open(dbPath, watcherBackend, error, (UIntPtr)error.Length);
+            var pollIntervalMs = Math.Max(1UL, (ulong)Math.Ceiling(updatePollInterval.TotalMilliseconds));
+            _watcher = open(dbPath, watcherBackend, pollIntervalMs, error, (UIntPtr)error.Length);
             if (_watcher == IntPtr.Zero)
             {
                 throw new InvalidOperationException(DecodeError(error));

--- a/packages/honker-dotnet/tests/Honker.Tests/BindingTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/BindingTests.cs
@@ -31,6 +31,22 @@ public sealed class BindingTests
         Assert.True(await move);
     }
 
+    [Fact]
+    public async Task OpenCustomUpdatePollIntervalDetectsCommits()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open(updatePollInterval: TimeSpan.FromMilliseconds(25));
+        var listener = db.Listen("interval");
+        await using var enumerator = listener.GetAsyncEnumerator();
+        using var writer = harness.Open();
+        writer.Notify("interval", new { ok = true });
+
+        var move = enumerator.MoveNextAsync().AsTask();
+        var completed = await Task.WhenAny(move, Task.Delay(TimeSpan.FromSeconds(2)));
+        Assert.Same(move, completed);
+        Assert.True(await move);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -1039,12 +1055,12 @@ public sealed class BindingTests
             return new TestHarness(dir, extensionPath);
         }
 
-        public Database Open(string? watcherBackend = null)
+        public Database Open(string? watcherBackend = null, TimeSpan? updatePollInterval = null)
         {
             return Database.Open(DatabasePath, new OpenOptions
             {
                 ExtensionPath = ExtensionPath,
-                UpdatePollInterval = TimeSpan.FromMilliseconds(5),
+                UpdatePollInterval = updatePollInterval ?? TimeSpan.FromMilliseconds(5),
                 WatcherBackend = watcherBackend,
             });
         }

--- a/packages/honker-ex/lib/honker.ex
+++ b/packages/honker-ex/lib/honker.ex
@@ -61,10 +61,14 @@ defmodule Honker do
   Honker extension. It accepts the same aliases as the other bindings:
   `nil`, `""`, `"poll"`, `"polling"`, `"kernel"`, `"kernel-watcher"`,
   `"shm"`, and `"shm-fast-path"`.
+
+  `:watcher_poll_interval_ms` raises the default 1 ms update watcher
+  cadence when lower idle CPU matters more than lowest-latency wakeups.
   """
   def open(path, opts) do
     extension_path = Keyword.fetch!(opts, :extension_path)
     backend = watcher_backend_param(Keyword.get(opts, :watcher_backend))
+    watcher_poll_interval_ms = Keyword.get(opts, :watcher_poll_interval_ms, 1)
 
     with {:ok, conn} <- Sqlite3.open(path),
          :ok <- Sqlite3.execute(conn, "PRAGMA busy_timeout = 5000;"),
@@ -74,7 +78,11 @@ defmodule Honker do
          :ok <- Sqlite3.execute(conn, @default_pragmas),
          :ok <- run_bare(conn, "SELECT honker_bootstrap()", []),
          {:ok, [watcher_id]} <-
-           query_first(conn, "SELECT honker_update_watcher_open(?1, ?2)", [path, backend]) do
+           query_first(conn, "SELECT honker_update_watcher_open(?1, ?2, ?3)", [
+             path,
+             backend,
+             watcher_poll_interval_ms
+           ]) do
       {:ok, %Database{conn: conn, path: path, watcher_id: watcher_id}}
     end
   end

--- a/packages/honker-ex/mix.exs
+++ b/packages/honker-ex/mix.exs
@@ -4,7 +4,7 @@ defmodule Honker.MixProject do
   def project do
     [
       app: :honker,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.17",
       description:
         "Durable queues, streams, pub/sub, and scheduler on SQLite. " <>

--- a/packages/honker-ex/test/honker_test.exs
+++ b/packages/honker-ex/test/honker_test.exs
@@ -216,6 +216,16 @@ defmodule HonkerWatcherBackendQueueTest do
     Honker.close(db)
   end
 
+  defp enqueue_stops(path, ext, count) do
+    {:ok, db} = Honker.open(path, extension_path: ext)
+
+    for _ <- 1..count do
+      {:ok, _} = Honker.Queue.enqueue(db, "shared", %{"stop" => true}, priority: -1)
+    end
+
+    Honker.close(db)
+  end
+
   defp spawn_writer(path, ext, first, count) do
     Task.async(fn -> run_helper(["writer", path, ext, to_string(first), to_string(count)]) end)
   end
@@ -252,6 +262,7 @@ defmodule HonkerWatcherBackendQueueTest do
           {worker, ready} = spawn_worker(path, ext, backend, "w1", dir)
           wait_ready(ready)
           enqueue_range(path, ext, 0, 25)
+          enqueue_stops(path, ext, 1)
           assert_int_set(Task.await(worker, 30_000), 25)
           close_pin(pin)
         end
@@ -274,6 +285,7 @@ defmodule HonkerWatcherBackendQueueTest do
           workers = for i <- 0..2, do: spawn_worker(path, ext, backend, "w#{i}", dir)
           for {_, ready} <- workers, do: wait_ready(ready)
           enqueue_range(path, ext, 0, 60)
+          enqueue_stops(path, ext, length(workers))
           results = workers |> Enum.flat_map(fn {worker, _} -> Task.await(worker, 30_000) end)
           assert_int_set(results, 60)
           assert Enum.uniq(results) |> length() == 60
@@ -303,6 +315,7 @@ defmodule HonkerWatcherBackendQueueTest do
                 do: spawn_writer(path, ext, offset, 20)
 
           Enum.each(writers, &Task.await(&1, 30_000))
+          enqueue_stops(path, ext, 1)
           assert_int_set(Task.await(worker, 30_000), 60)
           close_pin(pin)
         end
@@ -345,13 +358,19 @@ defmodule HonkerTest do
         dir = Path.join(System.tmp_dir!(), "honker-ex-#{System.unique_integer([:positive])}")
         File.mkdir_p!(dir)
         db_path = Path.join(dir, "t.db")
-        on_exit(fn -> File.rm_rf!(dir) end)
-        {:ok, %{ext: ext, db_path: db_path}}
+        {:ok, db} = Honker.open(db_path, extension_path: ext)
+
+        on_exit(fn ->
+          Honker.close(db)
+          File.rm_rf!(dir)
+        end)
+
+        {:ok, %{db: db, ext: ext, db_path: db_path}}
     end
   end
 
   test "enqueue / claim / ack round-trips", ctx do
-    {:ok, db} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+    db = ctx.db
     {:ok, id} = Honker.Queue.enqueue(db, "emails", %{"to" => "alice@example.com"})
     assert id > 0
 
@@ -365,7 +384,7 @@ defmodule HonkerTest do
   end
 
   test "retry-to-dead after max_attempts", ctx do
-    {:ok, db} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+    db = ctx.db
     db = Honker.configure_queue(db, "retries", max_attempts: 2)
 
     {:ok, _} = Honker.Queue.enqueue(db, "retries", %{"i" => 1})
@@ -390,7 +409,7 @@ defmodule HonkerTest do
   end
 
   test "notify inserts into _honker_notifications", ctx do
-    {:ok, db} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+    db = ctx.db
     {:ok, id} = Honker.notify(db, "orders", %{"id" => 42})
     assert id > 0
 

--- a/packages/honker-ex/test/honker_test.exs
+++ b/packages/honker-ex/test/honker_test.exs
@@ -2,6 +2,10 @@ defmodule HonkerWatcherBackendOptionTest do
   use ExUnit.Case, async: true
 
   @candidates [
+    "target/debug/libhonker_ext.dylib",
+    "target/debug/libhonker_ext.so",
+    "target/debug/libhonker_extension.dylib",
+    "target/debug/libhonker_extension.so",
     "target/release/libhonker_ext.dylib",
     "target/release/libhonker_ext.so",
     "target/release/libhonker_extension.dylib",
@@ -54,6 +58,20 @@ defmodule HonkerWatcherBackendOptionTest do
     end
   end
 
+  test "custom watcher poll interval detects commits" do
+    ext = find_extension() || flunk("honker extension not built")
+    dir = Path.join(System.tmp_dir!(), "honker-ex-watch-interval-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    path = Path.join(dir, "t.db")
+
+    {:ok, db} = Honker.open(path, extension_path: ext, watcher_poll_interval_ms: 25)
+    {:ok, writer} = Honker.open(path, extension_path: ext)
+    {:ok, _} = Honker.notify(writer, "interval", %{ok: true})
+    assert :changed = Honker.wait_for_update(db, 2_000)
+    Honker.close(writer)
+    Honker.close(db)
+  end
+
   test "accepts polling watcher backend aliases before opening sqlite" do
     for backend <- [nil, "", "poll", "polling"] do
       assert {:error, reason} =
@@ -85,6 +103,10 @@ defmodule HonkerWatcherBackendQueueTest do
   use ExUnit.Case, async: false
 
   @candidates [
+    "target/debug/libhonker_ext.dylib",
+    "target/debug/libhonker_ext.so",
+    "target/debug/libhonker_extension.dylib",
+    "target/debug/libhonker_extension.so",
     "target/release/libhonker_ext.dylib",
     "target/release/libhonker_ext.so",
     "target/release/libhonker_extension.dylib",
@@ -295,6 +317,10 @@ defmodule HonkerTest do
   use ExUnit.Case, async: false
 
   @candidates [
+    "target/debug/libhonker_ext.dylib",
+    "target/debug/libhonker_ext.so",
+    "target/debug/libhonker_extension.dylib",
+    "target/debug/libhonker_extension.so",
     "target/release/libhonker_ext.dylib",
     "target/release/libhonker_ext.so",
     "target/release/libhonker_extension.dylib",

--- a/packages/honker-ex/test/parity_test.exs
+++ b/packages/honker-ex/test/parity_test.exs
@@ -14,6 +14,8 @@ defmodule HonkerParityTest do
   alias Honker.{Job, Lock, Outbox, Queue, Scheduler, Stream, StreamEvent, Transaction}
 
   @candidates [
+    "target/debug/libhonker_ext.dylib",
+    "target/debug/libhonker_ext.so",
     "target/release/libhonker_ext.dylib",
     "target/release/libhonker_ext.so"
   ]
@@ -36,9 +38,13 @@ defmodule HonkerParityTest do
         dir = Path.join(System.tmp_dir!(), "honker-parity-#{System.unique_integer([:positive])}")
         File.mkdir_p!(dir)
         db_path = Path.join(dir, "t.db")
-        on_exit(fn -> File.rm_rf!(dir) end)
 
         {:ok, db} = Honker.open(db_path, extension_path: ext)
+        on_exit(fn ->
+          Honker.close(db)
+          File.rm_rf!(dir)
+        end)
+
         {:ok, %{db: db}}
     end
   end

--- a/packages/honker-ex/test/phase_mantle_test.exs
+++ b/packages/honker-ex/test/phase_mantle_test.exs
@@ -2,6 +2,10 @@ defmodule PhaseMantleTest do
   use ExUnit.Case, async: false
 
   @candidates [
+    "target/debug/libhonker_ext.dylib",
+    "target/debug/libhonker_ext.so",
+    "target/debug/libhonker_extension.dylib",
+    "target/debug/libhonker_extension.so",
     "target/release/libhonker_ext.dylib",
     "target/release/libhonker_ext.so",
     "target/release/libhonker_extension.dylib",
@@ -26,13 +30,19 @@ defmodule PhaseMantleTest do
         dir = Path.join(System.tmp_dir!(), "honker-mantle-#{System.unique_integer([:positive])}")
         File.mkdir_p!(dir)
         db_path = Path.join(dir, "t.db")
-        on_exit(fn -> File.rm_rf!(dir) end)
-        {:ok, %{ext: ext, db_path: db_path}}
+        {:ok, db} = Honker.open(db_path, extension_path: ext)
+
+        on_exit(fn ->
+          Honker.close(db)
+          File.rm_rf!(dir)
+        end)
+
+        {:ok, %{db: db, ext: ext, db_path: db_path}}
     end
   end
 
   test "schedule list round-trips fields", ctx do
-    {:ok, db} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+    db = ctx.db
     :ok =
       Honker.Scheduler.add(db,
         name: "recap",
@@ -60,7 +70,7 @@ defmodule PhaseMantleTest do
   end
 
   test "pause / resume idempotent", ctx do
-    {:ok, db} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+    db = ctx.db
     :ok =
       Honker.Scheduler.add(db,
         name: "a",
@@ -83,7 +93,7 @@ defmodule PhaseMantleTest do
   end
 
   test "update mutates fields, no-op on empty, recomputes next_fire_at on cron change", ctx do
-    {:ok, db} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+    db = ctx.db
     :ok =
       Honker.Scheduler.add(db,
         name: "t",
@@ -110,7 +120,7 @@ defmodule PhaseMantleTest do
   end
 
   test "queue cancel + get_job", ctx do
-    {:ok, db} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+    db = ctx.db
     {:ok, id} = Honker.Queue.enqueue(db, "emails", %{"to" => "alice@example.com"})
 
     {:ok, row} = Honker.Queue.get_job(db, id)
@@ -125,7 +135,7 @@ defmodule PhaseMantleTest do
   end
 
   test "cancel of processing invalidates ack", ctx do
-    {:ok, db} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+    db = ctx.db
     {:ok, id} = Honker.Queue.enqueue(db, "emails", %{"to" => "x"})
     {:ok, job} = Honker.Queue.claim_one(db, "emails", "worker-1")
     assert job.id == id
@@ -135,7 +145,7 @@ defmodule PhaseMantleTest do
   end
 
   test "paused schedule does not emit on tick", ctx do
-    {:ok, db} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+    db = ctx.db
     :ok =
       Honker.Scheduler.add(db,
         name: "due",
@@ -156,7 +166,7 @@ defmodule PhaseMantleTest do
   end
 
   test "get_job misses after ack (separate from cancel)", ctx do
-    {:ok, db} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+    db = ctx.db
     {:ok, id} = Honker.Queue.enqueue(db, "emails", %{"to" => "x"})
     {:ok, job} = Honker.Queue.claim_one(db, "emails", "worker-1")
     assert {:ok, true} = Honker.Job.ack(db, job)
@@ -164,7 +174,7 @@ defmodule PhaseMantleTest do
   end
 
   test "update payload null vs omitted distinction", ctx do
-    {:ok, db} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+    db = ctx.db
     :ok =
       Honker.Scheduler.add(db,
         name: "t",

--- a/packages/honker-ex/test/python_interop_test.exs
+++ b/packages/honker-ex/test/python_interop_test.exs
@@ -88,8 +88,13 @@ defmodule HonkerPythonInteropTest do
       dir = Path.join(System.tmp_dir!(), "honker-ex-python-#{System.unique_integer([:positive])}")
       File.mkdir_p!(dir)
       db_path = Path.join(dir, "elixir-python.db")
-      on_exit(fn -> File.rm_rf!(dir) end)
       {:ok, db} = Honker.open(db_path, extension_path: ext)
+
+      on_exit(fn ->
+        Honker.close(db)
+        File.rm_rf!(dir)
+      end)
+
       {:ok, db: db, db_path: db_path, python: python}
     end
   end

--- a/packages/honker-ex/test/smoke_test.exs
+++ b/packages/honker-ex/test/smoke_test.exs
@@ -11,6 +11,8 @@ defmodule HonkerSmokeTest do
   alias Exqlite.Sqlite3
 
   @candidates [
+    "target/debug/libhonker_ext.dylib",
+    "target/debug/libhonker_ext.so",
     "target/release/libhonker_ext.dylib",
     "target/release/libhonker_ext.so"
   ]
@@ -33,9 +35,13 @@ defmodule HonkerSmokeTest do
         dir = Path.join(System.tmp_dir!(), "honker-smoke-#{System.unique_integer([:positive])}")
         File.mkdir_p!(dir)
         db_path = Path.join(dir, "t.db")
-        on_exit(fn -> File.rm_rf!(dir) end)
 
         {:ok, db} = Honker.open(db_path, extension_path: ext)
+        on_exit(fn ->
+          Honker.close(db)
+          File.rm_rf!(dir)
+        end)
+
         {:ok, %{db: db}}
     end
   end

--- a/packages/honker-go/honker.go
+++ b/packages/honker-go/honker.go
@@ -31,6 +31,7 @@ package honker
 #include <dlfcn.h>
 
 typedef void* (*honker_watcher_open_fn)(const char*, const char*, char*, uintptr_t);
+typedef void* (*honker_watcher_open_v2_fn)(const char*, const char*, uint64_t, char*, uintptr_t);
 typedef int (*honker_watcher_wait_fn)(void*, uint64_t);
 typedef void (*honker_watcher_close_fn)(void*);
 
@@ -63,6 +64,10 @@ static void* honker_dl_sym(void* lib, const char* name, char* err, uintptr_t err
 
 static void* honker_call_watcher_open(void* fn, const char* path, const char* backend, char* err, uintptr_t err_len) {
 	return ((honker_watcher_open_fn)fn)(path, backend, err, err_len);
+}
+
+static void* honker_call_watcher_open_v2(void* fn, const char* path, const char* backend, uint64_t poll_interval_ms, char* err, uintptr_t err_len) {
+	return ((honker_watcher_open_v2_fn)fn)(path, backend, poll_interval_ms, err, err_len);
 }
 
 static int honker_call_watcher_wait(void* fn, void* watcher, uint64_t timeout_ms) {
@@ -108,6 +113,9 @@ type OpenOptions struct {
 	// aliases match the core contract exactly: "", "poll", "polling",
 	// "kernel", "kernel-watcher", "shm", and "shm-fast-path".
 	WatcherBackend string
+	// WatcherPollInterval sets the shared update watcher's polling
+	// cadence. The default is 1 ms.
+	WatcherPollInterval time.Duration
 }
 
 // driverCounter generates a unique sql.Register name per Open() so
@@ -198,7 +206,7 @@ func OpenWithOptions(path string, extensionPath string, opts OpenOptions) (*Data
 		return nil, fmt.Errorf("bootstrap: %w", err)
 	}
 	d := &Database{db: sqlDB, dbPath: path}
-	d.updates, err = newUpdateWatcher(extensionPath, path, opts.WatcherBackend)
+	d.updates, err = newUpdateWatcher(extensionPath, path, opts.WatcherBackend, opts.WatcherPollInterval)
 	if err != nil {
 		sqlDB.Close()
 		return nil, fmt.Errorf("update watcher: %w", err)
@@ -247,12 +255,12 @@ type updateWatcher struct {
 	closeFn  unsafe.Pointer
 }
 
-func newUpdateWatcher(extensionPath string, dbPath string, backend string) (*updateWatcher, error) {
+func newUpdateWatcher(extensionPath string, dbPath string, backend string, pollInterval time.Duration) (*updateWatcher, error) {
 	lib, openFn, waitFn, closeFn, err := loadCoreWatcherABI(extensionPath)
 	if err != nil {
 		return nil, err
 	}
-	watcher, err := openCoreWatcher(openFn, dbPath, backend)
+	watcher, err := openCoreWatcher(openFn, dbPath, backend, pollInterval)
 	if err != nil {
 		C.dlclose(lib)
 		return nil, err
@@ -349,7 +357,7 @@ func loadCoreWatcherABI(extensionPath string) (lib unsafe.Pointer, openFn unsafe
 		}
 	}()
 
-	openFn, err = lookupCoreWatcherSymbol(lib, "honker_watcher_open")
+	openFn, err = lookupCoreWatcherSymbol(lib, "honker_watcher_open_v2")
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -375,16 +383,24 @@ func lookupCoreWatcherSymbol(lib unsafe.Pointer, name string) (unsafe.Pointer, e
 	return sym, nil
 }
 
-func openCoreWatcher(openFn unsafe.Pointer, dbPath string, backend string) (unsafe.Pointer, error) {
+func openCoreWatcher(openFn unsafe.Pointer, dbPath string, backend string, pollInterval time.Duration) (unsafe.Pointer, error) {
 	cPath := C.CString(dbPath)
 	defer C.free(unsafe.Pointer(cPath))
 	cBackend := C.CString(backend)
 	defer C.free(unsafe.Pointer(cBackend))
+	if pollInterval == 0 {
+		pollInterval = time.Millisecond
+	}
+	if pollInterval < 0 {
+		return nil, fmt.Errorf("watcher poll interval must be positive")
+	}
+	pollIntervalMs := uint64((pollInterval + time.Millisecond - 1) / time.Millisecond)
 	errBuf := make([]byte, 1024)
-	watcher := C.honker_call_watcher_open(
+	watcher := C.honker_call_watcher_open_v2(
 		openFn,
 		cPath,
 		cBackend,
+		C.uint64_t(pollIntervalMs),
 		(*C.char)(unsafe.Pointer(&errBuf[0])),
 		C.uintptr_t(len(errBuf)),
 	)

--- a/packages/honker-go/honker_test.go
+++ b/packages/honker-go/honker_test.go
@@ -19,6 +19,10 @@ func findExtension(t *testing.T) string {
 	// thisFile = .../packages/honker-go/honker_test.go
 	repo := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
 	candidates := []string{
+		filepath.Join(repo, "target/debug/libhonker_ext.dylib"),
+		filepath.Join(repo, "target/debug/libhonker_ext.so"),
+		filepath.Join(repo, "target/debug/libhonker_extension.dylib"),
+		filepath.Join(repo, "target/debug/libhonker_extension.so"),
 		filepath.Join(repo, "target/release/libhonker_ext.dylib"),
 		filepath.Join(repo, "target/release/libhonker_ext.so"),
 		filepath.Join(repo, "target/release/libhonker_extension.dylib"),
@@ -192,6 +196,34 @@ func TestWatcherBackendOptionsDetectCommits(t *testing.T) {
 				t.Fatalf("watcher backend %q did not observe commit", backend)
 			}
 		})
+	}
+}
+
+func TestWatcherPollIntervalOptionDetectsCommits(t *testing.T) {
+	extPath := findExtension(t)
+	dbPath := filepath.Join(t.TempDir(), "t.db")
+	db, err := OpenWithOptions(dbPath, extPath, OpenOptions{WatcherPollInterval: 25 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	subID, updateCh := db.updates.subscribe()
+	defer db.updates.unsubscribe(subID)
+
+	writer, err := Open(dbPath, extPath)
+	if err != nil {
+		t.Fatalf("open writer: %v", err)
+	}
+	defer writer.Close()
+	if _, err := writer.Notify("interval", map[string]any{"ok": true}); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+
+	select {
+	case <-updateCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("custom watcher poll interval did not observe commit")
 	}
 }
 

--- a/packages/honker-node/Cargo.toml
+++ b/packages/honker-node/Cargo.toml
@@ -26,7 +26,7 @@ shm-fast-path = ["honker-core/shm-fast-path"]
 # inside the main honker repo (whether directly or as a submodule).
 # Standalone hacking on this repo alone requires honker-core on
 # crates.io (future) or a manual path override in .cargo/config.toml.
-honker-core = { path = "../../honker-core", version = "0.2.3" }
+honker-core = { path = "../../honker-core", version = "0.2.4" }
 napi = { version = "3.2", features = ["async", "serde-json", "tokio_rt"] }
 napi-derive = "3.2"
 parking_lot = "0.12.5"
@@ -35,7 +35,7 @@ serde_json = "1.0"
 tokio = { version = "1.52.1", features = ["rt", "rt-multi-thread"] }
 
 [target.'cfg(windows)'.dependencies]
-honker-core = { path = "../../honker-core", version = "0.2.3", features = ["bundled-sqlite"] }
+honker-core = { path = "../../honker-core", version = "0.2.4", features = ["bundled-sqlite"] }
 
 [build-dependencies]
 napi-build = "2.2"

--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -825,8 +825,22 @@ class Database {
 }
 
 module.exports = function buildApi(nativeBinding) {
-  function open(path, maxReaders, watcherBackend) {
-    return new Database(nativeBinding.open(path, maxReaders, watcherBackend));
+  function open(path, maxReaders, watcherBackend, watcherPollIntervalMs) {
+    if (maxReaders && typeof maxReaders === 'object') {
+      const opts = maxReaders;
+      return new Database(nativeBinding.open(
+        path,
+        opts.maxReaders,
+        opts.watcherBackend,
+        opts.watcherPollIntervalMs,
+      ));
+    }
+    return new Database(nativeBinding.open(
+      path,
+      maxReaders,
+      watcherBackend,
+      watcherPollIntervalMs,
+    ));
   }
 
   return {

--- a/packages/honker-node/index.d.ts
+++ b/packages/honker-node/index.d.ts
@@ -73,8 +73,11 @@ export declare class UpdateEvents {
  * - `"kernel"` — kernel filesystem notifications (experimental)
  * - `"shm"` — mmap `-shm` fast path (experimental)
  *
+ * `watcherPollIntervalMs` raises the default 1 ms watcher cadence when
+ * lower idle CPU matters more than lowest-latency wakeups.
+ *
  * Experimental backends require the corresponding Cargo feature. Builds
  * without that feature reject an explicit request instead of silently
  * falling back to polling.
  */
-export declare function open(path: string, maxReaders?: number | undefined | null, watcherBackend?: string | undefined | null): Database
+export declare function open(path: string, maxReaders?: number | undefined | null, watcherBackend?: string | undefined | null, watcherPollIntervalMs?: number | undefined | null): Database

--- a/packages/honker-node/index.js
+++ b/packages/honker-node/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-android-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-android-arm-eabi')
         const bindingPackageVersion = require('@russellthehippo/honker-node-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-x64-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-x64-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-ia32-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-arm64-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@russellthehippo/honker-node-darwin-universal')
       const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-darwin-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-darwin-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-freebsd-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-freebsd-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-x64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-x64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm-musleabihf')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-loong64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-loong64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-riscv64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-riscv64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-linux-ppc64-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-linux-s390x-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-arm')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.3.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.3.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.3.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/packages/honker-node/npm/darwin-arm64/package.json
+++ b/packages/honker-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-darwin-arm64",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "cpu": [
     "arm64"
   ],

--- a/packages/honker-node/npm/darwin-x64/package.json
+++ b/packages/honker-node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-darwin-x64",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "cpu": [
     "x64"
   ],

--- a/packages/honker-node/npm/linux-arm64-gnu/package.json
+++ b/packages/honker-node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-linux-arm64-gnu",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "cpu": [
     "arm64"
   ],

--- a/packages/honker-node/npm/linux-x64-gnu/package.json
+++ b/packages/honker-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-linux-x64-gnu",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "cpu": [
     "x64"
   ],

--- a/packages/honker-node/package.json
+++ b/packages/honker-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Node binding for honker — durable queues, streams, pub/sub, and scheduler on SQLite.",
   "main": "wrapper.js",
   "types": "wrapper.d.ts",
@@ -44,9 +44,9 @@
     "url": "https://github.com/russellromney/honker"
   },
   "optionalDependencies": {
-    "@russellthehippo/honker-node-darwin-arm64": "0.3.3",
-    "@russellthehippo/honker-node-darwin-x64": "0.3.3",
-    "@russellthehippo/honker-node-linux-x64-gnu": "0.3.3",
-    "@russellthehippo/honker-node-linux-arm64-gnu": "0.3.3"
+    "@russellthehippo/honker-node-darwin-arm64": "0.3.4",
+    "@russellthehippo/honker-node-darwin-x64": "0.3.4",
+    "@russellthehippo/honker-node-linux-x64-gnu": "0.3.4",
+    "@russellthehippo/honker-node-linux-arm64-gnu": "0.3.4"
   }
 }

--- a/packages/honker-node/src/lib.rs
+++ b/packages/honker-node/src/lib.rs
@@ -41,9 +41,16 @@ fn napi_err(e: impl std::fmt::Display) -> napi::Error {
     napi::Error::new(napi::Status::GenericFailure, e.to_string())
 }
 
-fn parse_watcher_backend(backend: Option<String>) -> Result<WatcherConfig> {
+fn parse_watcher_config(
+    backend: Option<String>,
+    watcher_poll_interval_ms: Option<u32>,
+) -> Result<WatcherConfig> {
     honker_core::WatcherBackend::parse(backend.as_deref())
-        .map(|backend| WatcherConfig { backend })
+        .map(WatcherConfig::with_backend)
+        .and_then(|config| match watcher_poll_interval_ms {
+            Some(ms) => config.with_poll_interval(std::time::Duration::from_millis(ms as u64)),
+            None => Ok(config),
+        })
         .map_err(napi_err)
 }
 
@@ -435,6 +442,9 @@ impl UpdateEvents {
 /// - `"kernel"` — kernel filesystem notifications (experimental)
 /// - `"shm"` — mmap `-shm` fast path (experimental)
 ///
+/// `watcherPollIntervalMs` raises the default 1 ms watcher cadence when
+/// lower idle CPU matters more than lowest-latency wakeups.
+///
 /// Experimental backends require the corresponding Cargo feature. Builds
 /// without that feature reject an explicit request instead of silently
 /// falling back to polling.
@@ -443,9 +453,10 @@ pub fn open(
     path: String,
     max_readers: Option<u32>,
     watcher_backend: Option<String>,
+    watcher_poll_interval_ms: Option<u32>,
 ) -> Result<Database> {
     let max_readers = max_readers.unwrap_or(8).max(1) as usize;
-    let watcher_config = parse_watcher_backend(watcher_backend)?;
+    let watcher_config = parse_watcher_config(watcher_backend, watcher_poll_interval_ms)?;
     let writer_conn = open_conn(&path, true).map_err(napi_err)?;
     // Register every honker_* SQL scalar on the writer connection so
     // Node callers get the full queue / scheduler / stream surface

--- a/packages/honker-node/test/basic.js
+++ b/packages/honker-node/test/basic.js
@@ -147,6 +147,35 @@ test('updateEvents fires on commit', async () => {
   }
 });
 
+test('custom watcherPollIntervalMs still fires on commit', async () => {
+  const { path: dbPath, cleanup } = tmpdb();
+  let db;
+  try {
+    db = lit.open(dbPath, { watcherPollIntervalMs: 25 });
+    {
+      const tx = db.transaction();
+      tx.execute('CREATE TABLE t (n INTEGER)');
+      tx.commit();
+    }
+    const ev = db.updateEvents();
+    setTimeout(() => {
+      const tx = db.transaction();
+      tx.execute('INSERT INTO t (n) VALUES (1)');
+      tx.commit();
+    }, 50);
+    await Promise.race([
+      ev.next(),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('custom watcher interval did not observe commit')), 1000)
+      ),
+    ]);
+    ev.close();
+  } finally {
+    db?.close();
+    cleanup();
+  }
+});
+
 test('updateEvents dropped without close() still releases the watcher thread', async () => {
   // Create+drop many UpdateEvents instances without calling .close() on
   // any of them. Dropping must cascade to the core UpdateWatcher's Drop,

--- a/packages/honker-node/test/parity.test.js
+++ b/packages/honker-node/test/parity.test.js
@@ -609,7 +609,7 @@ test('claimWaker: returns immediately when a job is already pending', async () =
   }
 });
 
-test('claimWaker: wakes when runAt deadline arrives', async () => {
+test('claimWaker: wakes when runAt deadline arrives', { timeout: 12_000 }, async () => {
   const { path: p, cleanup } = tmpdb();
   try {
     const db = honker.open(p);
@@ -621,7 +621,7 @@ test('claimWaker: wakes when runAt deadline arrives', async () => {
     const t0 = Date.now();
     const job = await Promise.race([
       waker.next('w1'),
-      new Promise((resolve) => setTimeout(() => resolve(null), 5000)),
+      new Promise((resolve) => setTimeout(() => resolve(null), 8000)),
     ]);
     const dt = Date.now() - t0;
     assert.ok(job, 'claimWaker timed out waiting for runAt job');
@@ -631,7 +631,7 @@ test('claimWaker: wakes when runAt deadline arrives', async () => {
       `runAt wake came too early: ${dt}ms (expected about ${msUntilDue}ms)`,
     );
     assert.ok(
-      dt <= msUntilDue + 2500,
+      dt <= msUntilDue + 5000,
       `runAt wake came too late: ${dt}ms (expected about ${msUntilDue}ms)`,
     );
     job.ack();

--- a/packages/honker-node/wrapper.d.ts
+++ b/packages/honker-node/wrapper.d.ts
@@ -173,7 +173,14 @@ export class Database {
   sweepResults(): number
 }
 
-export function open(path: string, maxReaders?: number | null, watcherBackend?: string | null): Database
+export interface OpenOptions {
+  maxReaders?: number | null
+  watcherBackend?: string | null
+  watcherPollIntervalMs?: number | null
+}
+
+export function open(path: string, options?: OpenOptions): Database
+export function open(path: string, maxReaders?: number | null, watcherBackend?: string | null, watcherPollIntervalMs?: number | null): Database
 
 export const native: any
 export const NativeDatabase: any

--- a/packages/honker-rs/Cargo.lock
+++ b/packages/honker-rs/Cargo.lock
@@ -248,7 +248,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "honker"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "honker-core",
  "parking_lot",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "honker-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "file-id",

--- a/packages/honker-rs/Cargo.toml
+++ b/packages/honker-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honker"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 description = "SQLite-native task runtime: durable queues, streams, pub/sub, and scheduler. Ergonomic Rust wrapper over honker-core."
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ shm-fast-path = ["honker-core/shm-fast-path"]
 # `path` resolves when this repo is a submodule inside the main
 # honker repo; `version` is what Cargo uses when honker-rs is
 # consumed from crates.io.
-honker-core = { path = "../../honker-core", version = "0.2.3" }
+honker-core = { path = "../../honker-core", version = "0.2.4" }
 rusqlite = { version = "0.39", features = ["functions"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -31,7 +31,7 @@ thiserror = "2"
 parking_lot = "0.12"
 
 [target.'cfg(windows)'.dependencies]
-honker-core = { path = "../../honker-core", version = "0.2.3", features = ["bundled-sqlite"] }
+honker-core = { path = "../../honker-core", version = "0.2.4", features = ["bundled-sqlite"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/packages/honker-rs/src/lib.rs
+++ b/packages/honker-rs/src/lib.rs
@@ -65,7 +65,18 @@ impl OpenOptions {
     pub fn watcher_backend(mut self, backend: impl AsRef<str>) -> Result<Self> {
         let backend =
             honker_core::WatcherBackend::parse(Some(backend.as_ref())).map_err(Error::Core)?;
-        self.watcher_config = WatcherConfig { backend };
+        self.watcher_config.backend = backend;
+        Ok(self)
+    }
+
+    /// Set the shared update watcher's polling cadence. The default is
+    /// 1 ms. Raise this when lower idle CPU matters more than the
+    /// lowest-latency cross-process wakeups.
+    pub fn watcher_poll_interval(mut self, interval: Duration) -> Result<Self> {
+        self.watcher_config = self
+            .watcher_config
+            .with_poll_interval(interval)
+            .map_err(Error::Core)?;
         Ok(self)
     }
 }

--- a/packages/honker-rs/tests/surface.rs
+++ b/packages/honker-rs/tests/surface.rs
@@ -581,6 +581,26 @@ fn update_events_wake_on_commit() {
     assert_eq!(got, Some(()), "should wake within 2s of the commit");
 }
 
+#[test]
+fn custom_watcher_poll_interval_wakes_on_commit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let opts = OpenOptions::default()
+        .watcher_poll_interval(Duration::from_millis(25))
+        .unwrap();
+    let db = Database::open_with_options(tmp.path().join("t.db"), opts).unwrap();
+
+    let events = db.update_events();
+
+    let db2 = db.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(50));
+        db2.notify("anything", &json!({})).unwrap();
+    });
+
+    let got = events.recv_timeout(Duration::from_secs(2)).unwrap();
+    assert_eq!(got, Some(()), "should wake with custom poll interval");
+}
+
 fn open_backend_or_skip(path: &Path, backend: Option<&str>) -> Option<Database> {
     match backend {
         Some(name) => match OpenOptions::default().watcher_backend(name) {

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -113,11 +113,11 @@ module Honker
   end
 
   class CoreWatcher
-    def initialize(db_path, extension_path, backend)
+    def initialize(db_path, extension_path, backend, watcher_poll_interval_ms)
       @lib = Fiddle.dlopen(extension_path)
       @open = Fiddle::Function.new(
-        @lib["honker_watcher_open"],
-        [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T],
+        @lib["honker_watcher_open_v2"],
+        [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_LONG_LONG, Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T],
         Fiddle::TYPE_VOIDP,
       )
       @wait = Fiddle::Function.new(
@@ -131,7 +131,13 @@ module Honker
         Fiddle::TYPE_VOID,
       )
       err = "\0" * 1024
-      @handle = @open.call(db_path.to_s, backend.to_s, err, err.bytesize)
+      @handle = @open.call(
+        db_path.to_s,
+        backend.to_s,
+        watcher_poll_interval_ms || 1,
+        err,
+        err.bytesize,
+      )
       return unless @handle.to_i.zero?
 
       raise ArgumentError, err.delete_suffix("\0").split("\0", 2).first
@@ -171,9 +177,13 @@ module Honker
     attr_reader :db
 
     def initialize(path, extension_path: nil, watcher_backend: nil,
+                   watcher_poll_interval_ms: nil,
                    extension_resolver: ExtensionResolver.new)
       unless watcher_backend.nil? || watcher_backend.is_a?(String)
         raise ArgumentError, "unknown watcher backend"
+      end
+      unless watcher_poll_interval_ms.nil? || watcher_poll_interval_ms.to_i.positive?
+        raise ArgumentError, "watcher_poll_interval_ms must be positive"
       end
 
       resolved_extension = extension_resolver.resolve(extension_path)
@@ -186,7 +196,7 @@ module Honker
       @db.enable_load_extension(false)
       @db.execute_batch(DEFAULT_PRAGMAS)
       @db.execute("SELECT honker_bootstrap()")
-      @watcher = CoreWatcher.new(path, resolved_extension, watcher_backend)
+      @watcher = CoreWatcher.new(path, resolved_extension, watcher_backend, watcher_poll_interval_ms)
     end
 
     def close

--- a/packages/honker-ruby/lib/honker/version.rb
+++ b/packages/honker-ruby/lib/honker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Honker
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/packages/honker-ruby/spec/honker_spec.rb
+++ b/packages/honker-ruby/spec/honker_spec.rb
@@ -11,6 +11,10 @@ REPO_ROOT = File.expand_path("../../..", __dir__)
 
 def find_extension
   candidates = %w[
+    target/debug/libhonker_ext.dylib
+    target/debug/libhonker_ext.so
+    target/debug/libhonker_extension.dylib
+    target/debug/libhonker_extension.so
     target/release/libhonker_ext.dylib
     target/release/libhonker_ext.so
     target/release/libhonker_extension.dylib
@@ -107,6 +111,22 @@ class HonkerWatcherBackendOptionTest < Minitest::Test
         writer.close
         db.close
       end
+    end
+  end
+
+  def test_custom_watcher_poll_interval_detects_commits
+    require_extension_loading!
+    ext = find_extension
+    skip "honker extension not built — run `cargo build -p honker-extension --release`" unless ext
+
+    Dir.mktmpdir("honker-ruby-watch-interval-") do |dir|
+      path = File.join(dir, "t.db")
+      db = Honker::Database.new(path, extension_path: ext, watcher_poll_interval_ms: 25)
+      writer = Honker::Database.new(path, extension_path: ext)
+      writer.notify("interval", { ok: true })
+      assert db.wait_for_update(2), "custom watcher poll interval did not observe commit"
+      writer.close
+      db.close
     end
   end
 

--- a/packages/honker-ruby/spec/parity_spec.rb
+++ b/packages/honker-ruby/spec/parity_spec.rb
@@ -14,6 +14,8 @@ REPO_ROOT = File.expand_path("../../..", __dir__) unless defined?(REPO_ROOT)
 
 def find_ext_parity
   %w[
+    target/debug/libhonker_ext.dylib
+    target/debug/libhonker_ext.so
     target/release/libhonker_ext.dylib
     target/release/libhonker_ext.so
   ].each do |rel|

--- a/packages/honker-ruby/spec/phase_mantle_spec.rb
+++ b/packages/honker-ruby/spec/phase_mantle_spec.rb
@@ -11,6 +11,10 @@ REPO_ROOT = File.expand_path("../../..", __dir__) unless defined?(REPO_ROOT)
 unless defined?(find_extension)
   def find_extension
     %w[
+      target/debug/libhonker_ext.dylib
+      target/debug/libhonker_ext.so
+      target/debug/libhonker_extension.dylib
+      target/debug/libhonker_extension.so
       target/release/libhonker_ext.dylib
       target/release/libhonker_ext.so
       target/release/libhonker_extension.dylib

--- a/packages/honker-ruby/spec/setup_helpers_spec.rb
+++ b/packages/honker-ruby/spec/setup_helpers_spec.rb
@@ -17,6 +17,10 @@ REPO_ROOT = File.expand_path("../../..", __dir__) unless defined?(REPO_ROOT)
 unless defined?(find_extension)
   def find_extension
     %w[
+      target/debug/libhonker_ext.dylib
+      target/debug/libhonker_ext.so
+      target/debug/libhonker_extension.dylib
+      target/debug/libhonker_extension.so
       target/release/libhonker_ext.dylib
       target/release/libhonker_ext.so
       target/release/libhonker_extension.dylib

--- a/packages/honker-ruby/spec/smoke_spec.rb
+++ b/packages/honker-ruby/spec/smoke_spec.rb
@@ -15,6 +15,8 @@ REPO_ROOT = File.expand_path("../../..", __dir__) unless defined?(REPO_ROOT)
 
 def find_ext
   %w[
+    target/debug/libhonker_ext.dylib
+    target/debug/libhonker_ext.so
     target/release/libhonker_ext.dylib
     target/release/libhonker_ext.so
   ].each do |rel|

--- a/packages/honker/Cargo.toml
+++ b/packages/honker/Cargo.toml
@@ -27,10 +27,10 @@ kernel-watcher = ["honker-core/kernel-watcher"]
 shm-fast-path = ["honker-core/shm-fast-path"]
 
 [dependencies]
-honker-core = { path = "../../honker-core", version = "0.2.3" }
+honker-core = { path = "../../honker-core", version = "0.2.4" }
 parking_lot = "0.12.5"
 pyo3 = { version = "0.28.3", features = ["extension-module", "abi3-py311"] }
 rusqlite = { version = "0.39.0", features = ["functions", "hooks"] }
 
 [target.'cfg(windows)'.dependencies]
-honker-core = { path = "../../honker-core", version = "0.2.3", features = ["bundled-sqlite"] }
+honker-core = { path = "../../honker-core", version = "0.2.4", features = ["bundled-sqlite"] }

--- a/packages/honker/pyproject.toml
+++ b/packages/honker/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "honker"
-version = "0.2.5"
+version = "0.2.6"
 description = "Durable queues, streams, pub/sub, and cron scheduler on SQLite. One file, zero servers."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/honker/python/honker/_honker.py
+++ b/packages/honker/python/honker/_honker.py
@@ -7,9 +7,14 @@ from collections import deque
 from typing import Any, AsyncIterator, Callable, Optional
 
 
-def _core_open(path, max_readers, watcher_backend=None):
+def _core_open(path, max_readers, watcher_backend=None, watcher_poll_interval_ms=None):
     from honker._honker_native import open as _open
-    return _open(path, max_readers=max_readers, watcher_backend=watcher_backend)
+    return _open(
+        path,
+        max_readers=max_readers,
+        watcher_backend=watcher_backend,
+        watcher_poll_interval_ms=watcher_poll_interval_ms,
+    )
 
 
 async def _raise_if_dead(awaitable):
@@ -1214,6 +1219,7 @@ def open(
     path: str,
     max_readers: int = 8,
     watcher_backend: Optional[str] = None,
+    watcher_poll_interval_ms: Optional[int] = None,
 ) -> Database:
     """Open a Honker database at `path`.
 
@@ -1226,9 +1232,15 @@ def open(
 
     Wheels not built with the requested experimental feature raise a
     `ValueError` instead of silently falling back to polling.
+
+    `watcher_poll_interval_ms` raises the default 1 ms watcher cadence
+    when lower idle CPU matters more than lowest-latency wakeups.
     """
     return Database(_core_open(
-        path, max_readers=max_readers, watcher_backend=watcher_backend
+        path,
+        max_readers=max_readers,
+        watcher_backend=watcher_backend,
+        watcher_poll_interval_ms=watcher_poll_interval_ms,
     ))
 
 

--- a/packages/honker/src/lib.rs
+++ b/packages/honker/src/lib.rs
@@ -22,9 +22,16 @@ fn core_err<E: std::fmt::Display>(e: E) -> PyErr {
     PyRuntimeError::new_err(e.to_string())
 }
 
-fn parse_watcher_backend(backend: Option<String>) -> PyResult<WatcherConfig> {
+fn parse_watcher_config(
+    backend: Option<String>,
+    watcher_poll_interval_ms: Option<u64>,
+) -> PyResult<WatcherConfig> {
     honker_core::WatcherBackend::parse(backend.as_deref())
-        .map(|backend| WatcherConfig { backend })
+        .map(WatcherConfig::with_backend)
+        .and_then(|config| match watcher_poll_interval_ms {
+            Some(ms) => config.with_poll_interval(std::time::Duration::from_millis(ms)),
+            None => Ok(config),
+        })
         .map_err(pyo3::exceptions::PyValueError::new_err)
 }
 
@@ -172,13 +179,14 @@ struct Database {
 #[pymethods]
 impl Database {
     #[new]
-    #[pyo3(signature = (path, max_readers=8, watcher_backend=None))]
+    #[pyo3(signature = (path, max_readers=8, watcher_backend=None, watcher_poll_interval_ms=None))]
     fn new(
         path: String,
         max_readers: usize,
         watcher_backend: Option<String>,
+        watcher_poll_interval_ms: Option<u64>,
     ) -> PyResult<Self> {
-        let watcher_config = parse_watcher_backend(watcher_backend)?;
+        let watcher_config = parse_watcher_config(watcher_backend, watcher_poll_interval_ms)?;
         // Writer conn registers the notify() SQL function + ensures
         // _honker_notifications exists. Readers just SELECT.
         let writer_conn = open_conn(&path, true).map_err(core_err)?;
@@ -650,13 +658,14 @@ impl UpdateEvents {
 // ---------------------------------------------------------------------
 
 #[pyfunction]
-#[pyo3(signature = (path, max_readers=8, watcher_backend=None))]
+#[pyo3(signature = (path, max_readers=8, watcher_backend=None, watcher_poll_interval_ms=None))]
 fn open(
     path: String,
     max_readers: usize,
     watcher_backend: Option<String>,
+    watcher_poll_interval_ms: Option<u64>,
 ) -> PyResult<Database> {
-    Database::new(path, max_readers, watcher_backend)
+    Database::new(path, max_readers, watcher_backend, watcher_poll_interval_ms)
 }
 
 /// Compute the next unix timestamp strictly after `from_unix` that

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -82,7 +82,10 @@ def test_extension_info_loads_sqlite_extension_when_available(tmp_path):
 
     conn = sqlite3.connect(str(tmp_path / "extension-info.db"))
     conn.enable_load_extension(True)
-    conn.load_extension(path, entrypoint=entrypoint)
+    try:
+        conn.load_extension(path, entrypoint=entrypoint)
+    except TypeError:
+        conn.execute("SELECT load_extension(?, ?)", (path, entrypoint))
     conn.execute("SELECT honker_bootstrap()")
 
 

--- a/tests/test_watcher_backends.py
+++ b/tests/test_watcher_backends.py
@@ -108,6 +108,12 @@ async def test_watcher_backend_detects_commits(db_path, backend):
     )
 
 
+async def test_custom_watcher_poll_interval_detects_commits(db_path):
+    db = honker.open(db_path, watcher_poll_interval_ms=25)
+    counted = await _drive_commits_and_count_wakes(db, n=2, spacing_ms=60)
+    assert counted >= 2
+
+
 async def test_unknown_watcher_backend_raises(db_path):
     with pytest.raises(ValueError, match="unknown watcher backend"):
         honker.open(db_path, watcher_backend="bogus")


### PR DESCRIPTION
## Summary
- tighten README/docs positioning and binding support notes
- add configurable watcher poll interval in core and all maintained bindings
- add focused custom-interval watcher tests across bindings

## Verification
- cargo check
- cargo test -p honker-core watcher_config_rejects_zero_poll_interval
- cargo test --test surface custom_watcher_poll_interval_wakes_on_commit
- go test ./...
- bun test test/basic.test.ts
- node --test test/basic.js
- dotnet test tests/Honker.Tests/Honker.Tests.csproj --filter OpenCustomUpdatePollIntervalDetectsCommits
- mix test test/honker_test.exs:61 --trace
- Python direct asyncio smoke with watcher_poll_interval_ms=25
- zig build test -Dsqlite-prefix=/opt/homebrew/opt/sqlite -Djson-prefix=/opt/homebrew/opt/nlohmann-json -Dhonker-ext=/Users/russellromney/.codex/worktrees/2612/honker/packages/honker-cpp/../../target/debug/libhonker_ext.dylib

Note: Ruby custom interval test is added but skipped locally because the available sqlite3 gem lacks loadable-extension support.