### PR TITLE
fix(node): reuse pending update waits across timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Test (basic — node only)
         working-directory: packages/honker-node
         shell: bash
-        run: node --test test/basic.js
+        run: node --test test/api.test.js test/basic.js
       - name: Test (parity — node API surface)
         working-directory: packages/honker-node
         shell: bash

--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -43,18 +43,34 @@ function abortPromise(signal) {
   });
 }
 
+const pendingUpdateWaits = new WeakMap();
+
+function nextUpdate(updateEvents) {
+  const existing = pendingUpdateWaits.get(updateEvents);
+  if (existing) return existing;
+
+  const pending = updateEvents.next().catch(() => undefined);
+  pendingUpdateWaits.set(updateEvents, pending);
+  void pending.finally(() => {
+    if (pendingUpdateWaits.get(updateEvents) === pending) {
+      pendingUpdateWaits.delete(updateEvents);
+    }
+  });
+  return pending;
+}
+
 async function waitForUpdateOrTimeout(updateEvents, signal, timeoutMs) {
   if (aborted(signal)) return;
   if (timeoutMs == null) {
     await Promise.race([
-      updateEvents.next().catch(() => undefined),
+      nextUpdate(updateEvents),
       abortPromise(signal),
     ]);
     return;
   }
   const ms = Math.max(0, timeoutMs);
   await Promise.race([
-    updateEvents.next().catch(() => undefined),
+    nextUpdate(updateEvents),
     delay(ms),
     abortPromise(signal),
   ]);

--- a/packages/honker-node/package.json
+++ b/packages/honker-node/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "node --test test/basic.js test/parity.test.js test/cross_lang_python_to_node.js test/cross_lang_node_to_python.js test/cross_lang_supporting.js test/watcher_backends.js test/watcher_backends_e2e.js test/watcher_backends_queue_e2e.js test/phase_mantle.js"
+    "test": "node --test test/api.test.js test/basic.js test/parity.test.js test/cross_lang_python_to_node.js test/cross_lang_node_to_python.js test/cross_lang_supporting.js test/watcher_backends.js test/watcher_backends_e2e.js test/watcher_backends_queue_e2e.js test/phase_mantle.js"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.0.0"

--- a/packages/honker-node/test/api.test.js
+++ b/packages/honker-node/test/api.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const buildApi = require('../api');
+
+test('claim waker reuses a pending update wait across poll timeouts', async () => {
+  const { ClaimWaker } = buildApi({});
+  let nextCalls = 0;
+  let closed = false;
+  const updateEvents = {
+    next() {
+      nextCalls += 1;
+      return new Promise(() => {});
+    },
+    close() {
+      closed = true;
+    },
+  };
+  const queue = {
+    _db: { updateEvents: () => updateEvents },
+    claimOne: () => null,
+    _nextClaimAt: () => null,
+  };
+  const controller = new AbortController();
+  const abortTimer = setTimeout(() => controller.abort(), 50);
+  const waker = new ClaimWaker(queue, { idlePollS: 0.001 });
+
+  try {
+    await waker.next('worker', { signal: controller.signal });
+    assert.equal(
+      nextCalls,
+      1,
+      'poll timeouts must not start additional native update waits'
+    );
+  } finally {
+    clearTimeout(abortTimer);
+    waker.close();
+  }
+
+  assert.equal(closed, true);
+});


### PR DESCRIPTION
## Summary

- reuse one pending `UpdateEvents.next()` promise per update source when a timeout wins the race
- remove the cached promise after the native wait settles so the next database update is still observed normally
- add a deterministic public-API regression test and include it in the Node CI job

## Why

`Promise.race()` does not cancel its losing promises. Each poll timeout previously left a native `UpdateEvents.next()` call blocked in Tokio and started another on the next iteration. Long-running schedulers and claim wakers could therefore fill Tokio's blocking pool and retain hundreds of OS threads.

This is separate from the losing `abortPromise()` listener reported in #67; this PR only addresses the native update wait.

Closes #68.

## Validation

- Regression before the fix: 43 outstanding `next()` calls after 50 ms
- Regression after the fix: one outstanding call, stable across repeated runs
- `npm run build`
- Node/native suite: 60 passed, 0 failed, 16 feature-gated skips

The aggregate `npm test` command was also attempted locally; its Python interop cases require `.venv/bin/python`, which was not present in the clean checkout. The Node/native portions above completed successfully, and the repository CI provisions the required Python environment for the cross-language jobs.
