### PR TITLE
fix: close CI review gaps after #78

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,9 @@ jobs:
           prefix-key: "v1-bench-${{ hashFiles('bench/wal_index_methods/Cargo.toml', 'bench/wal_index_methods/src/**/*.rs') }}"
       - name: Run wal_index_methods bench
         working-directory: bench/wal_index_methods
-        run: cargo run --locked --release | tee /tmp/bench.out
+        run: |
+          set -o pipefail
+          cargo run --locked --release | tee /tmp/bench.out
       - name: Assert mmap-shm beats cached PRAGMA by >=50x
         run: |
           set -euo pipefail

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,8 @@ lint:
 lint-fix:
 	cargo fmt --all
 	cargo clippy --fix --workspace --all-targets --locked --allow-dirty
+	cargo clippy --fix --workspace --all-targets --locked --allow-dirty \
+		--features honker-core/kernel-watcher,honker-core/shm-fast-path
 
 # ---- builds ----
 

--- a/honker-core/src/kernel_watcher.rs
+++ b/honker-core/src/kernel_watcher.rs
@@ -64,7 +64,6 @@ pub(crate) fn run_kernel_watch_loop<F>(
     #[cfg(target_os = "macos")]
     {
         run_kqueue_loop(db_path, on_change, stop, ready);
-        return;
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -187,7 +186,7 @@ fn check_db_identity(db_path: &std::path::Path, initial: (u64, u64)) -> bool {
 pub(crate) fn probe(db_path: &std::path::Path) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        return probe_kqueue(db_path);
+        probe_kqueue(db_path)
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -227,7 +226,7 @@ mod macos {
         }
 
         fn add_vnode(&self, fd: libc::c_int) -> Result<(), String> {
-            let mut event = libc::kevent {
+            let event = libc::kevent {
                 ident: fd as libc::uintptr_t,
                 filter: libc::EVFILT_VNODE,
                 flags: libc::EV_ADD | libc::EV_ENABLE | libc::EV_CLEAR,
@@ -240,8 +239,7 @@ mod macos {
                 data: 0,
                 udata: ptr::null_mut(),
             };
-            let n =
-                unsafe { libc::kevent(self.fd, &mut event, 1, ptr::null_mut(), 0, ptr::null()) };
+            let n = unsafe { libc::kevent(self.fd, &event, 1, ptr::null_mut(), 0, ptr::null()) };
             if n < 0 {
                 Err(format!(
                     "kevent add failed: {}",

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -2391,15 +2391,19 @@ while True:
     fn kernel_watcher_detects_all_commits() {
         use std::sync::atomic::{AtomicU32, Ordering as AO};
 
-        let tmp = std::env::temp_dir().join(format!(
-            "honker-kernel-watcher-{}-{}",
+        // The kernel backend watches the database's parent directory.
+        // Give this test an isolated directory so parallel tests and
+        // unrelated /tmp activity cannot inflate the runaway-wake count.
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "honker-kernel-watcher-dir-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .subsec_nanos()
         ));
-        let _ = std::fs::remove_file(&tmp);
+        std::fs::create_dir(&tmp_dir).unwrap();
+        let tmp = tmp_dir.join("app.db");
 
         let writer = open_conn(tmp.to_str().unwrap(), false).unwrap();
         writer.execute_batch("CREATE TABLE t (x INT)").unwrap();
@@ -2441,9 +2445,11 @@ while True:
 
         let observed = count.load(AO::SeqCst);
         drop(watcher);
+        drop(writer);
         let _ = std::fs::remove_file(&tmp);
         let _ = std::fs::remove_file(format!("{}-wal", tmp.display()));
         let _ = std::fs::remove_file(format!("{}-shm", tmp.display()));
+        let _ = std::fs::remove_dir_all(&tmp_dir);
 
         // Experimental contract: spurious wakes are allowed (the backend
         // fires on every filesystem event, and SQLite produces several
@@ -2619,8 +2625,11 @@ while True:
     /// detects every committed insert. Tolerates +1 wake (a commit
     /// straddling the drain boundary) but does not tolerate misses.
     fn watcher_works_in_journal_mode(backend: WatcherBackend, mode: &str) {
-        let tmp = std::env::temp_dir().join(format!(
-            "honker-watcher-{}-{}-{}-{}",
+        // Kernel watchers observe every entry event in the parent
+        // directory. Isolate the database so upper bounds measure this
+        // watcher, not unrelated files created by parallel tests.
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "honker-watcher-dir-{}-{}-{}-{}",
             mode.to_ascii_lowercase(),
             std::process::id(),
             std::time::SystemTime::now()
@@ -2635,7 +2644,8 @@ while True:
                 WatcherBackend::ShmFastPath => "shm",
             },
         ));
-        let _ = std::fs::remove_file(&tmp);
+        std::fs::create_dir(&tmp_dir).unwrap();
+        let tmp = tmp_dir.join("app.db");
 
         // Watcher inherits the file's journal mode, so set it before opening.
         let setup = Connection::open(&tmp).unwrap();
@@ -2676,6 +2686,7 @@ while True:
         let _ = std::fs::remove_file(format!("{}-wal", tmp.display()));
         let _ = std::fs::remove_file(format!("{}-shm", tmp.display()));
         let _ = std::fs::remove_file(format!("{}-journal", tmp.display()));
+        let _ = std::fs::remove_dir_all(&tmp_dir);
 
         // Polling/shm dedupe → ~1 wake per commit. Kernel fires per
         // filesystem event (inotify is granular) → upper bound is just

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -2383,15 +2383,11 @@ while True:
     /// observed 3 wakes for 5 commits on a CI runner. kernel_watcher.rs
     /// documents missed wakes as permitted, and this backend has no
     /// data_version verification or safety-net poll behind it, so there
-    /// is nothing to recover the lost event. The backend is not proven
-    /// on Windows; say so rather than loosening the threshold until it
-    /// passes. Linux and macOS deliver reliably and stay gated.
+    /// is nothing to recover the lost event. Windows still runs the test
+    /// and enforces the runaway-wake bound; only its lower bound is waived.
+    /// Linux and macOS deliver reliably and stay gated.
     #[test]
     #[cfg(feature = "kernel-watcher")]
-    #[cfg_attr(
-        windows,
-        ignore = "ReadDirectoryChangesW drops/coalesces events; missed wakes are permitted by the backend contract"
-    )]
     fn kernel_watcher_detects_all_commits() {
         use std::sync::atomic::{AtomicU32, Ordering as AO};
 
@@ -2451,13 +2447,27 @@ while True:
 
         // Experimental contract: spurious wakes are allowed (the backend
         // fires on every filesystem event, and SQLite produces several
-        // events per commit). The thing that must not happen is a *missed*
-        // commit — assert at least n wakes.
+        // events per commit). Keep a generous upper bound on every platform
+        // so a runaway watcher cannot hide behind a Windows test carve-out.
+        let upper = n * 200;
+        assert!(
+            observed <= upper,
+            "kernel watcher detected {observed} wakes for {n} commits, \
+             upper bound {upper} (runaway watcher?)"
+        );
+        #[cfg(not(windows))]
         assert!(
             observed >= n,
             "kernel watcher detected {observed} wakes for {n} commits — \
              missed at least one"
         );
+        #[cfg(windows)]
+        if observed < n {
+            eprintln!(
+                "kernel watcher under-delivered on Windows: \
+                 {observed} wakes for {n} commits"
+            );
+        }
     }
 
     /// Prove that the shm fast path fires on the same commits as the
@@ -2678,15 +2688,26 @@ while True:
             WatcherBackend::ShmFastPath => n + 1,
         };
         assert!(
-            observed >= n,
-            "journal_mode={mode}: observed {observed} wakes for {n} commits \
-             (missed at least one)"
-        );
-        assert!(
             observed <= upper,
             "journal_mode={mode}: observed {observed} wakes for {n} commits, \
              upper bound {upper} (runaway watcher?)"
         );
+        #[cfg(feature = "kernel-watcher")]
+        let allows_missed_wakes = cfg!(windows) && matches!(backend, WatcherBackend::KernelWatch);
+        #[cfg(not(feature = "kernel-watcher"))]
+        let allows_missed_wakes = false;
+        if allows_missed_wakes && observed < n {
+            eprintln!(
+                "journal_mode={mode}: kernel watcher under-delivered on Windows: \
+                 {observed} wakes for {n} commits"
+            );
+        } else {
+            assert!(
+                observed >= n,
+                "journal_mode={mode}: observed {observed} wakes for {n} commits \
+                 (missed at least one)"
+            );
+        }
     }
 
     // ---- Polling × every supported journal mode (regression coverage) ----
@@ -2732,8 +2753,8 @@ while True:
     #[test]
     #[cfg(feature = "kernel-watcher")]
     #[cfg_attr(
-        any(target_os = "macos", windows),
-        ignore = "kqueue: in-place writes don't fire dir events; ReadDirectoryChangesW drops/coalesces them"
+        target_os = "macos",
+        ignore = "kqueue: in-place writes don't fire dir events"
     )]
     fn kernel_watcher_works_in_delete() {
         watcher_works_in_journal_mode(WatcherBackend::KernelWatch, "DELETE");
@@ -2742,8 +2763,8 @@ while True:
     #[test]
     #[cfg(feature = "kernel-watcher")]
     #[cfg_attr(
-        any(target_os = "macos", windows),
-        ignore = "kqueue: in-place writes don't fire dir events; ReadDirectoryChangesW drops/coalesces them"
+        target_os = "macos",
+        ignore = "kqueue: in-place writes don't fire dir events"
     )]
     fn kernel_watcher_works_in_truncate() {
         watcher_works_in_journal_mode(WatcherBackend::KernelWatch, "TRUNCATE");
@@ -2752,8 +2773,8 @@ while True:
     #[test]
     #[cfg(feature = "kernel-watcher")]
     #[cfg_attr(
-        any(target_os = "macos", windows),
-        ignore = "kqueue: in-place writes don't fire dir events; ReadDirectoryChangesW drops/coalesces them"
+        target_os = "macos",
+        ignore = "kqueue: in-place writes don't fire dir events"
     )]
     fn kernel_watcher_works_in_persist() {
         watcher_works_in_journal_mode(WatcherBackend::KernelWatch, "PERSIST");
@@ -2870,10 +2891,6 @@ while True:
         ignore = "notify/kqueue can drop the watcher thread under CI load; functional kernel watcher tests still run"
     )]
     #[cfg(feature = "kernel-watcher")]
-    #[cfg_attr(
-        target_os = "macos",
-        ignore = "kqueue under CI load may deliver zero wakes"
-    )]
     fn kernel_watcher_wake_latency_is_event_driven() {
         let tmp = std::env::temp_dir().join(format!(
             "honker-kw-lat-{}-{}",

--- a/packages/honker-node/test/watcher_backends.js
+++ b/packages/honker-node/test/watcher_backends.js
@@ -95,15 +95,24 @@ for (const backend of [null, 'kernel', 'shm']) {
       if (!db) return;
       const n = 4;
       const counted = await driveCommitsAndCountWakes(db, n, 30);
-      const minWakes = backend === 'kernel' && process.platform === 'win32' ? 1 : n;
-      assert.ok(
-        counted >= minWakes,
-        `watcherBackend=${label}: only ${counted} wakes for ${n} commits`,
-      );
       const maxWakes = backend === 'kernel' ? n * 4 : n + 2;
       assert.ok(
         counted <= maxWakes,
         `watcherBackend=${label}: ${counted} wakes for ${n} commits exceeds bound ${maxWakes}`,
+      );
+      // ReadDirectoryChangesW may drop or coalesce every event in a burst.
+      // Keep the upper-bound assertion above active on Windows, but match
+      // the Rust and Python proofs by recording under-delivery as an explicit
+      // platform limitation instead of pretending one wake is guaranteed.
+      if (backend === 'kernel' && process.platform === 'win32' && counted < n) {
+        t.todo(
+          `kernel-watcher not proven on Windows: ${counted} wakes for ${n} commits`,
+        );
+        return;
+      }
+      assert.ok(
+        counted >= n,
+        `watcherBackend=${label}: only ${counted} wakes for ${n} commits`,
       );
     } finally {
       cleanup();

--- a/scripts/proof/package-install-smoke.sh
+++ b/scripts/proof/package-install-smoke.sh
@@ -73,7 +73,7 @@ echo "== node package install =="
 mkdir -p "$TMP/npm"
 (
   cd "$ROOT/packages/honker-node"
-  npm install
+  npm ci
   cp index.js "$TMP/node-index.js"
   npx napi build --platform --release
   cp "$TMP/node-index.js" index.js


### PR DESCRIPTION
Follow-up to #78.

## What changed

- keep the Windows kernel-watcher characterization tests running so their runaway-wake upper bounds remain enforced; waive only the unsupported no-missed-wakes lower bound
- make the benchmark step propagate a failing `cargo run` through `tee`
- make `make lint-fix` cover the same feature-gated watcher code as `make lint`
- use the newly committed Node lockfile in the package-install proof
- fix new stable-Clippy findings exposed by the lint gate, including duplicate macOS test attributes and mechanical kqueue warnings

## Why

The broad Windows `#[ignore]` attributes hid every assertion in those tests, the benchmark pipeline could report success when Cargo failed, and the local fix target did not match the new CI lint surface.

## Validation

- `make lint`
- `make lint-fix`
- `cargo test -p honker-core --locked --lib`
- `cargo test -p honker-core --locked --lib --features kernel-watcher,shm-fast-path`
- `npm ci --ignore-scripts`
- `bash -n scripts/proof/package-install-smoke.sh`
- `zizmor --min-severity low .github/`
- `actionlint .github/workflows/*.yml` (only pre-existing warnings outside the edited step)
- `git diff --check`
