### PR TITLE
fix(node): degrade event-only waits to poll cadence on dead watcher

### DIFF
--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -61,6 +61,11 @@ async function waitForUpdateOrTimeout(updateEvents, signal, timeoutMs) {
   // native-wait failures): skip the event wait and degrade to plain
   // poll cadence instead of hot-looping on instantly-rejecting waits.
   const wait = updateEvents._dead == null ? updateEvents._subscribe() : null;
+  // An event-only wait (timeoutMs == null) on a dead watcher could
+  // never settle — not even close() would wake it, since there is no
+  // parked waiter left to reject. Degrade it to a 1 s cadence so the
+  // wait loops keep re-checking their closed/abort flags.
+  const effectiveMs = wait == null && timeoutMs == null ? 1000 : timeoutMs;
   const onAbort = abortPromise(signal);
   try {
     // Waiter promises reject on watcher death / close(); internal wait
@@ -68,7 +73,7 @@ async function waitForUpdateOrTimeout(updateEvents, signal, timeoutMs) {
     // flags and exit), so swallow it here.
     const racers = [];
     if (wait) racers.push(wait.promise.catch(() => undefined));
-    if (timeoutMs != null) racers.push(delay(Math.max(0, timeoutMs)));
+    if (effectiveMs != null) racers.push(delay(Math.max(0, effectiveMs)));
     racers.push(onAbort.promise);
     await Promise.race(racers);
   } finally {

--- a/packages/honker-node/test/api.test.js
+++ b/packages/honker-node/test/api.test.js
@@ -316,6 +316,64 @@ test('watcher death degrades wait loops to poll cadence', {
   }
 });
 
+test('event-only waker still exits after watcher death', {
+  // Regression: a waker with idlePollS null parked before the watcher
+  // dies re-waits on the dead path, where an event-only wait could
+  // never settle — close() could not wake it (hang). The dead path
+  // degrades null timeouts to a 1 s cadence instead.
+  skip: process.platform === 'win32' ? 'rename-over-open denied on Windows' : false,
+  timeout: 15000,
+}, async () => {
+  const fs = require('node:fs');
+  const { path: dbPath, open, cleanup } = tmpdb();
+  const db = open(dbPath);
+  try {
+    const tx = db.transaction();
+    tx.execute('CREATE TABLE _warm (i INTEGER)');
+    tx.commit();
+    await delay(100);
+
+    const q = db.queue('q');
+    // The replace may leave the db itself broken (disk I/O error on
+    // later reads) — out of scope here; only the wait cadence is
+    // under test, so the loop's SQL calls are made error-tolerant.
+    const tolerant = (fn, fallback) => (...args) => {
+      try {
+        return fn(...args);
+      } catch {
+        return fallback;
+      }
+    };
+    q._nextClaimAt = tolerant(q._nextClaimAt.bind(q), null);
+    q.claimOne = tolerant(q.claimOne.bind(q), null);
+    const waker = q.claimWaker({ idlePollS: null }); // event-only, no signal
+    const parked = waker.next('worker');
+    await delay(100); // waker is parked in its event wait
+
+    const replacement = `${dbPath}.replacement`;
+    fs.writeFileSync(replacement, '');
+    fs.renameSync(replacement, dbPath);
+
+    // Wait for the death to reach the waker's own subscription.
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline && waker._updates._dead == null) {
+      await delay(50);
+    }
+    assert.ok(waker._updates._dead, 'watcher death reached the waker');
+
+    const started = Date.now();
+    waker.close();
+    const result = await parked;
+    assert.equal(result, null);
+    assert.ok(
+      Date.now() - started < 5000,
+      'close() must unblock an event-only wait on a dead watcher'
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 test('no unhandled promise rejections from shared waits', async () => {
   // Last test in the file (node --test runs top-level tests in order):
   // gives any stray rejection from the scenarios above time to surface.


### PR DESCRIPTION
## Summary

Found during a post-merge adversarial review of #73 (which shipped in the `node-v0.4.3` tag, not yet published to npm).

#73's dead-watcher degradation has a corner-case regression: a wait loop parked with an **explicit null poll interval** (`idlePollS: null` / `fallbackPollS: null`) **and no abort signal** re-waits on the dead path after the watcher dies. That path races only the abort promise — no parked waiter left to reject, no timeout — so it can never settle again. `close()` cannot wake it: **a hang**, where the pre-#73 behavior was a close-responsive hot loop. Reproduced against the real atomic-replace death trigger: `waker.next()` still parked 2.5 s after `close()`.

Every default configuration uses a finite poll (waker 5 s, listener 15 s, stream 1 s) and is unaffected — those paths are strictly better after #73. The hang needs all three: dead watcher + explicit null poll + no signal.

## Fix

In `waitForUpdateOrTimeout`, when the watcher is dead and the wait is event-only (`timeoutMs == null`), race a 1 s cadence so the loops keep re-checking their closed/abort flags. Finite intervals are untouched.

## Tests

New regression test: real atomic-replace death with a null-poll waker parked before the death — hangs the full 15 s test timeout on the previous code, returns `null` within ~1 s of `close()` with the fix. The loop's SQL calls are made error-tolerant (post-replace db usability is nondeterministic and out of scope — only the wait cadence is under test).

## Validation

- New test: 15 s timeout hang on previous code, ~1 s pass with fix
- Full node suite with `kernel-watcher,shm-fast-path` build: 86 passed, 0 failed
- `test/api.test.js` 11/11 across 3 consecutive runs
