### PR TITLE
fix(node): remove abort listeners after races; degrade on watcher death

### DIFF
--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -36,29 +36,44 @@ function aborted(signal) {
 }
 
 function abortPromise(signal) {
-  if (!signal) return new Promise(() => {});
-  if (signal.aborted) return Promise.resolve();
-  return new Promise((resolve) => {
+  // Every caller must cancel() once its race settles: an { once: true }
+  // listener is only removed by the platform when abort actually fires,
+  // so without cancel() each poll timeout would leak one listener on
+  // the signal until it aborts (issue #67).
+  if (!signal) return { promise: new Promise(() => {}), cancel() {} };
+  if (signal.aborted) return { promise: Promise.resolve(), cancel() {} };
+  let onAbort;
+  const promise = new Promise((resolve) => {
+    onAbort = resolve;
     signal.addEventListener('abort', resolve, { once: true });
   });
+  return {
+    promise,
+    cancel() {
+      signal.removeEventListener('abort', onAbort);
+    },
+  };
 }
 
 async function waitForUpdateOrTimeout(updateEvents, signal, timeoutMs) {
   if (aborted(signal)) return;
-  const wait = updateEvents._subscribe();
+  // A dead watcher never fires again (UpdateEvents._settle records
+  // native-wait failures): skip the event wait and degrade to plain
+  // poll cadence instead of hot-looping on instantly-rejecting waits.
+  const wait = updateEvents._dead == null ? updateEvents._subscribe() : null;
+  const onAbort = abortPromise(signal);
   try {
     // Waiter promises reject on watcher death / close(); internal wait
     // loops treat that as an ordinary wake (they re-check their closed
     // flags and exit), so swallow it here.
-    const settled = wait.promise.catch(() => undefined);
-    if (timeoutMs == null) {
-      await Promise.race([settled, abortPromise(signal)]);
-      return;
-    }
-    const ms = Math.max(0, timeoutMs);
-    await Promise.race([settled, delay(ms), abortPromise(signal)]);
+    const racers = [];
+    if (wait) racers.push(wait.promise.catch(() => undefined));
+    if (timeoutMs != null) racers.push(delay(Math.max(0, timeoutMs)));
+    racers.push(onAbort.promise);
+    await Promise.race(racers);
   } finally {
-    wait.cancel();
+    if (wait) wait.cancel();
+    onAbort.cancel();
   }
 }
 
@@ -113,6 +128,12 @@ class UpdateEvents {
     // has no cancellation, and the alternative is a thread per wait.
     this._pending = null;
     this._waiters = new Set();
+    // Set when the native wait fails (watcher death — close() is
+    // checked first and takes precedence). The subscription can never
+    // fire again: the shared watcher's sender is gone, and a fresh
+    // native next() would reject instantly. Internal wait loops check
+    // this to degrade to poll cadence instead of hot-looping.
+    this._dead = null;
   }
 
   raw() {
@@ -130,6 +151,9 @@ class UpdateEvents {
   _subscribe() {
     if (this._closed) {
       return { promise: Promise.resolve(), cancel() {} };
+    }
+    if (this._dead != null) {
+      return { promise: Promise.reject(this._dead), cancel() {} };
     }
     if (!this._pending) {
       const pending = this._ev.next().then(
@@ -154,6 +178,7 @@ class UpdateEvents {
   _settle(pending, err) {
     if (this._pending !== pending) return;
     this._pending = null;
+    if (err != null) this._dead = err;
     const waiters = [...this._waiters];
     this._waiters.clear();
     for (const w of waiters) {
@@ -519,7 +544,11 @@ class StreamSubscription {
         this._maybeSaveOffset();
         return { done: false, value: event };
       }
-      await this._updates.next().catch(() => undefined);
+      // 1 s fallback poll: while the watcher is live the event wait
+      // wins every race, so this costs nothing; when the watcher is
+      // dead it bounds the loop to poll cadence instead of spinning
+      // on instantly-rejecting waits.
+      await waitForUpdateOrTimeout(this._updates, null, 1000);
     }
     return { done: true, value: undefined };
   }

--- a/packages/honker-node/test/api.test.js
+++ b/packages/honker-node/test/api.test.js
@@ -200,6 +200,122 @@ test('listener wakes on notify after fallback poll timeouts', async () => {
   }
 });
 
+test('poll timeouts remove their abort listeners', async () => {
+  const { path: dbPath, open, cleanup } = tmpdb();
+  const db = open(dbPath);
+  try {
+    const q = db.queue('q');
+    const waker = q.claimWaker({ idlePollS: 0.001 });
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(), 200);
+
+    // Count listeners on the real AbortSignal. Every poll iteration
+    // subscribes to 'abort'; losing the race to the timeout must
+    // remove that listener again (issue #67).
+    let added = 0;
+    let removed = 0;
+    const signal = controller.signal;
+    const realAdd = signal.addEventListener.bind(signal);
+    const realRemove = signal.removeEventListener.bind(signal);
+    signal.addEventListener = (...args) => {
+      added += 1;
+      return realAdd(...args);
+    };
+    signal.removeEventListener = (...args) => {
+      removed += 1;
+      return realRemove(...args);
+    };
+
+    try {
+      await waker.next('worker', { signal });
+    } finally {
+      clearTimeout(abortTimer);
+      waker.close();
+    }
+
+    assert.ok(added >= 2, `expected several poll iterations, saw ${added}`);
+    // The listener whose abort fires is auto-removed by the platform
+    // (once: true) without a removeEventListener call — allow that one.
+    assert.ok(
+      added - removed <= 1,
+      `${added - removed} abort listeners leaked across poll timeouts`
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('watcher death degrades wait loops to poll cadence', {
+  // Same trigger as the watcher-death contract tests: atomically
+  // replace the db file so the watcher thread panics and dies.
+  skip: process.platform === 'win32' ? 'rename-over-open denied on Windows' : false,
+}, async () => {
+  const fs = require('node:fs');
+  const { path: dbPath, open, cleanup } = tmpdb();
+  const db = open(dbPath);
+  try {
+    const tx = db.transaction();
+    tx.execute('CREATE TABLE _warm (i INTEGER)');
+    tx.commit();
+    await delay(100);
+
+    const updates = db.updateEvents();
+    const replacement = `${dbPath}.replacement`;
+    fs.writeFileSync(replacement, '');
+    fs.renameSync(replacement, dbPath);
+
+    // Public contract: next() rejects once the watcher dies (an
+    // ordinary wake may come first — keep awaiting until rejection).
+    let raised = false;
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline && !raised) {
+      const result = await updates.next().then(() => null, (e) => e);
+      if (result instanceof Error) raised = true;
+    }
+    assert.ok(raised, 'next() must reject after watcher death');
+    assert.ok(updates._dead, 'the death is recorded on the subscription');
+
+    // The wait loops must fall back to poll cadence. Count real
+    // claimOne calls over one abort window: poll cadence (200 ms)
+    // means ~3 calls; a hot loop on instantly-rejecting waits means
+    // thousands. After the replace the db itself may or may not still
+    // answer (the panic message says to reopen) — that's out of scope
+    // here, so the loop's own SQL calls are made error-tolerant; only
+    // their cadence is under test.
+    const q = db.queue('q');
+    const tolerant = (fn, fallback) => (...args) => {
+      try {
+        return fn(...args);
+      } catch {
+        return fallback;
+      }
+    };
+    q._nextClaimAt = tolerant(q._nextClaimAt.bind(q), null);
+    let claims = 0;
+    const realClaimOne = q.claimOne.bind(q);
+    q.claimOne = tolerant((workerId) => {
+      claims += 1;
+      return realClaimOne(workerId);
+    }, null);
+    const waker = q.claimWaker({ idlePollS: 0.2 });
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(), 500);
+    try {
+      const result = await waker.next('worker', { signal: controller.signal });
+      assert.equal(result, null);
+    } finally {
+      clearTimeout(abortTimer);
+      waker.close();
+    }
+    assert.ok(
+      claims <= 8,
+      `${claims} claimOne calls in 500 ms — a hot loop would make thousands`
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 test('no unhandled promise rejections from shared waits', async () => {
   // Last test in the file (node --test runs top-level tests in order):
   // gives any stray rejection from the scenarios above time to surface.


### PR DESCRIPTION
## Summary

Two pre-existing leaks in the Node wait loops, the remaining follow-ups from the #68/#69 thread-leak review chain. Closes #67.

- **#67 — abort listener accumulation.** Every `waitForUpdateOrTimeout` iteration added an `abort` listener to the caller's signal that was only removed if the abort actually fired (`{ once: true }` listeners are platform-removed only on fire). A long-running scheduler or claim waker polling at 5 s leaked ~17k listeners/day per signal; aggressive pollers hit it in minutes. `abortPromise` now returns `{ promise, cancel }` that removes the listener, and the wait cancels in `finally` — the same pattern as the waiter-set.
- **Watcher-death hot loop (pre-existing, all versions).** When the watcher thread dies (e.g. db file replaced), every native wait rejects instantly, and the claim waker / listener / scheduler / stream loops spun on them at full CPU forever. `UpdateEvents` now records the death (`_dead`): the public `next()` keeps rejecting (contract from `watcher_backends_e2e.js` unchanged), and `waitForUpdateOrTimeout` skips the event wait once dead, degrading the loops to plain poll cadence — which is the useful behavior, since the db itself may still serve queries. `StreamSubscription` moves onto `waitForUpdateOrTimeout` with a 1 s fallback poll (free while the watcher is live — the event always wins the race; bounded when dead) instead of its own unguarded `next()` loop.

## Tests (real binding, no mocks)

- **Abort listeners**: instruments a real `AbortSignal`'s `add/removeEventListener` across ~200 poll timeouts and asserts the counts balance (±1 for the platform-removed firing listener). Fails on the old code (~200 leaked).
- **Watcher death**: uses the real atomic-replace trigger — asserts `next()` rejects, `_dead` is recorded, and the claim waker then holds poll cadence, proven by counting real `claimOne` calls over a 500 ms window (≤8 with the fix, thousands with the hot loop). The db's own usability after the replace is explicitly out of scope (the panic says to reopen), so the loop's SQL calls are made error-tolerant for the cadence measurement.

Both fail against the previous implementation.

## Validation

- `node --test` over api/basic/parity/watcher_backends*/phase_mantle with `kernel-watcher,shm-fast-path` build: 85 passed, 0 failed
- `test/api.test.js` 10/10 across 3 consecutive runs (the death test is timing-sensitive by nature)
- Adversarial e2e script (12 checks): all pass
