### PR TITLE
ci: fix zizmor ref-version-mismatch pin comments

### DIFF
--- a/.github/workflows/package-proof.yml
+++ b/.github/workflows/package-proof.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - name: Set up Rust

--- a/.github/workflows/registry-gauntlet.yml
+++ b/.github/workflows/registry-gauntlet.yml
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - name: Set up Rust

--- a/.github/workflows/release-bun.yml
+++ b/.github/workflows/release-bun.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - name: Set up Rust

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -32,7 +32,7 @@ jobs:
   package-proof:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           # Don't leave the GITHUB_TOKEN in `.git/config` for later
           # steps to scoop up.

--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -35,7 +35,7 @@ jobs:
             rid: win-x64
             native_name: honker_ext.dll
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - name: Set up Rust
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: native-assets
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4

--- a/.github/workflows/release-elixir.yml
+++ b/.github/workflows/release-elixir.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - name: Set up Rust

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -31,7 +31,7 @@ jobs:
             os: macos-latest
             rust_target: aarch64-apple-darwin
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - name: Set up Rust
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: native
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -30,7 +30,7 @@ jobs:
           - platform: windows-x64
             os: windows-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - name: Set up Rust

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -28,7 +28,7 @@ jobs:
           - os: macos-latest
             gem_platform: arm64-darwin
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - name: Set up Rust
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - name: Set up Rust

--- a/.github/workflows/scary-nightly.yml
+++ b/.github/workflows/scary-nightly.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 35
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - name: Set up Rust
@@ -67,7 +67,7 @@ jobs:
     timeout-minutes: 25
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - name: Set up Rust

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -34,7 +34,7 @@ jobs:
     name: zizmor
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e  # v0.5.3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -29,3 +29,9 @@ rules:
       # workflow only builds proof artifacts. Publishing remains local.
       - release-node.yml
       - release-bun.yml
+  adhoc-packages:
+    ignore:
+      # The smoke tests install the tarballs/gems the same job just
+      # built — there is no lockfile for an artifact produced in-job.
+      - release-node.yml
+      - release-ruby.yml


### PR DESCRIPTION
## Summary

Unblocks the zizmor workflow lint for any PR that touches `.github/workflows/**` (first seen failing on #69, which only changed one line of `ci.yml`).

- Newer zizmor runs the `ref-version-mismatch` audit (online): it resolves a hash-pinned action's version comment against the GitHub API. `actions/checkout@34e11487...` is the **v4.3.1** commit, but the moving `v4` tag now points to a different commit — so every `# v4` comment on that pin mismatches. 15 findings across `release-*.yml`, `package-proof.yml`, `registry-gauntlet.yml`, `scary-nightly.yml`, `zizmor.yml`.
- Fix applied via `zizmor --fix`: **comment-only** changes (`# v4` → `# v4.3.1` etc.). No pin hashes changed — diff verified line by line.
- Also suppresses `adhoc-packages` on `release-node.yml` / `release-ruby.yml`: their smoke tests install the tarball/gem the same job just built, so there is no lockfile by construction. Same documented-ignore style as the existing `cache-poisoning` entries.

## Validation

- `zizmor .github/workflows/ .github/zizmor.yml` with online audits (v1.27.0): **No findings to report** (was 15 medium + 3 low).