### PR TITLE
docs: correct binding and release coverage claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ stance recorded in the phase entry that drove it.
   or processing row and returns whether one was removed; `get_job(job_id)`
   is a pure read. Cancelling a claimed-but-unacked job makes the worker's
   later `ack()` a no-op, matching expired-claim semantics.
-- Wired through every maintained binding — Python, Node, Rust, Go, Bun,
-  Ruby, Elixir, C++, and .NET — each with a binding-local round-trip
-  proof, not just the three bindings originally scoped.
+- Wired through nine bindings — Python, Node, Rust, Go, Bun, Ruby,
+  Elixir, C++, and .NET — each with a binding-local round-trip proof,
+  not just the three bindings originally scoped. JVM and Kotlin do not
+  yet expose the Mantle lifecycle methods.
 
 ## Unreleased — correctness priority fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ git tag ext-v0.1.1
 git push origin ext-v0.1.1
 ```
 
-GitHub Actions (`.github/workflows/release-crates.yml`) picks up tags matching `core-v*` / `ext-v*` and builds, verifies, and smoke-tests the crate artifacts. It does not publish — `cargo publish` is a manual step after the proof job is green. The same holds for the other release workflows that exist today.
+GitHub Actions (`.github/workflows/release-crates.yml`) picks up tags matching `core-v*` / `ext-v*` and runs the test suite plus Cargo's package verification. It does not publish — `cargo publish` is a manual step after the proof job is green. The other release workflows that exist today are also proof-only, although their verification depth varies by ecosystem.
 
 Each language binding lives in `packages/` in this repo. Bindings with dedicated release workflows use ecosystem-specific tag prefixes; `honker-rs`, Go, C++, JVM, and Kotlin do not yet have dedicated proof workflows.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,9 @@ git tag ext-v0.1.1
 git push origin ext-v0.1.1
 ```
 
-GitHub Actions (`.github/workflows/release-crates.yml`) picks up tags matching `core-v*` / `ext-v*` and builds, verifies, and smoke-tests the crate artifacts. It does not publish — `cargo publish` is a manual step after the proof job is green. The same holds for every other ecosystem's release workflow.
+GitHub Actions (`.github/workflows/release-crates.yml`) picks up tags matching `core-v*` / `ext-v*` and builds, verifies, and smoke-tests the crate artifacts. It does not publish — `cargo publish` is a manual step after the proof job is green. The same holds for the other release workflows that exist today.
 
-Each language binding lives in `packages/` in this repo and has its own release tag prefix; see each binding's README.
+Each language binding lives in `packages/` in this repo. Bindings with dedicated release workflows use ecosystem-specific tag prefixes; `honker-rs`, Go, C++, JVM, and Kotlin do not yet have dedicated proof workflows.
 
 ## Making changes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -600,15 +600,17 @@ adoption.
 
 This is not 1.0 prep. The goal is simpler: make normal releases boring.
 
-The build-and-verify half is done for seven release workflow families.
-Those workflows fire on their own tag prefix — `core-v*` /
+Seven release workflow families now build package artifacts from their
+own tag prefix — `core-v*` /
 `ext-v*`, `py-v*`, `node-v*`, `bun-v*`, `rb-v*`, `ex-v*`, `dotnet-v*` —
-and each builds the artifact, checks it contains the bundled extension
-or native binary, and smoke-tests a consumer install. A separate
-registry install gauntlet installs published versions from the real
-registries on demand. The per-ecosystem split is the design now, not a
-stopgap: binding versions move independently and a single tag would
-force lockstep bumps.
+but their proof depth is not uniform. Node, Ruby, and .NET smoke-test
+the packaged artifact; Node and .NET also inspect bundled native
+contents. The crates workflow relies on `cargo package` verification,
+Bun and Elixir test the source tree before packing, and Python currently
+only builds and uploads its wheels. A separate registry install gauntlet
+installs published versions from the real registries on demand. The
+per-ecosystem split is the design now, not a stopgap: binding versions
+move independently and a single tag would force lockstep bumps.
 
 The publish half is deliberately absent. Every one of those workflows
 is named `Proof · ...` and stops at uploading artifacts; the actual
@@ -624,6 +626,10 @@ Remaining:
       accident of the workflows having been stripped. If it stays,
       say so in `CONTRIBUTING.md`; if it doesn't, the proof jobs
       already produce exactly the artifacts a publish step needs.
+- [ ] Standardize the desired proof depth. Python still needs an
+      installed-wheel smoke test; Bun and Elixir test before packing
+      rather than from a clean consumer; crates rely on Cargo's package
+      verification rather than a separate consumer project.
 - [ ] Decide the release contract for `honker-rs` and the in-tree
       bindings without dedicated proof workflows (Go, C++, JVM,
       Kotlin): add workflows and tag prefixes, or document the intended

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -322,10 +322,13 @@ the default either way; "available in wheels" is the only flip.
 Phase Mantle itself shipped in PR #42 (see `CHANGELOG.md`): the
 `enabled` column, the six new `honker_scheduler_*` / `honker_cancel` /
 `honker_get_job` SQL functions, scheduler `pause` / `resume` / `remove`
-/ `list` / `update`, and queue `cancel` / `get_job` across every
-maintained binding. Two acceptance items were never met and are the
-only work left here.
+/ `list` / `update`, and queue `cancel` / `get_job` across nine
+bindings. Three items remain:
 
+- [ ] Add the lifecycle methods to the JVM binding and expose them
+      through Kotlin, with binding-local round-trip proofs. These two
+      maintained bindings shipped after PR #42 and do not yet expose
+      `pause` / `resume` / `list` / `update` or `cancel` / `get_job`.
 - [ ] Cross-process proof: `pause` from process A observed by the
       scheduler in process B within ≤ 1 s; `resume` re-emits within
       ≤ 1 s. Current coverage in `tests/test_phase_mantle.py` is
@@ -597,8 +600,8 @@ adoption.
 
 This is not 1.0 prep. The goal is simpler: make normal releases boring.
 
-The build-and-verify half is done, for every ecosystem. Seven
-per-ecosystem workflows fire on their own tag prefix — `core-v*` /
+The build-and-verify half is done for seven release workflow families.
+Those workflows fire on their own tag prefix — `core-v*` /
 `ext-v*`, `py-v*`, `node-v*`, `bun-v*`, `rb-v*`, `ex-v*`, `dotnet-v*` —
 and each builds the artifact, checks it contains the bundled extension
 or native binary, and smoke-tests a consumer install. A separate
@@ -621,9 +624,10 @@ Remaining:
       accident of the workflows having been stripped. If it stays,
       say so in `CONTRIBUTING.md`; if it doesn't, the proof jobs
       already produce exactly the artifacts a publish step needs.
-- [ ] Decide whether the in-tree bindings without a package registry
-      story (Go, C++, JVM, Kotlin) need release automation at all, or
-      whether tag-and-go is the whole contract for them.
+- [ ] Decide the release contract for `honker-rs` and the in-tree
+      bindings without dedicated proof workflows (Go, C++, JVM,
+      Kotlin): add workflows and tag prefixes, or document the intended
+      manual/tag-and-go process.
 - [ ] Keep release notes tied to `CHANGELOG.md`.
 
 ## Later 1.0 Prep


### PR DESCRIPTION
Follow-up to #79.

## Summary

- describe Phase Mantle as shipped across the nine bindings that actually expose its lifecycle APIs
- track JVM/Kotlin lifecycle parity as remaining Mantle work
- describe release automation in terms of the seven proof workflows that exist today
- record the bindings that still lack dedicated release workflows/tag contracts

## Verification

- `git diff --check`
- compared the lifecycle API implementations across all in-tree bindings
- compared the documented tag prefixes with `.github/workflows/release-*.yml`