### PR TITLE
docs: fix scheduler README snippet and document queue-in-transaction deadlock

### DIFF
--- a/packages/honker/README.md
+++ b/packages/honker/README.md
@@ -65,23 +65,34 @@ import time
 q.enqueue({"to": "later@example.com"}, run_at=int(time.time()) + 10)
 ```
 
-Recurring schedules use `schedule` expressions:
+Recurring schedules are registered on a `Scheduler`. Build the schedule with
+`crontab(expr)` or `every_s(n)`, then run the scheduler loop (it enqueues onto
+the target queue on each boundary; a normal worker claims the jobs):
 
 ```python
-sched = db.scheduler()
-sched.add("fast", queue="emails", schedule="@every 1s", payload={"kind": "tick"})
+from honker import Scheduler, crontab, every_s
+
+sched = Scheduler(db)
+sched.add(name="fast", queue="emails", schedule=every_s(1), payload={"kind": "tick"})
+sched.add(name="nightly", queue="emails", schedule=crontab("0 3 * * *"))
+
+await sched.run()  # acquires the leader lock and fires due tasks
 ```
 
-Supported schedule forms:
+`add()` is keyword-only and `schedule` must be a `CronSchedule` (from `crontab`
+or `every_s`), not a raw string. Supported schedule expressions:
 
-- 5-field cron: `0 3 * * *`
-- 6-field cron: `*/2 * * * * *`
-- interval: `@every 1s`
+- 5-field cron: `crontab("0 3 * * *")`
+- 6-field cron: `crontab("*/2 * * * * *")`
+- interval: `every_s(1)` (equivalently `crontab("@every 1s")`)
 
 ## Notes
 
 - `claim()` wakes on database updates and on due deadlines like `run_at`.
 - `schedule` is the canonical recurring-schedule name.
 - `cron` still works as a compatibility alias in older call sites.
+- Construct `db.queue(name)` handles **outside** an open `db.transaction()` (the
+  first call for a name runs its own schema-init transaction — a nested one
+  deadlocks). Create the handle first, then pass `tx=` to `enqueue`.
 
 For streams, notify/listen, tasks, SQL extension usage, and full scheduler docs, see the main repo and docs site.

--- a/packages/honker/python/honker/_honker.py
+++ b/packages/honker/python/honker/_honker.py
@@ -216,6 +216,12 @@ class Queue:
         # so this binding and the SQLite loadable extension can't drift
         # on column counts. View + schema-version cleanup are
         # Python-binding-specific and stay here.
+        #
+        # NOTE: this opens its own transaction, so a Queue must not be
+        # constructed while a caller's `db.transaction()` is already open —
+        # the nested BEGIN deadlocks the single write connection. See the
+        # warning in `Database.queue`. Construct queues outside the
+        # transaction and pass `tx=` to `enqueue`.
         with self.db.transaction() as tx:
             tx.bootstrap_honker_schema()
             # Inspection view: UNION live + dead with a synthetic `state`.
@@ -1131,6 +1137,28 @@ class Database:
         visibility_timeout_s: int = 300,
         max_attempts: int = 3,
     ) -> Queue:
+        """Get (or lazily create) the queue named `name`.
+
+        Handles are cached per name, so repeated calls are cheap and return
+        the same object.
+
+        IMPORTANT — construct outside an open transaction. The *first* call
+        for a given name initializes the queue's schema in its own
+        transaction. Calling it for a brand-new name while a
+        ``with db.transaction()`` block is already open deadlocks: the nested
+        ``BEGIN`` blocks on the single write connection the outer transaction
+        holds, and the wait happens in the native extension (holding the GIL),
+        so it can't be interrupted. Create the handle first, then pass
+        ``tx=`` to :meth:`Queue.enqueue` inside the transaction::
+
+            emails = db.queue("emails")          # construct up front
+            with db.transaction() as tx:
+                tx.execute("INSERT INTO orders ...", [...])
+                emails.enqueue(payload, tx=tx)   # atomic outbox handoff
+
+        (Re-fetching an already-constructed name inside a transaction is fine —
+        only first construction runs the schema init.)
+        """
         existing = self._queues.get(name)
         if existing is not None:
             return existing
@@ -1144,6 +1172,14 @@ class Database:
         return q
 
     def stream(self, name: str) -> Stream:
+        """Get (or lazily create) the durable stream named `name`.
+
+        Handles are cached per name. Unlike :meth:`queue`, stream construction
+        does not run a schema-init transaction, so it is safe to call inside an
+        open ``with db.transaction()`` block. The common pattern is still to
+        construct the handle up front and pass ``tx=`` to
+        :meth:`Stream.publish` so the event commits atomically with the work.
+        """
         existing = self._streams.get(name)
         if existing is not None:
             return existing


### PR DESCRIPTION
## Summary

Two documentation bugs in the Python bindings, both found while building an app
against `honker` 0.2.6 and verified against this repo's source and the published
wheel. **Docs/docstrings only — no behavior change.**

## 1. Quick-start scheduler snippet doesn't work

`packages/honker/README.md` showed:

```python
sched = db.scheduler()
sched.add("fast", queue="emails", schedule="@every 1s", payload={"kind": "tick"})
```

Every line of that fails against the real API:

- `Database` has no `scheduler()` method (`hasattr(db, "scheduler")` is `False`).
- `Scheduler.add()` is keyword-only, so the positional `"fast"` is a `TypeError`.
- `schedule` must be a `CronSchedule` from `crontab()` / `every_s()`; a raw
  string raises `AttributeError: 'str' object has no attribute 'expr'`.

Replaced it with the real API — the same form `examples/scheduler.py` already
uses correctly:

```python
from honker import Scheduler, crontab, every_s

sched = Scheduler(db)
sched.add(name="fast", queue="emails", schedule=every_s(1), payload={"kind": "tick"})
sched.add(name="nightly", queue="emails", schedule=crontab("0 3 * * *"))

await sched.run()
```

## 2. Constructing a `Queue` inside an open transaction deadlocks (undocumented)

Calling `db.queue(name)` for a **not-yet-seen** name while a `db.transaction()`
is already open hangs forever:

```python
with db.transaction() as tx:
    q = db.queue("new_name")   # hangs — never returns
    q.enqueue({"x": 1}, tx=tx)
```

`Queue._init_schema` (run on first construction) opens its **own** nested
transaction on the single write connection; the inner `BEGIN` blocks on the lock
the outer transaction holds. Because the wait is in the native extension (GIL
held), it can't be interrupted — Ctrl-C and signal-based timeouts don't fire, so
the process must be `kill`ed. This is easy to hit since the transactional-outbox
pattern is literally "open a transaction, then enqueue."

`Database.queue` had **no docstring at all**. This PR:

- documents the constraint on `Database.queue`, with the correct
  construct-first-then-`tx=` pattern;
- documents `Database.stream` and notes it is **safe** inside a transaction
  (no schema-init), since the asymmetry is surprising;
- adds a maintainer note at `Queue._init_schema` explaining the nested-`BEGIN`
  hazard;
- adds a one-line pointer in the README Notes.

(A behavioral fix — reuse the open transaction, or fail fast instead of hanging —
would be a good follow-up; this PR is docs-only.)

## Verification

- `python -m py_compile packages/honker/python/honker/_honker.py` — passes.
- Ran the corrected README scheduler snippet against 0.2.6 — registers `fast`
  and `nightly` successfully.
- Reproduced the deadlock (`timeout` exit 124) and confirmed the documented
  workaround (construct outside the tx) returns cleanly.

## Scope

Docs and docstrings only — no runtime behavior changes.
