### PR TITLE
fix(python): fail fast on Queue construct inside open transaction

### DIFF
--- a/packages/honker/README.md
+++ b/packages/honker/README.md
@@ -84,15 +84,17 @@ or `every_s`), not a raw string. Supported schedule expressions:
 
 - 5-field cron: `crontab("0 3 * * *")`
 - 6-field cron: `crontab("*/2 * * * * *")`
-- interval: `every_s(1)` (equivalently `crontab("@every 1s")`)
+- interval: `every_s(1)` (use `every_s`, not `crontab("@every …")`)
 
 ## Notes
 
 - `claim()` wakes on database updates and on due deadlines like `run_at`.
 - `schedule` is the canonical recurring-schedule name.
 - `cron` still works as a compatibility alias in older call sites.
-- Construct `db.queue(name)` handles **outside** an open `db.transaction()` (the
-  first call for a name runs its own schema-init transaction — a nested one
-  deadlocks). Create the handle first, then pass `tx=` to `enqueue`.
+- Construct `db.queue(name)` handles **outside** an open `db.transaction()`.
+  First open for a name runs schema init in its own write transaction; doing
+  that inside an outer `transaction()` raises `RuntimeError` (would otherwise
+  deadlock the single writer). Create the handle first, then pass `tx=` to
+  `enqueue`.
 
 For streams, notify/listen, tasks, SQL extension usage, and full scheduler docs, see the main repo and docs site.

--- a/packages/honker/python/honker/_honker.py
+++ b/packages/honker/python/honker/_honker.py
@@ -227,11 +227,18 @@ class Queue:
         # on column counts. View + schema-version cleanup are
         # Python-binding-specific and stay here.
         #
-        # NOTE: this opens its own transaction, so a Queue must not be
-        # constructed while a caller's `db.transaction()` is already open —
-        # the nested BEGIN deadlocks the single write connection. See the
-        # warning in `Database.queue`. Construct queues outside the
-        # transaction and pass `tx=` to `enqueue`.
+        # Schema init opens its own write transaction. The writer is a
+        # single connection slot: nested transaction() on the same thread
+        # waits forever for a slot the outer `with` still holds. Fail fast
+        # instead of hanging (see Database.queue). Construct queues
+        # outside the transaction and pass tx= to enqueue.
+        if getattr(self.db, "_tx_depth", 0) > 0:
+            raise RuntimeError(
+                f"cannot construct Queue {self.name!r} while a "
+                "db.transaction() is open: schema init needs its own write "
+                "transaction and would deadlock the single writer. "
+                "Construct the queue first, then pass tx= to enqueue."
+            )
         with self.db.transaction() as tx:
             tx.bootstrap_honker_schema()
             # Inspection view: UNION live + dead with a synthetic `state`.
@@ -1007,6 +1014,41 @@ class _Lock:
         return False  # don't suppress exceptions from the with-body
 
 
+class _TxDepthGuard:
+    """Tracks open `Database.transaction()` blocks for reentrancy checks.
+
+    The native writer is a single connection slot. Nested
+    `transaction()` on the same thread deadlocks (outer holds the slot;
+    inner waits for it). Queue schema init opens its own transaction, so
+    first-time `db.queue(name)` inside an open outer tx would hang.
+    Depth is counted here so that path can raise instead.
+
+    Bootstrap in `Database.__init__` uses `_inner.transaction()` directly
+    and does not bump depth — correct, since no user outer tx is open.
+    """
+
+    __slots__ = ("_db", "_inner", "_entered")
+
+    def __init__(self, db: "Database", inner):
+        self._db = db
+        self._inner = inner
+        self._entered = False
+
+    def __enter__(self):
+        tx = self._inner.__enter__()
+        self._db._tx_depth += 1
+        self._entered = True
+        return tx
+
+    def __exit__(self, exc_type, exc, tb):
+        try:
+            return self._inner.__exit__(exc_type, exc, tb)
+        finally:
+            if self._entered:
+                self._db._tx_depth -= 1
+                self._entered = False
+
+
 class Database:
     """Wrapper over the honker Database that adds queue/stream/outbox."""
 
@@ -1015,6 +1057,8 @@ class Database:
         self._queues: dict = {}
         self._streams: dict = {}
         self._outboxes: dict = {}
+        # Nesting depth of `self.transaction()` (not `_inner.transaction()`).
+        self._tx_depth = 0
         # Bootstrap the shared honker schema up-front so features
         # like db.lock() (which doesn't touch Queue or Stream) find
         # their tables on first use.
@@ -1022,7 +1066,7 @@ class Database:
             tx.bootstrap_honker_schema()
 
     def transaction(self):
-        return self._inner.transaction()
+        return _TxDepthGuard(self, self._inner.transaction())
 
     def listen(self, channel: str, fallback_poll_s: Optional[float] = 15.0):
         return Listener(self, channel, fallback_poll_s=fallback_poll_s)
@@ -1191,11 +1235,10 @@ class Database:
         IMPORTANT — construct outside an open transaction. The *first* call
         for a given name initializes the queue's schema in its own
         transaction. Calling it for a brand-new name while a
-        ``with db.transaction()`` block is already open deadlocks: the nested
-        ``BEGIN`` blocks on the single write connection the outer transaction
-        holds, and the wait happens in the native extension (holding the GIL),
-        so it can't be interrupted. Create the handle first, then pass
-        ``tx=`` to :meth:`Queue.enqueue` inside the transaction::
+        ``with db.transaction()`` block is already open raises
+        ``RuntimeError`` (it would otherwise deadlock the single writer).
+        Create the handle first, then pass ``tx=`` to
+        :meth:`Queue.enqueue` inside the transaction::
 
             emails = db.queue("emails")          # construct up front
             with db.transaction() as tx:

--- a/packages/honker/python/honker/_honker.py
+++ b/packages/honker/python/honker/_honker.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import threading
 import time
 import traceback
 import uuid
@@ -1018,13 +1019,18 @@ class _TxDepthGuard:
     """Tracks open `Database.transaction()` blocks for reentrancy checks.
 
     The native writer is a single connection slot. Nested
-    `transaction()` on the same thread deadlocks (outer holds the slot;
-    inner waits for it). Queue schema init opens its own transaction, so
-    first-time `db.queue(name)` inside an open outer tx would hang.
-    Depth is counted here so that path can raise instead.
+    `transaction()` on the *same thread* deadlocks (outer holds the
+    slot; inner waits for it forever). Depth is **per-thread** so
+    another thread waiting for the writer still blocks correctly until
+    the holder releases — only same-thread re-entry fails fast.
 
-    Bootstrap in `Database.__init__` uses `_inner.transaction()` directly
-    and does not bump depth — correct, since no user outer tx is open.
+    Queue schema init opens its own transaction, so first-time
+    `db.queue(name)` inside an open outer tx on this thread would hang;
+    that path raises with a queue-specific message before entering.
+
+    Bootstrap in `Database.__init__` uses `_inner.transaction()`
+    directly and does not bump depth — correct, since no user outer tx
+    is open.
     """
 
     __slots__ = ("_db", "_inner", "_entered")
@@ -1035,8 +1041,18 @@ class _TxDepthGuard:
         self._entered = False
 
     def __enter__(self):
+        # Same-thread re-entry would deadlock on the writer slot.
+        # Cross-thread wait (depth 0 here, another thread holds the
+        # slot) is fine — native acquire blocks until free.
+        if self._db._tx_depth > 0:
+            raise RuntimeError(
+                "nested db.transaction() is not supported: the writer is "
+                "a single connection slot and re-entry deadlocks on this "
+                "thread. Keep one open transaction and pass tx= to "
+                "enqueue/publish/..."
+            )
         tx = self._inner.__enter__()
-        self._db._tx_depth += 1
+        self._db._tx_local.depth = self._db._tx_depth + 1
         self._entered = True
         return tx
 
@@ -1045,7 +1061,7 @@ class _TxDepthGuard:
             return self._inner.__exit__(exc_type, exc, tb)
         finally:
             if self._entered:
-                self._db._tx_depth -= 1
+                self._db._tx_local.depth = max(0, self._db._tx_depth - 1)
                 self._entered = False
 
 
@@ -1057,13 +1073,19 @@ class Database:
         self._queues: dict = {}
         self._streams: dict = {}
         self._outboxes: dict = {}
-        # Nesting depth of `self.transaction()` (not `_inner.transaction()`).
-        self._tx_depth = 0
+        # Per-thread nesting depth of `self.transaction()` (not
+        # `_inner.transaction()`). See `_TxDepthGuard`.
+        self._tx_local = threading.local()
         # Bootstrap the shared honker schema up-front so features
         # like db.lock() (which doesn't touch Queue or Stream) find
         # their tables on first use.
         with self._inner.transaction() as tx:
             tx.bootstrap_honker_schema()
+
+    @property
+    def _tx_depth(self) -> int:
+        """Open `self.transaction()` count on *this* thread only."""
+        return int(getattr(self._tx_local, "depth", 0) or 0)
 
     def transaction(self):
         return _TxDepthGuard(self, self._inner.transaction())

--- a/tests/test_queue_in_tx.py
+++ b/tests/test_queue_in_tx.py
@@ -1,0 +1,76 @@
+"""First-time Queue construction inside an open transaction must fail fast.
+
+See #63: nested schema-init used to hang forever on the single writer slot.
+"""
+
+import pytest
+
+import honker
+
+
+def test_queue_first_construct_inside_open_tx_raises(db_path):
+    db = honker.open(db_path)
+    with db.transaction() as tx:
+        with pytest.raises(RuntimeError, match="cannot construct Queue"):
+            db.queue("brand_new_inside_tx")
+        # Outer tx still usable after the failed construct.
+        assert tx.query("SELECT 1 AS n")[0]["n"] == 1
+
+
+def test_queue_construct_outside_then_enqueue_in_tx(db_path):
+    db = honker.open(db_path)
+    q = db.queue("emails")
+    with db.transaction() as tx:
+        q.enqueue({"to": "a@example.com"}, tx=tx)
+    rows = db.query(
+        "SELECT COUNT(*) AS c FROM _honker_live WHERE queue=?", ["emails"]
+    )
+    assert rows[0]["c"] == 1
+
+
+def test_queue_cached_reopen_inside_tx_ok(db_path):
+    db = honker.open(db_path)
+    q1 = db.queue("emails")
+    with db.transaction() as tx:
+        q2 = db.queue("emails")
+        assert q2 is q1
+        q2.enqueue({"to": "b@example.com"}, tx=tx)
+    rows = db.query(
+        "SELECT COUNT(*) AS c FROM _honker_live WHERE queue=?", ["emails"]
+    )
+    assert rows[0]["c"] == 1
+
+
+def test_stream_construct_inside_tx_ok(db_path):
+    db = honker.open(db_path)
+    with db.transaction() as tx:
+        s = db.stream("events")
+        s.publish({"ok": True}, tx=tx)
+    rows = db.query(
+        "SELECT COUNT(*) AS c FROM _honker_stream WHERE topic=?", ["events"]
+    )
+    assert rows[0]["c"] == 1
+
+
+def test_outbox_first_construct_inside_open_tx_raises(db_path):
+    db = honker.open(db_path)
+
+    def delivery(_payload):
+        pass
+
+    with db.transaction():
+        with pytest.raises(RuntimeError, match="cannot construct Queue"):
+            db.outbox("hooks", delivery=delivery)
+
+
+def test_tx_depth_restored_after_exception(db_path):
+    db = honker.open(db_path)
+    try:
+        with db.transaction():
+            raise ValueError("boom")
+    except ValueError:
+        pass
+    assert db._tx_depth == 0
+    # Construction works again after the failed outer tx.
+    q = db.queue("after_exc")
+    q.enqueue({"n": 1})

--- a/tests/test_queue_in_tx.py
+++ b/tests/test_queue_in_tx.py
@@ -3,6 +3,9 @@
 See #63: nested schema-init used to hang forever on the single writer slot.
 """
 
+import threading
+import time
+
 import pytest
 
 import honker
@@ -15,6 +18,11 @@ def test_queue_first_construct_inside_open_tx_raises(db_path):
             db.queue("brand_new_inside_tx")
         # Outer tx still usable after the failed construct.
         assert tx.query("SELECT 1 AS n")[0]["n"] == 1
+    # Failed construct must not leave a half-built cache entry.
+    assert "brand_new_inside_tx" not in db._queues
+    # Retry outside the transaction works.
+    q = db.queue("brand_new_inside_tx")
+    q.enqueue({"ok": True})
 
 
 def test_queue_construct_outside_then_enqueue_in_tx(db_path):
@@ -61,6 +69,7 @@ def test_outbox_first_construct_inside_open_tx_raises(db_path):
     with db.transaction():
         with pytest.raises(RuntimeError, match="cannot construct Queue"):
             db.outbox("hooks", delivery=delivery)
+    assert "hooks" not in db._outboxes
 
 
 def test_tx_depth_restored_after_exception(db_path):
@@ -74,3 +83,73 @@ def test_tx_depth_restored_after_exception(db_path):
     # Construction works again after the failed outer tx.
     q = db.queue("after_exc")
     q.enqueue({"n": 1})
+
+
+def test_nested_transaction_raises_not_hangs(db_path):
+    """Same root cause as #63: nested transaction() on one thread deadlocks."""
+    db = honker.open(db_path)
+    with db.transaction() as tx:
+        with pytest.raises(RuntimeError, match="nested db.transaction"):
+            with db.transaction():
+                pass
+        assert tx.query("SELECT 1 AS n")[0]["n"] == 1
+    assert db._tx_depth == 0
+
+
+def test_queue_first_construct_waits_while_other_thread_holds_tx(db_path):
+    """Depth is per-thread: another thread holding a write tx must not
+    make first-time queue construct fail-fast — only wait for the writer.
+    """
+    db = honker.open(db_path)
+    started = threading.Event()
+    release = threading.Event()
+    holder_err = []
+    opener_result = {}
+
+    def holder():
+        try:
+            with db.transaction() as tx:
+                tx.execute("CREATE TABLE side (id INTEGER)")
+                started.set()
+                if not release.wait(timeout=5):
+                    holder_err.append("release timeout")
+        except Exception as e:
+            holder_err.append(e)
+
+    def opener():
+        if not started.wait(timeout=5):
+            opener_result["err"] = "started timeout"
+            return
+        t0 = time.time()
+        try:
+            q = db.queue("from_other_thread")
+            opener_result["name"] = q.name
+            opener_result["dt"] = time.time() - t0
+        except Exception as e:
+            opener_result["err"] = e
+
+    th = threading.Thread(target=holder)
+    to = threading.Thread(target=opener)
+    th.start()
+    to.start()
+    # Opener is blocked on the writer while holder keeps the tx open.
+    time.sleep(0.15)
+    assert to.is_alive(), "opener should still be waiting on writer"
+    assert "err" not in opener_result
+    release.set()
+    th.join(timeout=5)
+    to.join(timeout=5)
+    assert not holder_err, holder_err
+    assert "err" not in opener_result, opener_result
+    assert opener_result.get("name") == "from_other_thread"
+    # Waited at least a slice of the hold window (not an instant false raise).
+    assert opener_result.get("dt", 0) >= 0.05
+
+
+def test_issue_63_repro_raises_not_hangs(db_path):
+    """Exact shape from #63 — must raise, not hang."""
+    db = honker.open(db_path)
+    with db.transaction() as tx:
+        with pytest.raises(RuntimeError, match="cannot construct Queue"):
+            q = db.queue("brand_new_name")
+            q.enqueue({"x": 1}, tx=tx)


### PR DESCRIPTION
## Summary

Fixes #63.

First construction of `db.queue(name)` runs schema init in its own write transaction. Doing that inside an open `db.transaction()` deadlocked on the single writer slot (same-thread: outer holds the slot, inner waits forever).

**Change:** track `Database.transaction()` nesting depth (`_TxDepthGuard`) and raise `RuntimeError` from `Queue._init_schema` when depth > 0 instead of hanging.

Also:
- update README / docstrings: say **raises**, not deadlocks
- fix README lie: `crontab("@every …")` is not valid — use `every_s()`
- docs-only #64 was the band-aid; this is the real fix for the hang

## Behavior

```python
with db.transaction() as tx:
    db.queue("new")  # RuntimeError — was hang forever
```

Safe pattern unchanged:

```python
q = db.queue("emails")
with db.transaction() as tx:
    q.enqueue(payload, tx=tx)
```

Cached re-fetch and `stream()` inside a tx still work. Outbox first construct inside a tx raises the same way (it goes through `db.queue`).

## Test plan

- [x] `tests/test_queue_in_tx.py` — raise, safe pattern, cache hit, stream ok, outbox raise, depth restore after exception
- [x] Prove: with the `if _tx_depth` guard removed, the raise test hangs (SIGALRM 142); with guard restored, passes
- [x] Outbox / python_api smoke on this branch