### PR TITLE
fix(bun,node): stream resume off-by-one; 'watcher died' rejection message

### DIFF
--- a/packages/honker-bun/src/index.ts
+++ b/packages/honker-bun/src/index.ts
@@ -1030,7 +1030,11 @@ async function* subscribeImpl(
         continue;
       }
       for (const ev of events) {
-        yield ev;
+        // Advance BEFORE the yield: if the consumer breaks or throws
+        // after receiving this event, the offset (and any periodic
+        // save) must already reflect it — otherwise the finally-flush
+        // saves the previous offset and the event is re-delivered on
+        // the next subscribe.
         lastOffset = ev.offset;
         const enoughEvents = saveEveryN > 0 && lastOffset - lastSaved >= saveEveryN;
         const enoughTime = saveEveryS > 0 && Date.now() - lastSaveAt >= saveEveryS * 1000;
@@ -1039,6 +1043,7 @@ async function* subscribeImpl(
           lastSaved = lastOffset;
           lastSaveAt = Date.now();
         }
+        yield ev;
       }
     }
   } finally {

--- a/packages/honker-bun/test/parity.test.ts
+++ b/packages/honker-bun/test/parity.test.ts
@@ -208,6 +208,34 @@ maybe("honker-bun parity — Stream", () => {
   );
 
   test(
+    "breaking mid-stream resumes after the last delivered event",
+    withDb(async (db) => {
+      const s = db.stream("orders");
+      s.publish({ i: 1 });
+      s.publish({ i: 2 });
+
+      // Consume one event, then break — the on-close flush must save
+      // the offset of the event actually delivered, not the one
+      // before it (regression: the yield preceded the offset advance,
+      // so the final event was re-delivered on the next subscribe).
+      for await (const ev of s.subscribe("billing")) {
+        expect((ev.payload as any).i).toBe(1);
+        break;
+      }
+      expect(s.getOffset("billing")).toBe(1);
+
+      const resumed = s.subscribe("billing")[Symbol.asyncIterator]();
+      try {
+        const next = await resumed.next();
+        expect(next.done).toBe(false);
+        expect((next.value.payload as any).i).toBe(2);
+      } finally {
+        await resumed.return?.();
+      }
+    }),
+  );
+
+  test(
     "publishTx + saveOffsetTx respect rollback",
     withDb((db) => {
       const s = db.stream("orders");

--- a/packages/honker-node/src/lib.rs
+++ b/packages/honker-node/src/lib.rs
@@ -414,12 +414,19 @@ impl Drop for UpdateEvents {
 #[napi]
 impl UpdateEvents {
     /// Await the next database update. Resolves on every DB commit.
+    /// Rejects with a "watcher died or was closed" message when the
+    /// subscription's channel closes — either because the watcher
+    /// thread died (e.g. the db file was replaced) or because close()
+    /// unsubscribed. Callers can match on "watcher died" to decide
+    /// whether to reopen the database.
     #[napi]
     pub async fn next(&self) -> Result<()> {
         let rx = self.rx.clone();
         tokio::task::spawn_blocking(move || {
             let r = rx.lock();
-            r.recv().map_err(napi_err)
+            r.recv().map_err(|_| {
+                napi_err("honker update watcher died or was closed (subscription channel closed)")
+            })
         })
         .await
         .map_err(napi_err)??;

--- a/packages/honker-node/test/api.test.js
+++ b/packages/honker-node/test/api.test.js
@@ -174,7 +174,7 @@ test('UpdateEvents.next() rejects when closed mid-wait', async () => {
     const pending = updates.next();
     await delay(50); // let the native wait park
     updates.close();
-    await assert.rejects(pending);
+    await assert.rejects(pending, /watcher died|closed/i);
   } finally {
     cleanup();
   }
@@ -267,12 +267,18 @@ test('watcher death degrades wait loops to poll cadence', {
     // Public contract: next() rejects once the watcher dies (an
     // ordinary wake may come first — keep awaiting until rejection).
     let raised = false;
+    let result = null;
     const deadline = Date.now() + 5000;
     while (Date.now() < deadline && !raised) {
-      const result = await updates.next().then(() => null, (e) => e);
+      result = await updates.next().then(() => null, (e) => e);
       if (result instanceof Error) raised = true;
     }
     assert.ok(raised, 'next() must reject after watcher death');
+    assert.match(
+      String(result && result.message),
+      /watcher died/i,
+      'rejection must be identifiable as watcher death'
+    );
     assert.ok(updates._dead, 'the death is recorded on the subscription');
 
     // The wait loops must fall back to poll cadence. Count real


### PR DESCRIPTION
## Summary

Two binding bugs found during a full docs review (every doc example was executed or compiled against the real bindings — these two were behavioral bugs the docs inadvertently exposed):

- **fix(bun): stream resume off-by-one.** `subscribeImpl` advanced `lastOffset` *after* yielding each event. A consumer that `break`s (or throws) after receiving an event had the on-close flush save the *previous* offset, so the last delivered event was re-delivered on the next subscribe. Now the offset advances (and periodic saves happen) *before* the yield, matching the Node wrapper. Regression test: consume one event, break, assert saved offset and that resume delivers the *next* event — fails on the old ordering.
- **fix(node): 'watcher died' rejection message.** `UpdateEvents.next()` rejected with the raw mpsc error `receiving on a closed channel` when the watcher thread died or `close()` unsubscribed — indistinguishable from a mundane channel error, so callers couldn't detect watcher death programmatically. Now rejects with `honker update watcher died or was closed (subscription channel closed)`. Tests assert the message on both the death and close-mid-wait paths.

## Validation

- Bun: new test fails pre-fix, passes post-fix; full suite 58/58 (`bun test`, real extension build)
- Node: full suite 86/86 with `kernel-watcher,shm-fast-path` build (`test/api.test.js` includes the new message assertions; `watcher_backends_e2e.js` rejection-contract tests still pass)
