### PR TITLE
fix(node): detach timed-out races from the shared update wait

### DIFF
--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -43,37 +43,61 @@ function abortPromise(signal) {
   });
 }
 
+// One pending native UpdateEvents.next() per source, reused across poll
+// timeouts: Promise.race does not cancel its losers, and each abandoned
+// native next() pins a Tokio blocking-pool thread until the next commit.
+// Callers subscribe their own promise via the record's waiter set and
+// MUST cancel() when their race settles another way — racing the cached
+// promise directly would retain one settled-race closure per poll until
+// the next commit (unbounded growth while the database stays idle).
+//
+// While no commit arrives, the single pending native wait holds its one
+// blocking thread even between waker.next() calls (e.g. during job
+// processing). That residual thread is deliberate: native next() has no
+// cancellation, and the pre-fix alternative leaked one thread per poll.
 const pendingUpdateWaits = new WeakMap();
 
 function nextUpdate(updateEvents) {
-  const existing = pendingUpdateWaits.get(updateEvents);
-  if (existing) return existing;
-
-  const pending = updateEvents.next().catch(() => undefined);
-  pendingUpdateWaits.set(updateEvents, pending);
-  void pending.finally(() => {
-    if (pendingUpdateWaits.get(updateEvents) === pending) {
-      pendingUpdateWaits.delete(updateEvents);
-    }
+  let record = pendingUpdateWaits.get(updateEvents);
+  if (!record) {
+    record = { waiters: new Set() };
+    pendingUpdateWaits.set(updateEvents, record);
+    const settle = () => {
+      if (pendingUpdateWaits.get(updateEvents) === record) {
+        pendingUpdateWaits.delete(updateEvents);
+      }
+      const waiters = [...record.waiters];
+      record.waiters.clear();
+      for (const resolve of waiters) resolve();
+    };
+    void updateEvents.next().then(settle, settle);
+  }
+  let resolveWait;
+  const promise = new Promise((resolve) => {
+    resolveWait = resolve;
   });
-  return pending;
+  record.waiters.add(resolveWait);
+  return {
+    promise,
+    cancel() {
+      record.waiters.delete(resolveWait);
+    },
+  };
 }
 
 async function waitForUpdateOrTimeout(updateEvents, signal, timeoutMs) {
   if (aborted(signal)) return;
-  if (timeoutMs == null) {
-    await Promise.race([
-      nextUpdate(updateEvents),
-      abortPromise(signal),
-    ]);
-    return;
+  const wait = nextUpdate(updateEvents);
+  try {
+    if (timeoutMs == null) {
+      await Promise.race([wait.promise, abortPromise(signal)]);
+      return;
+    }
+    const ms = Math.max(0, timeoutMs);
+    await Promise.race([wait.promise, delay(ms), abortPromise(signal)]);
+  } finally {
+    wait.cancel();
   }
-  const ms = Math.max(0, timeoutMs);
-  await Promise.race([
-    nextUpdate(updateEvents),
-    delay(ms),
-    abortPromise(signal),
-  ]);
 }
 
 function unwrapTx(tx) {
@@ -883,3 +907,8 @@ module.exports = function buildApi(nativeBinding) {
     NativeUpdateEvents: nativeBinding.UpdateEvents,
   };
 };
+
+// Test-only handle for observing shared wait bookkeeping (api.test.js).
+// Attached to the buildApi function itself so the exported API surface
+// (and parity tests) stay unchanged.
+module.exports._pendingUpdateWaits = pendingUpdateWaits;

--- a/packages/honker-node/test/api.test.js
+++ b/packages/honker-node/test/api.test.js
@@ -5,6 +5,10 @@ const assert = require('node:assert/strict');
 
 const buildApi = require('../api');
 
+// The unit under test in this file is waitForUpdateOrTimeout in
+// ../api.js — the shared wait helper used by ClaimWaker, Listener, and
+// Scheduler. The ClaimWaker is just the most convenient public handle.
+
 test('claim waker reuses a pending update wait across poll timeouts', async () => {
   const { ClaimWaker } = buildApi({});
   let nextCalls = 0;
@@ -40,4 +44,44 @@ test('claim waker reuses a pending update wait across poll timeouts', async () =
   }
 
   assert.equal(closed, true);
+});
+
+test('poll timeouts do not accumulate waiters on the shared update wait', async () => {
+  const { ClaimWaker } = buildApi({});
+  let resolveNative;
+  const updateEvents = {
+    next() {
+      return new Promise((resolve) => {
+        resolveNative = resolve;
+      });
+    },
+    close() {},
+  };
+  const queue = {
+    _db: { updateEvents: () => updateEvents },
+    claimOne: () => null,
+    _nextClaimAt: () => null,
+  };
+  const controller = new AbortController();
+  const abortTimer = setTimeout(() => controller.abort(), 50);
+  const waker = new ClaimWaker(queue, { idlePollS: 0.001 });
+
+  try {
+    await waker.next('worker', { signal: controller.signal });
+  } finally {
+    clearTimeout(abortTimer);
+    waker.close();
+  }
+
+  // Each timed-out race must detach from the shared wait. Racing the
+  // cached promise directly would retain one settled-race closure per
+  // poll until the next commit — unbounded growth on an idle database.
+  const record = buildApi._pendingUpdateWaits.get(updateEvents);
+  assert.ok(record, 'the native wait is still pending after the abort');
+  assert.equal(record.waiters.size, 0, 'timed-out polls must unsubscribe');
+
+  // The pending native wait still observes the next update, then evicts.
+  resolveNative();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(buildApi._pendingUpdateWaits.get(updateEvents), undefined);
 });


### PR DESCRIPTION
## Summary

Follow-up to #69 (review findings). Three changes, all in `packages/honker-node`:

- **Waiter-set design for the shared update wait.** Racing the cached pending promise directly retained one settled-`Promise.race` closure per poll timeout until the next commit — unbounded memory growth while the database stays idle (a commit releases everything, so severity depends on poll rate × idle time). Each waiter now subscribes its own promise via a per-source waiter set and unsubscribes (`cancel()`) when its race settles another way. Memory is bounded at one waiter per in-flight wait.
- **Document the residual parked thread.** The single pending native wait holds one Tokio blocking thread even between `waker.next()` calls (e.g. during job processing). Comment in `api.js` records why this is deliberate: native `next()\) has no cancellation, and the pre-#69 alternative leaked one thread per poll iteration.
- **Test note.** `api.test.js` now names `waitForUpdateOrTimeout` as the unit under test, and gains a regression test asserting timed-out polls leave zero waiters on the shared record and that the pending native wait still observes the next update before evicting.

## Validation

- New waiter test fails on the #69 implementation, passes with this change
- `node --test test/api.test.js test/basic.js`: 10 passed, 0 failed
- `test/parity.test.js`: 26 passed, 6 failed — identical failures with and without this change (stale local prebuilt `.node` vs. Rust sources; CI builds the binding fresh)
- Real-binding e2e: enqueue after ~30 poll timeouts wakes the waker through the reused wait in ~6 ms; a second enqueue after eviction wakes a fresh wait

The pre-existing `abortPromise` listener accumulation (#67) is unchanged and still tracked separately.