### PR TITLE
fix(node): share the pending update wait inside UpdateEvents.next()

### DIFF
--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -43,58 +43,20 @@ function abortPromise(signal) {
   });
 }
 
-// One pending native UpdateEvents.next() per source, reused across poll
-// timeouts: Promise.race does not cancel its losers, and each abandoned
-// native next() pins a Tokio blocking-pool thread until the next commit.
-// Callers subscribe their own promise via the record's waiter set and
-// MUST cancel() when their race settles another way — racing the cached
-// promise directly would retain one settled-race closure per poll until
-// the next commit (unbounded growth while the database stays idle).
-//
-// While no commit arrives, the single pending native wait holds its one
-// blocking thread even between waker.next() calls (e.g. during job
-// processing). That residual thread is deliberate: native next() has no
-// cancellation, and the pre-fix alternative leaked one thread per poll.
-const pendingUpdateWaits = new WeakMap();
-
-function nextUpdate(updateEvents) {
-  let record = pendingUpdateWaits.get(updateEvents);
-  if (!record) {
-    record = { waiters: new Set() };
-    pendingUpdateWaits.set(updateEvents, record);
-    const settle = () => {
-      if (pendingUpdateWaits.get(updateEvents) === record) {
-        pendingUpdateWaits.delete(updateEvents);
-      }
-      const waiters = [...record.waiters];
-      record.waiters.clear();
-      for (const resolve of waiters) resolve();
-    };
-    void updateEvents.next().then(settle, settle);
-  }
-  let resolveWait;
-  const promise = new Promise((resolve) => {
-    resolveWait = resolve;
-  });
-  record.waiters.add(resolveWait);
-  return {
-    promise,
-    cancel() {
-      record.waiters.delete(resolveWait);
-    },
-  };
-}
-
 async function waitForUpdateOrTimeout(updateEvents, signal, timeoutMs) {
   if (aborted(signal)) return;
-  const wait = nextUpdate(updateEvents);
+  const wait = updateEvents._subscribe();
   try {
+    // Waiter promises reject on watcher death / close(); internal wait
+    // loops treat that as an ordinary wake (they re-check their closed
+    // flags and exit), so swallow it here.
+    const settled = wait.promise.catch(() => undefined);
     if (timeoutMs == null) {
-      await Promise.race([wait.promise, abortPromise(signal)]);
+      await Promise.race([settled, abortPromise(signal)]);
       return;
     }
     const ms = Math.max(0, timeoutMs);
-    await Promise.race([wait.promise, delay(ms), abortPromise(signal)]);
+    await Promise.race([settled, delay(ms), abortPromise(signal)]);
   } finally {
     wait.cancel();
   }
@@ -138,15 +100,76 @@ class UpdateEvents {
   constructor(ev) {
     this._ev = ev;
     this._closed = false;
+    // One pending native wait shared by every concurrent waiter. The
+    // native next() parks a Tokio blocking-pool thread on recv() until
+    // the next commit or close(), and it cannot be cancelled — so every
+    // abandoned next() (Promise.race losers, in particular) would pin
+    // one more OS thread for the life of an idle database. Sharing the
+    // wait means N concurrent next() calls cost one thread total.
+    //
+    // While no commit arrives, the single pending wait holds its one
+    // thread even between waker.next() calls (e.g. during job
+    // processing). That residual thread is deliberate: the native wait
+    // has no cancellation, and the alternative is a thread per wait.
+    this._pending = null;
+    this._waiters = new Set();
   }
 
   raw() {
     return this._ev;
   }
 
+  // Internal: subscribe to the shared native wait. The promise
+  // RESOLVES on the next update and REJECTS when the native wait fails
+  // (watcher death, close()) — same contract as awaiting next().
+  // Callers that race the returned promise MUST cancel() when their
+  // race settles another way — otherwise each abandoned race leaves
+  // its waiter in the set until the wait settles (bounded by poll
+  // rate × idle time; waitForUpdateOrTimeout cancels, keeping the set
+  // at one entry per in-flight wait).
+  _subscribe() {
+    if (this._closed) {
+      return { promise: Promise.resolve(), cancel() {} };
+    }
+    if (!this._pending) {
+      const pending = this._ev.next().then(
+        () => this._settle(pending, null),
+        (err) => this._settle(pending, err),
+      );
+      this._pending = pending;
+    }
+    let waiter;
+    const promise = new Promise((resolve, reject) => {
+      waiter = { resolve, reject };
+    });
+    this._waiters.add(waiter);
+    return {
+      promise,
+      cancel: () => {
+        this._waiters.delete(waiter);
+      },
+    };
+  }
+
+  _settle(pending, err) {
+    if (this._pending !== pending) return;
+    this._pending = null;
+    const waiters = [...this._waiters];
+    this._waiters.clear();
+    for (const w of waiters) {
+      if (err == null) w.resolve();
+      else w.reject(err);
+    }
+  }
+
+  /** Wait for the next database update. Resolves on the next commit;
+   *  rejects when the watcher dies or close() cuts the subscription.
+   *  Concurrent calls share one native wait and settle together — a
+   *  wake is a "go re-read state" hint, not a per-caller event — so
+   *  racing next() against your own timeout never starts extra native
+   *  waits. */
   async next() {
-    if (this._closed) return;
-    await this._ev.next();
+    await this._subscribe().promise;
   }
 
   close() {
@@ -907,8 +930,3 @@ module.exports = function buildApi(nativeBinding) {
     NativeUpdateEvents: nativeBinding.UpdateEvents,
   };
 };
-
-// Test-only handle for observing shared wait bookkeeping (api.test.js).
-// Attached to the buildApi function itself so the exported API surface
-// (and parity tests) stay unchanged.
-module.exports._pendingUpdateWaits = pendingUpdateWaits;

--- a/packages/honker-node/test/api.test.js
+++ b/packages/honker-node/test/api.test.js
@@ -1,87 +1,208 @@
+// End-to-end tests for the shared update wait — UpdateEvents.next()
+// and waitForUpdateOrTimeout, which ClaimWaker, Listener, and
+// Scheduler all wait through — against the real native binding.
+// No mocks: the regression these tests guard is a native thread leak
+// (one parked Tokio blocking thread per abandoned next()), which only
+// exists behind the real UpdateEvents wrapper. Run with
+// `node --test test/api.test.js` after `npm run build`.
+
 'use strict';
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const { setTimeout: delay } = require('node:timers/promises');
 
-const buildApi = require('../api');
+const lit = require('..');
+const { createTempDb } = require('./helpers');
 
-// The unit under test in this file is waitForUpdateOrTimeout in
-// ../api.js — the shared wait helper used by ClaimWaker, Listener, and
-// Scheduler. The ClaimWaker is just the most convenient public handle.
+function tmpdb() {
+  return createTempDb('honker-node-api-', lit.open.bind(lit));
+}
 
-test('claim waker reuses a pending update wait across poll timeouts', async () => {
-  const { ClaimWaker } = buildApi({});
-  let nextCalls = 0;
-  let closed = false;
-  const updateEvents = {
-    next() {
-      nextCalls += 1;
-      return new Promise(() => {});
-    },
-    close() {
-      closed = true;
-    },
-  };
-  const queue = {
-    _db: { updateEvents: () => updateEvents },
-    claimOne: () => null,
-    _nextClaimAt: () => null,
-  };
-  const controller = new AbortController();
-  const abortTimer = setTimeout(() => controller.abort(), 50);
-  const waker = new ClaimWaker(queue, { idlePollS: 0.001 });
+const unhandled = [];
+process.on('unhandledRejection', (err) => unhandled.push(err));
 
+test('claim waker reuses one native update wait across poll timeouts', async () => {
+  const { path: dbPath, open, cleanup } = tmpdb();
+  const db = open(dbPath);
   try {
-    await waker.next('worker', { signal: controller.signal });
+    const q = db.queue('q');
+    const waker = q.claimWaker({ idlePollS: 0.001 }); // 1 ms polls
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(), 200);
+
+    // Sample the shared native wait for the whole run: on an idle
+    // database its identity must never change. A new promise means a
+    // new native next() — one more parked OS thread per poll timeout.
+    let firstPending = null;
+    const samples = [];
+    const sampler = setInterval(() => {
+      const pending = waker._updates._pending;
+      if (!pending) return;
+      if (!firstPending) firstPending = pending;
+      samples.push(pending === firstPending);
+    }, 5);
+
+    let result;
+    try {
+      result = await waker.next('worker', { signal: controller.signal });
+    } finally {
+      clearTimeout(abortTimer);
+      clearInterval(sampler);
+      waker.close();
+    }
+
+    assert.equal(result, null, 'abort with no jobs returns null');
+    assert.ok(firstPending, 'a native wait was started');
+    assert.ok(samples.length > 0, 'sampler observed the native wait');
+    assert.ok(
+      samples.every(Boolean),
+      'poll timeouts must not start additional native waits'
+    );
     assert.equal(
-      nextCalls,
-      1,
-      'poll timeouts must not start additional native update waits'
+      waker._updates._waiters.size,
+      0,
+      'timed-out polls must unsubscribe from the shared wait'
     );
   } finally {
-    clearTimeout(abortTimer);
-    waker.close();
+    cleanup();
   }
-
-  assert.equal(closed, true);
 });
 
-test('poll timeouts do not accumulate waiters on the shared update wait', async () => {
-  const { ClaimWaker } = buildApi({});
-  let resolveNative;
-  const updateEvents = {
-    next() {
-      return new Promise((resolve) => {
-        resolveNative = resolve;
-      });
-    },
-    close() {},
-  };
-  const queue = {
-    _db: { updateEvents: () => updateEvents },
-    claimOne: () => null,
-    _nextClaimAt: () => null,
-  };
-  const controller = new AbortController();
-  const abortTimer = setTimeout(() => controller.abort(), 50);
-  const waker = new ClaimWaker(queue, { idlePollS: 0.001 });
-
+test('updates wake the shared wait across repeated idle polls', async () => {
+  const { path: dbPath, open, cleanup } = tmpdb();
+  const db = open(dbPath);
   try {
-    await waker.next('worker', { signal: controller.signal });
+    const q = db.queue('q');
+    // 60 s poll interval: only a real update can wake these waits.
+    const waker = q.claimWaker({ idlePollS: 60 });
+    try {
+      for (const n of [1, 2]) {
+        const pending = waker.next('worker');
+        await delay(50);
+        q.enqueue({ n });
+        const job = await pending;
+        assert.ok(job, `wait ${n} returned a job`);
+        assert.equal(job.payload.n, n);
+      }
+      // After each wake the shared wait settles and is evicted, so the
+      // next wait starts a fresh native next().
+      assert.equal(waker._updates._pending, null);
+    } finally {
+      waker.close();
+    }
   } finally {
-    clearTimeout(abortTimer);
-    waker.close();
+    cleanup();
   }
+});
 
-  // Each timed-out race must detach from the shared wait. Racing the
-  // cached promise directly would retain one settled-race closure per
-  // poll until the next commit — unbounded growth on an idle database.
-  const record = buildApi._pendingUpdateWaits.get(updateEvents);
-  assert.ok(record, 'the native wait is still pending after the abort');
-  assert.equal(record.waiters.size, 0, 'timed-out polls must unsubscribe');
+test('close during an event-only wait returns promptly', async () => {
+  const { path: dbPath, open, cleanup } = tmpdb();
+  const db = open(dbPath);
+  try {
+    const q = db.queue('q');
+    const waker = q.claimWaker({ idlePollS: null }); // no poll fallback
+    const started = Date.now();
+    const pending = waker.next('worker');
+    setTimeout(() => waker.close(), 50);
+    const result = await pending;
+    assert.equal(result, null);
+    assert.ok(Date.now() - started < 5000, 'close must unblock the wait');
+  } finally {
+    cleanup();
+  }
+});
 
-  // The pending native wait still observes the next update, then evicts.
-  resolveNative();
-  await new Promise((resolve) => setImmediate(resolve));
-  assert.equal(buildApi._pendingUpdateWaits.get(updateEvents), undefined);
+test('concurrent UpdateEvents.next() calls share one native wait', async () => {
+  const { path: dbPath, open, cleanup } = tmpdb();
+  const db = open(dbPath);
+  try {
+    const updates = db.updateEvents();
+    const first = updates.next();
+    const second = updates.next();
+    const shared = updates._pending;
+    assert.ok(shared, 'a native wait was started');
+    assert.equal(updates._waiters.size, 2, 'both callers wait on it');
+
+    db.notify('chan', { wake: true }); // any commit resolves the wait
+    await Promise.all([first, second]);
+    assert.equal(updates._pending, null, 'settle evicts the shared wait');
+    assert.equal(updates._waiters.size, 0, 'settle drains the waiters');
+    updates.close();
+  } finally {
+    cleanup();
+  }
+});
+
+test('racing UpdateEvents.next() against timeouts starts no extra native waits', async () => {
+  const { path: dbPath, open, cleanup } = tmpdb();
+  const db = open(dbPath);
+  try {
+    const updates = db.updateEvents();
+    const raced = [];
+    let firstPending = null;
+    for (let i = 0; i < 50; i++) {
+      // The timeout always wins on an idle database. Before the wait
+      // was shared, each losing race abandoned a native next() — one
+      // parked OS thread per iteration (issue #68 through public API).
+      const attempt = updates.next();
+      raced.push(attempt);
+      await Promise.race([attempt, delay(1)]);
+      const pending = updates._pending;
+      assert.ok(pending, 'the shared native wait survives the race');
+      if (!firstPending) firstPending = pending;
+      assert.equal(
+        pending,
+        firstPending,
+        `iteration ${i} must reuse the same native wait`
+      );
+    }
+    updates.close();
+    // Abandoned race losers settle (here: reject on close) — drain
+    // them so nothing surfaces as an unhandled rejection.
+    await Promise.all(raced.map((p) => p.catch(() => undefined)));
+  } finally {
+    cleanup();
+  }
+});
+
+test('UpdateEvents.next() rejects when closed mid-wait', async () => {
+  const { path: dbPath, open, cleanup } = tmpdb();
+  const db = open(dbPath);
+  try {
+    const updates = db.updateEvents();
+    const pending = updates.next();
+    await delay(50); // let the native wait park
+    updates.close();
+    await assert.rejects(pending);
+  } finally {
+    cleanup();
+  }
+});
+
+test('listener wakes on notify after fallback poll timeouts', async () => {
+  const { path: dbPath, open, cleanup } = tmpdb();
+  const db = open(dbPath);
+  try {
+    const listener = db.listen('chan', { fallbackPollS: 0.005 });
+    try {
+      const pending = listener.next();
+      await delay(60); // several fallback timeouts inside the wait
+      db.notify('chan', { hello: 1 });
+      const { value, done } = await pending;
+      assert.equal(done, false);
+      assert.deepEqual(value.payload, { hello: 1 });
+    } finally {
+      listener.close();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('no unhandled promise rejections from shared waits', async () => {
+  // Last test in the file (node --test runs top-level tests in order):
+  // gives any stray rejection from the scenarios above time to surface.
+  await delay(100);
+  assert.deepEqual(unhandled, []);
 });

--- a/packages/honker-node/wrapper.d.ts
+++ b/packages/honker-node/wrapper.d.ts
@@ -79,6 +79,11 @@ export class Transaction {
 
 export class UpdateEvents {
   raw(): any
+  /** Wait for the next database update. Resolves on the next commit;
+   *  rejects when the watcher dies or close() cuts the subscription.
+   *  Concurrent calls share one native wait and settle together, so
+   *  racing next() against your own timeout never starts extra native
+   *  waits. */
   next(): Promise<void>
   close(): void
 }


### PR DESCRIPTION
## Summary

Follow-up to #69/#70, from the #70 review. Two changes in `packages/honker-node`:

- **Harden the public `UpdateEvents.next()`.** #69/#70 made the framework's own wait loops (ClaimWaker, Listener, Scheduler) share one pending native wait, but the public `db.updateEvents().next()\) still started a fresh non-cancellable native wait per call. User code racing it against a timeout — the natural way to write a custom poll loop — recreated the #68 leak: one parked Tokio blocking thread per lost race on an idle database. The waiter-set now lives inside the `UpdateEvents` wrapper: concurrent `next()\) calls share one native wait and resolve together (a wake is a "go re-read state" hint, not a per-caller event). `waitForUpdateOrTimeout` subscribes through the same path with `cancel()` for race losers; the module-level WeakMap is gone.
- **Rewrite `api.test.js` as real e2e — no mocks.** The previous tests used a fake `updateEvents`; the regression they guard (a native thread leak) only exists behind the real wrapper. New tests run against the actual binding and cover: shared-wait identity across ~200 poll timeouts, waiter drain to zero after abort, wake after settle/eviction with a 60 s poll interval, prompt return from `close()` during an event-only wait, concurrent `next()` sharing one wait, racing the public `next()` against 50 timeouts (the #68 foot-gun, now fixed), listener wakes after fallback timeouts, and zero unhandled rejections across all scenarios.

## Validation

- 5 of the 7 new tests **fail against the pre-change implementation**, pass with it (the other 2 are behavior coverage that also holds on main)
- `node --test test/api.test.js test/basic.js test/parity.test.js`: 47 passed, 0 failed
- Separate adversarial e2e script (12 checks: abort/close negatives, 300-timeout soak, scheduler abort cycle, two wakers, listener): all pass

## Behavior change

Concurrent `UpdateEvents.next()\) calls on the same object now resolve together on one wake instead of consuming one watcher tick each. This matches the wake-as-hint contract (consumers always re-read state) and is what makes the public API safe to race.

The pre-existing `abortPromise` listener accumulation (#67) is unchanged and still tracked separately.