### PR TITLE
docs: add examples READMEs for bun, elixir, go, rust, ruby bindings

### DIFF
--- a/packages/honker-bun/examples/README.md
+++ b/packages/honker-bun/examples/README.md
@@ -1,0 +1,22 @@
+# Bun examples
+
+Each example is runnable from `packages/honker-bun` once the Honker SQLite
+extension is built:
+
+```bash
+cargo build --release -p honker-extension    # if you haven't already
+HONKER_EXTENSION_PATH=../../target/release/libhonker_ext.so \
+    bun run examples/basic.ts
+```
+
+Both examples default to `target/release/libhonker_ext.dylib` in the repo root,
+so on macOS you can drop the env var.
+
+| File | What it shows |
+|---|---|
+| [`basic.ts`](basic.ts) | enqueue → `claimOne` → `ack` via the typed `db.queue(...)` wrapper |
+| [`atomic.ts`](atomic.ts) | `INSERT INTO orders` + `honker_enqueue(...)` committed in one `db.raw.transaction(...)`. Throwing inside the transaction rolls back both. |
+
+`atomic.ts` works in a temp directory and cleans up after itself. `basic.ts`
+writes `demo.db` in the working directory, so delete it between runs if you
+want a clean queue.

--- a/packages/honker-bun/examples/basic.ts
+++ b/packages/honker-bun/examples/basic.ts
@@ -4,7 +4,7 @@ import { open } from "../src/index.ts";
 const EXT_PATH =
   process.env.HONKER_EXTENSION_PATH ??
   new URL(
-    "../../../target/release/libhonker_extension.dylib",
+    "../../../target/release/libhonker_ext.dylib",
     import.meta.url,
   ).pathname;
 

--- a/packages/honker-ex/examples/README.md
+++ b/packages/honker-ex/examples/README.md
@@ -1,0 +1,22 @@
+# Elixir examples
+
+Each example is runnable from `packages/honker-ex` once the Honker SQLite
+extension is built:
+
+```bash
+cargo build --release -p honker-extension    # if you haven't already
+HONKER_EXTENSION_PATH=../../target/release/libhonker_ext.so \
+    mix run examples/basic.exs
+```
+
+Both examples default to `target/release/libhonker_ext.dylib` in the repo root,
+so on macOS you can drop the env var.
+
+| File | What it shows |
+|---|---|
+| [`basic.exs`](basic.exs) | `Honker.Queue.enqueue/3` → `claim_one/3` → `Honker.Job.ack/2`, draining the queue recursively |
+| [`atomic.exs`](atomic.exs) | `INSERT INTO orders` + `honker_enqueue(...)` between `BEGIN IMMEDIATE` and `COMMIT`. The `ROLLBACK` path drops both. |
+
+`atomic.exs` works in a temp directory and cleans up after itself. `basic.exs`
+writes `demo.db` in the working directory, so delete it between runs if you
+want a clean queue.

--- a/packages/honker-go/examples/README.md
+++ b/packages/honker-go/examples/README.md
@@ -1,0 +1,22 @@
+# Go examples
+
+Each example is a `main` package in its own directory. Build the Honker SQLite
+extension first, then run from `packages/honker-go`:
+
+```bash
+cargo build --release -p honker-extension    # if you haven't already
+go run -tags sqlite_load_extension ./examples/atomic
+```
+
+The `sqlite_load_extension` build tag is required — without it the driver
+refuses to load the extension.
+
+| File | What it shows |
+|---|---|
+| [`basic/main.go`](basic/main.go) | `Queue.Enqueue` → `ClaimOne` → `Job.Ack` via the typed `db.Queue(...)` wrapper |
+| [`atomic/main.go`](atomic/main.go) | `INSERT INTO orders` + `honker_enqueue(...)` on one `*sql.Tx`. Rollback drops both. |
+
+`atomic/main.go` locates the built extension under `target/release/` on its own
+and works in a temp directory that it cleans up. `basic/main.go` expects
+`./libhonker_extension.dylib` next to the working directory and writes
+`demo.db` there, so copy or symlink the built extension before running it.

--- a/packages/honker-rs/examples/README.md
+++ b/packages/honker-rs/examples/README.md
@@ -1,0 +1,18 @@
+# Rust examples
+
+Each example is runnable from `packages/honker-rs` with Cargo's `--example`
+flag:
+
+```bash
+cargo run --example basic
+cargo run --release --example atomic
+```
+
+| File | What it shows |
+|---|---|
+| [`basic.rs`](basic.rs) | `Queue::enqueue` → `claim_one` → `Job::ack` via the typed `db.queue(...)` wrapper |
+| [`atomic.rs`](atomic.rs) | `INSERT INTO orders` + `q.enqueue_tx(&tx, ...)` on one `db.transaction()`. Rollback drops both — no dual-write, no outbox table. |
+
+`atomic.rs` runs against a `tempfile::tempdir()` and asserts the committed and
+rolled-back counts, so it doubles as a smoke test. `basic.rs` writes `demo.db`
+in the working directory, so delete it between runs if you want a clean queue.

--- a/packages/honker-ruby/examples/README.md
+++ b/packages/honker-ruby/examples/README.md
@@ -1,0 +1,22 @@
+# Ruby examples
+
+Each example is runnable from `packages/honker-ruby`. A released gem ships the
+extension already built; from a checkout, build it and point Honker at it:
+
+```bash
+cargo build --release -p honker-extension    # if you haven't already
+HONKER_EXTENSION_PATH=../../target/release/libhonker_ext.so \
+    ruby examples/basic.rb
+```
+
+| File | What it shows |
+|---|---|
+| [`basic.rb`](basic.rb) | `Queue#enqueue` → `claim_one` → `Job#ack` via the typed `db.queue(...)` wrapper |
+| [`atomic.rb`](atomic.rb) | `INSERT INTO orders` + `honker_enqueue(...)` inside one `sqlite3` transaction on `db.db`. Raising inside the block rolls back both. |
+
+`Queue#enqueue` runs its own SQLite write, so `atomic.rb` drops to the raw
+connection to keep the business write and the job in the same transaction.
+
+`atomic.rb` works in a `Dir.mktmpdir` block and cleans up after itself.
+`basic.rb` writes `demo.db` in the working directory, so delete it between runs
+if you want a clean queue.

--- a/packages/honker-ruby/examples/README.md
+++ b/packages/honker-ruby/examples/README.md
@@ -14,8 +14,17 @@ HONKER_EXTENSION_PATH=../../target/release/libhonker_ext.so \
 | [`basic.rb`](basic.rb) | `Queue#enqueue` → `claim_one` → `Job#ack` via the typed `db.queue(...)` wrapper |
 | [`atomic.rb`](atomic.rb) | `INSERT INTO orders` + `honker_enqueue(...)` inside one `sqlite3` transaction on `db.db`. Raising inside the block rolls back both. |
 
-`Queue#enqueue` runs its own SQLite write, so `atomic.rb` drops to the raw
-connection to keep the business write and the job in the same transaction.
+`Queue#enqueue` runs its own SQLite write, so it is *not* atomic with a write
+you issue yourself. `atomic.rb` drops to the raw connection to show the
+extension-level `honker_enqueue(...)` primitive, but you do not have to: the
+binding also ships a typed transaction API that does the same thing —
+
+```ruby
+db.transaction do |tx|
+  tx.execute("INSERT INTO orders (user_id, total) VALUES (?, ?)", [42, 9900])
+  q.enqueue_tx(tx, { to: "alice@example.com", order_id: 42 })
+end
+```
 
 `atomic.rb` works in a `Dir.mktmpdir` block and cleans up after itself.
 `basic.rb` writes `demo.db` in the working directory, so delete it between runs


### PR DESCRIPTION
Mirrors the format of packages/honker/examples/README.md: a runnable command, a file/what-it-shows table, and a note on leftover state.


Claude-Session: https://claude.ai/code/session_017WJwW7TzyZGEtJyvKQYSWo