### PR TITLE
fix: prevent TOCTOU race in prune_notifications max_keep logic

### DIFF
--- a/packages/honker/python/honker/_honker.py
+++ b/packages/honker/python/honker/_honker.py
@@ -1213,19 +1213,18 @@ class Database:
             conditions.append("created_at < unixepoch() - ?")
             params.append(int(older_than_s))
         if max_keep is not None:
-            # Pre-compute MAX(id) once instead of a subquery the
-            # planner might (or might not) hoist out of the DELETE
-            # predicate. Also correctly handles an empty table and
-            # a max_keep larger than the current row count — both
-            # devolve to "nothing qualifies for id-based deletion."
-            rows = self.query(
-                "SELECT MAX(id) AS m FROM _honker_notifications"
+            # Use a subquery so MAX(id) is evaluated atomically
+            # inside the DELETE, avoiding a TOCTOU race where rows
+            # inserted between a separate SELECT and the DELETE
+            # would cause the wrong number of rows to be removed.
+            # COALESCE handles an empty table (MAX returns NULL)
+            # and when max_keep >= row count the subtraction goes
+            # negative, matching zero rows — both are safe no-ops.
+            conditions.append(
+                "id <= (SELECT COALESCE(MAX(id), 0) - ? "
+                "FROM _honker_notifications)"
             )
-            max_id = rows[0]["m"] if rows and rows[0]["m"] is not None else 0
-            threshold = max_id - int(max_keep)
-            if threshold >= 1:
-                conditions.append("id <= ?")
-                params.append(threshold)
+            params.append(int(max_keep))
         if not conditions:
             return 0
         with self.transaction() as tx:


### PR DESCRIPTION
## Summary

Fixed a time-of-check-time-of-use (TOCTOU) race condition in `prune_notifications()` where `MAX(id)` was read outside the DELETE transaction, allowing concurrent inserts to cause incorrect pruning.

## Changes

**`packages/honker/python/honker/_honker.py`** (lines 1215-1228)

**Before:** The function ran a separate `SELECT MAX(id)` query, computed `threshold = max_id - max_keep`, then used `id <= threshold` in a DELETE inside a different transaction. If rows were inserted between the SELECT and DELETE, the threshold was stale and more rows than intended would survive.

**After:** Uses a subquery `id <= (SELECT COALESCE(MAX(id), 0) - ? FROM _honker_notifications)` directly in the DELETE condition. This evaluates `MAX(id)` atomically within the same statement, eliminating the race window.

Edge cases preserved:
- Empty table: `COALESCE(MAX(id), 0)` returns 0, subtraction goes negative → zero rows match → safe no-op
- `max_keep >= row count`: subtraction goes negative → zero rows match → safe no-op
- `older_than_s` condition: unchanged, still OR-joined with the id condition

## Test plan

- [x] Verified the subquery produces identical results to the old logic in the non-concurrent case
- [x] Verified empty table and max_keep > row_count edge cases are safe no-ops
- [x] The COALESCE handles NULL from MAX on empty tables