### PR TITLE
fix: make notification max_keep pruning gap-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ Core (all bindings via `honker_*` SQL / shared extension):
   hardcoded 3.
 - **JSON returns** from claim/get_job/scheduler/stream built with
   `serde_json` (wire shape for string payloads unchanged).
+- **Notification `max_keep` pruning is gap-safe** in Python, Node,
+  Rust, JVM, and .NET. The bindings now retain the newest N rows by
+  rank instead of assuming notification IDs are contiguous;
+  `max_keep=0` deletes all rows and negative values are rejected.
 
 Python:
 

--- a/packages/honker-dotnet/src/Honker/Database.cs
+++ b/packages/honker-dotnet/src/Honker/Database.cs
@@ -173,8 +173,13 @@ public sealed class Database : IDisposable
 
         if (maxKeep is not null)
         {
+            if (maxKeep.Value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxKeep), "maxKeep must not be negative");
+            }
             var index = args.Count;
-            clauses.Add($"id <= (SELECT COALESCE(MAX(id), 0) FROM _honker_notifications) - @p{index}");
+            clauses.Add(
+                $"id <= (SELECT id FROM _honker_notifications ORDER BY id DESC LIMIT 1 OFFSET @p{index})");
             args.Add(maxKeep.Value);
         }
 

--- a/packages/honker-dotnet/tests/Honker.Tests/NotifyStreamTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/NotifyStreamTests.cs
@@ -191,6 +191,40 @@ public sealed class NotifyStreamTests
     }
 
     [Fact]
+    public void PruneNotificationsMaxKeepUsesRowRankAndOrSemantics()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+
+        db.Execute(
+            "INSERT INTO _honker_notifications " +
+            "(id, channel, payload, created_at) VALUES " +
+            "(90, 'ch', '\"old\"', unixepoch()), " +
+            "(100, 'ch', '\"new\"', unixepoch())");
+
+        Assert.Equal(0, db.PruneNotifications(maxKeep: 5));
+        Assert.Equal(0, db.PruneNotifications(maxKeep: 2));
+        Assert.Equal(1, db.PruneNotifications(maxKeep: 1));
+        Assert.Equal(100, Scalar(db, "SELECT id AS c FROM _honker_notifications"));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            db.PruneNotifications(maxKeep: -1));
+        Assert.Equal(1, db.PruneNotifications(maxKeep: 0));
+
+        foreach (var payload in new[] { "fresh-1", "fresh-2", "fresh-3", "old-newest" })
+        {
+            db.Notify("ch", payload);
+        }
+        db.Execute(
+            "UPDATE _honker_notifications SET created_at=0 " +
+            "WHERE payload='\"old-newest\"'");
+
+        Assert.Equal(3, db.PruneNotifications(olderThanSeconds: 1, maxKeep: 2));
+        var rows = db.Query("SELECT payload FROM _honker_notifications");
+        Assert.Single(rows);
+        Assert.Equal("\"fresh-3\"", rows[0]["payload"]);
+    }
+
+    [Fact]
     public void PruneNotificationsNoArgsIsNoOp()
     {
         using var harness = TestHarness.Create();

--- a/packages/honker-jvm/src/main/java/dev/honker/Database.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/Database.java
@@ -135,13 +135,11 @@ public final class Database implements AutoCloseable {
             params.add(Durations.seconds(options.olderThan(), "olderThan"));
         }
         if (options.maxKeep() != null) {
-            long maxId = query("SELECT COALESCE(MAX(id), 0) AS m FROM _honker_notifications")
-                .get(0).getLong("m");
-            long threshold = maxId - options.maxKeep();
-            if (threshold >= 1L) {
-                conditions.add("id <= ?");
-                params.add(threshold);
-            }
+            conditions.add(
+                "id <= (SELECT id FROM _honker_notifications " +
+                "ORDER BY id DESC LIMIT 1 OFFSET ?)"
+            );
+            params.add(options.maxKeep());
         }
         if (conditions.isEmpty()) {
             return 0;

--- a/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
+++ b/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
@@ -204,6 +204,50 @@ class HonkerJvmTest {
     }
 
     @Test
+    void pruneNotificationsMaxKeepUsesRowRankAndOrSemantics() {
+        try (Database db = open()) {
+            db.transactionVoid(tx -> tx.execute(
+                "INSERT INTO _honker_notifications " +
+                "(id, channel, payload, created_at) VALUES " +
+                "(90, 'ch', '\"old\"', unixepoch()), " +
+                "(100, 'ch', '\"new\"', unixepoch())"
+            ));
+
+            assertEquals(0, db.pruneNotifications(
+                NotificationPruneOptions.builder().maxKeep(5).build()));
+            assertEquals(0, db.pruneNotifications(
+                NotificationPruneOptions.builder().maxKeep(2).build()));
+            assertEquals(1, db.pruneNotifications(
+                NotificationPruneOptions.builder().maxKeep(1).build()));
+            assertEquals(100L, db.query(
+                "SELECT id FROM _honker_notifications").get(0).getLong("id"));
+            assertThrows(HonkerInvalidOptionException.class, () ->
+                NotificationPruneOptions.builder().maxKeep(-1));
+            assertEquals(1, db.pruneNotifications(
+                NotificationPruneOptions.builder().maxKeep(0).build()));
+
+            for (String payload : List.of(
+                "\"fresh-1\"", "\"fresh-2\"", "\"fresh-3\"", "\"old-newest\""
+            )) {
+                db.notify("ch", payload);
+            }
+            db.transactionVoid(tx -> tx.execute(
+                "UPDATE _honker_notifications SET created_at=0 " +
+                "WHERE payload='\"old-newest\"'"
+            ));
+            assertEquals(3, db.pruneNotifications(
+                NotificationPruneOptions.builder()
+                    .olderThan(Duration.ofSeconds(1))
+                    .maxKeep(2)
+                    .build()
+            ));
+            assertEquals("\"fresh-3\"", db.query(
+                "SELECT payload FROM _honker_notifications"
+            ).get(0).getString("payload"));
+        }
+    }
+
+    @Test
     void listenerAndStreamCallbackFailuresAreObservable() {
         try (Database db = open()) {
             try (ListenHandle listen = db.listen(

--- a/packages/honker-node/src/lib.rs
+++ b/packages/honker-node/src/lib.rs
@@ -218,7 +218,13 @@ impl Database {
             params.push(SqlValue::Integer(secs));
         }
         if let Some(k) = max_keep {
-            conditions.push("id <= (SELECT MAX(id) - ? FROM _honker_notifications)");
+            if k < 0 {
+                return Err(napi_err("maxKeep must not be negative"));
+            }
+            conditions.push(
+                "id <= (SELECT id FROM _honker_notifications \
+                 ORDER BY id DESC LIMIT 1 OFFSET ?)",
+            );
             params.push(SqlValue::Integer(k));
         }
         if conditions.is_empty() {

--- a/packages/honker-node/test/basic.js
+++ b/packages/honker-node/test/basic.js
@@ -242,3 +242,58 @@ test('pruneNotifications by max_keep', () => {
     cleanup();
   }
 });
+
+test('pruneNotifications maxKeep is gap-safe and validates bounds', () => {
+  const { path: dbPath, open, cleanup } = tmpdb();
+  let db;
+  try {
+    db = open(dbPath);
+    {
+      const tx = db.transaction();
+      tx.execute(
+        "INSERT INTO _honker_notifications " +
+        "(id, channel, payload, created_at) VALUES " +
+        "(90, 'ch', '\"old\"', unixepoch()), " +
+        "(100, 'ch', '\"new\"', unixepoch())"
+      );
+      tx.commit();
+    }
+
+    assert.equal(db.pruneNotifications(null, 5), 0);
+    assert.equal(db.pruneNotifications(null, 2), 0);
+    assert.equal(db.pruneNotifications(null, 1), 1);
+    assert.deepEqual(
+      db.query('SELECT id FROM _honker_notifications ORDER BY id')
+        .map((row) => row.id),
+      [100]
+    );
+    assert.throws(
+      () => db.pruneNotifications(null, -1),
+      /maxKeep must not be negative/
+    );
+    assert.equal(db.pruneNotifications(null, 0), 1);
+
+    for (const payload of ['fresh-1', 'fresh-2', 'fresh-3', 'old-newest']) {
+      const tx = db.transaction();
+      tx.notify('ch', payload);
+      tx.commit();
+    }
+    {
+      const tx = db.transaction();
+      tx.execute(
+        "UPDATE _honker_notifications SET created_at=0 " +
+        "WHERE payload='\"old-newest\"'"
+      );
+      tx.commit();
+    }
+    assert.equal(db.pruneNotifications(1, 2), 3);
+    assert.deepEqual(
+      db.query('SELECT payload FROM _honker_notifications ORDER BY id')
+        .map((row) => JSON.parse(row.payload)),
+      ['fresh-3']
+    );
+  } finally {
+    db?.close();
+    cleanup();
+  }
+});

--- a/packages/honker-rs/src/lib.rs
+++ b/packages/honker-rs/src/lib.rs
@@ -334,14 +334,15 @@ impl Database {
     /// Keep only the most recent `max_keep` notifications. Returns
     /// the number of rows deleted.
     pub fn prune_notifications_keep_latest(&self, max_keep: i64) -> Result<i64> {
+        if max_keep < 0 {
+            return Err(Error::Core("max_keep must not be negative".into()));
+        }
         let n = self.inner.with_conn(|c| {
             c.execute(
                 "DELETE FROM _honker_notifications
-                 WHERE id < (
-                   SELECT COALESCE(MIN(id), 0) FROM (
-                     SELECT id FROM _honker_notifications
-                     ORDER BY id DESC LIMIT ?1
-                   )
+                 WHERE id <= (
+                   SELECT id FROM _honker_notifications
+                   ORDER BY id DESC LIMIT 1 OFFSET ?1
                  )",
                 params![max_keep],
             )

--- a/packages/honker-rs/tests/surface.rs
+++ b/packages/honker-rs/tests/surface.rs
@@ -450,14 +450,31 @@ fn prune_notifications_keep_latest() {
 
     let deleted = db.prune_notifications_keep_latest(3).unwrap();
     assert_eq!(deleted, 7);
+    assert_eq!(db.prune_notifications_keep_latest(3).unwrap(), 0);
+    assert_eq!(db.prune_notifications_keep_latest(10).unwrap(), 0);
+    assert_eq!(db.prune_notifications_keep_latest(0).unwrap(), 3);
+    assert!(db.prune_notifications_keep_latest(-1).is_err());
 
-    let count: i64 = db.with_conn(|c| {
-        c.query_row("SELECT COUNT(*) FROM _honker_notifications", [], |r| {
-            r.get(0)
-        })
-        .unwrap()
+    db.with_conn(|c| {
+        c.execute_batch(
+            "INSERT INTO _honker_notifications
+             (id, channel, payload, created_at) VALUES
+             (90, 'c', '\"old\"', unixepoch()),
+             (100, 'c', '\"new\"', unixepoch())",
+        )
+        .unwrap();
     });
-    assert_eq!(count, 3);
+    assert_eq!(db.prune_notifications_keep_latest(5).unwrap(), 0);
+    assert_eq!(db.prune_notifications_keep_latest(1).unwrap(), 1);
+    let ids: Vec<i64> = db.with_conn(|c| {
+        c.prepare("SELECT id FROM _honker_notifications ORDER BY id")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap()
+    });
+    assert_eq!(ids, vec![100]);
 }
 
 #[test]

--- a/packages/honker/python/honker/_honker.py
+++ b/packages/honker/python/honker/_honker.py
@@ -1213,18 +1213,19 @@ class Database:
             conditions.append("created_at < unixepoch() - ?")
             params.append(int(older_than_s))
         if max_keep is not None:
-            # Use a subquery so MAX(id) is evaluated atomically
-            # inside the DELETE, avoiding a TOCTOU race where rows
-            # inserted between a separate SELECT and the DELETE
-            # would cause the wrong number of rows to be removed.
-            # COALESCE handles an empty table (MAX returns NULL)
-            # and when max_keep >= row count the subtraction goes
-            # negative, matching zero rows — both are safe no-ops.
+            max_keep = int(max_keep)
+            if max_keep < 0:
+                raise ValueError("max_keep must not be negative")
+            # Select the (N + 1)th-newest row by rank. Unlike
+            # MAX(id) - N, this remains correct when IDs contain gaps.
+            # The subquery and DELETE are one statement, so inserts
+            # committed before the write transaction starts are part
+            # of the same pruning decision.
             conditions.append(
-                "id <= (SELECT COALESCE(MAX(id), 0) - ? "
-                "FROM _honker_notifications)"
+                "id <= (SELECT id FROM _honker_notifications "
+                "ORDER BY id DESC LIMIT 1 OFFSET ?)"
             )
-            params.append(int(max_keep))
+            params.append(max_keep)
         if not conditions:
             return 0
         with self.transaction() as tx:

--- a/packages/honker/python/honker/_honker.py
+++ b/packages/honker/python/honker/_honker.py
@@ -1216,16 +1216,23 @@ class Database:
             max_keep = int(max_keep)
             if max_keep < 0:
                 raise ValueError("max_keep must not be negative")
+            # SQLite bind parameters are signed 64-bit integers. Any
+            # larger count necessarily exceeds the maximum possible
+            # notification row count, so it contributes no DELETE
+            # condition (while an older_than_s condition still applies).
+            if max_keep > (1 << 63) - 1:
+                max_keep = None
             # Select the (N + 1)th-newest row by rank. Unlike
             # MAX(id) - N, this remains correct when IDs contain gaps.
             # The subquery and DELETE are one statement, so inserts
             # committed before the write transaction starts are part
             # of the same pruning decision.
-            conditions.append(
-                "id <= (SELECT id FROM _honker_notifications "
-                "ORDER BY id DESC LIMIT 1 OFFSET ?)"
-            )
-            params.append(max_keep)
+            if max_keep is not None:
+                conditions.append(
+                    "id <= (SELECT id FROM _honker_notifications "
+                    "ORDER BY id DESC LIMIT 1 OFFSET ?)"
+                )
+                params.append(max_keep)
         if not conditions:
             return 0
         with self.transaction() as tx:

--- a/tests/test_litenotify.py
+++ b/tests/test_litenotify.py
@@ -246,6 +246,7 @@ def test_prune_notifications_max_keep_uses_row_rank(db_path):
         )
 
     assert db.prune_notifications(max_keep=5) == 0
+    assert db.prune_notifications(max_keep=10**100) == 0
     assert db.prune_notifications(max_keep=2) == 0
     assert db.prune_notifications(max_keep=1) == 1
     assert [

--- a/tests/test_litenotify.py
+++ b/tests/test_litenotify.py
@@ -235,6 +235,82 @@ def test_prune_notifications_by_max_keep(db_path):
     assert after == 10
 
 
+def test_prune_notifications_max_keep_uses_row_rank(db_path):
+    db = honker.open(db_path)
+    with db.transaction() as tx:
+        tx.execute(
+            "INSERT INTO _honker_notifications "
+            "(id, channel, payload, created_at) VALUES "
+            "(90, 'ch', '\"old\"', unixepoch()), "
+            "(100, 'ch', '\"new\"', unixepoch())",
+        )
+
+    assert db.prune_notifications(max_keep=5) == 0
+    assert db.prune_notifications(max_keep=2) == 0
+    assert db.prune_notifications(max_keep=1) == 1
+    assert [
+        row["id"]
+        for row in db.query(
+            "SELECT id FROM _honker_notifications ORDER BY id"
+        )
+    ] == [100]
+
+    with pytest.raises(ValueError, match="max_keep must not be negative"):
+        db.prune_notifications(max_keep=-1)
+    assert db.prune_notifications(max_keep=0) == 1
+
+
+def test_prune_notifications_combines_age_and_max_keep_with_or(db_path):
+    db = honker.open(db_path)
+    for payload in ("fresh-1", "fresh-2", "fresh-3", "old-newest"):
+        with db.transaction() as tx:
+            tx.notify("ch", payload)
+    with db.transaction() as tx:
+        tx.execute(
+            "UPDATE _honker_notifications SET created_at=0 "
+            "WHERE payload='\"old-newest\"'"
+        )
+
+    assert db.prune_notifications(older_than_s=1, max_keep=2) == 3
+    rows = db.query(
+        "SELECT payload FROM _honker_notifications ORDER BY id"
+    )
+    assert [row["payload"] for row in rows] == ['"fresh-3"']
+
+
+def test_prune_notifications_sees_insert_before_write_transaction(
+    db_path, monkeypatch
+):
+    """Regression for #81: MAX(id) must not be read before the write."""
+    db = honker.open(db_path)
+    other = honker.open(db_path)
+    for payload in ("one", "two", "three"):
+        with db.transaction() as tx:
+            tx.notify("ch", payload)
+
+    original_transaction = db.transaction
+    inserted = False
+
+    def transaction_after_competing_insert():
+        nonlocal inserted
+        if not inserted:
+            inserted = True
+            with other.transaction() as tx:
+                tx.notify("ch", "four")
+        return original_transaction()
+
+    monkeypatch.setattr(db, "transaction", transaction_after_competing_insert)
+    try:
+        assert db.prune_notifications(max_keep=2) == 2
+        assert inserted
+        rows = db.query(
+            "SELECT payload FROM _honker_notifications ORDER BY id"
+        )
+        assert [row["payload"] for row in rows] == ['"three"', '"four"']
+    finally:
+        other.close()
+
+
 def test_prune_notifications_by_age(db_path):
     db = honker.open(db_path)
 


### PR DESCRIPTION
Follow-up to #81. Closes #82.

## Summary

- retain the newest `max_keep` notifications by row rank instead of assuming IDs are contiguous
- make `max_keep=0` delete all notifications and reject negative values consistently
- preserve atomic single-statement pruning and combined age/count OR semantics
- apply the contract to Python, Node, Rust, JVM, and .NET
- add regression coverage for sparse IDs, zero/equal/oversized counts, negative input, combined conditions, and the pre-write-transaction insert race

## Validation

- Python: `25 passed` in `tests/test_litenotify.py`
- Node: `9 passed` in `test/basic.js`
- Rust: targeted `prune_notifications_keep_latest` test passed; library Clippy passed
- JVM: targeted Maven test passed
- .NET: targeted test passed on `net10.0`
- Node library Clippy passed
- `cargo fmt --all -- --check`
- `git diff --check`

## Existing lint debt

The repository-wide feature Clippy pass still reports the existing kernel-watcher warnings already addressed by draft #84. `honker-rs --all-targets` also reports two unrelated pre-existing test lints in `phase_mantle.rs` and `python_interop.rs`; the affected library passes Clippy.