### PR TITLE
deps: upgrade rusqlite across all Rust packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,12 +148,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.11.0"
+name = "hashbrown"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "hashbrown",
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -270,9 +279,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -462,15 +471,15 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "thiserror",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/honker-core/Cargo.toml
+++ b/honker-core/Cargo.toml
@@ -27,7 +27,7 @@ name = "honker_core"
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 parking_lot = "0.12.5"
-rusqlite = { version = "0.39.0", features = ["functions", "hooks"] }
+rusqlite = { version = "0.40.1", features = ["functions", "hooks"] }
 serde_json = "1"
 thiserror = "2.0.18"
 # Optional: kernel-watch backend.

--- a/honker-extension/Cargo.toml
+++ b/honker-extension/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 honker-core = { path = "../honker-core", version = "0.4.0", default-features = false }
 # "loadable_extension" feature makes rusqlite usable from inside a
 # sqlite3_extension_init entry point.
-rusqlite = { version = "0.39.0", features = ["functions", "hooks", "loadable_extension"] }
+rusqlite = { version = "0.40.1", features = ["functions", "hooks", "loadable_extension"] }
 
 [features]
 default = []

--- a/packages/honker-node/Cargo.toml
+++ b/packages/honker-node/Cargo.toml
@@ -30,7 +30,7 @@ honker-core = { path = "../../honker-core", version = "0.4.0" }
 napi = { version = "3.2", features = ["async", "serde-json", "tokio_rt"] }
 napi-derive = "3.2"
 parking_lot = "0.12.5"
-rusqlite = { version = "0.39.0", features = ["functions", "hooks"] }
+rusqlite = { version = "0.40.1", features = ["functions", "hooks"] }
 serde_json = "1.0"
 tokio = { version = "1.52.1", features = ["rt", "rt-multi-thread"] }
 

--- a/packages/honker-rs/Cargo.lock
+++ b/packages/honker-rs/Cargo.lock
@@ -198,14 +198,17 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -356,9 +359,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -545,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/packages/honker-rs/Cargo.toml
+++ b/packages/honker-rs/Cargo.toml
@@ -24,7 +24,7 @@ shm-fast-path = ["honker-core/shm-fast-path"]
 # honker repo; `version` is what Cargo uses when honker-rs is
 # consumed from crates.io.
 honker-core = { path = "../../honker-core", version = "0.4.0" }
-rusqlite = { version = "0.39", features = ["functions"] }
+rusqlite = { version = "0.40.1", features = ["functions"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/packages/honker/Cargo.toml
+++ b/packages/honker/Cargo.toml
@@ -30,7 +30,7 @@ shm-fast-path = ["honker-core/shm-fast-path"]
 honker-core = { path = "../../honker-core", version = "0.4.0" }
 parking_lot = "0.12.5"
 pyo3 = { version = "0.28.3", features = ["extension-module", "abi3-py311"] }
-rusqlite = { version = "0.39.0", features = ["functions", "hooks"] }
+rusqlite = { version = "0.40.1", features = ["functions", "hooks"] }
 
 [target.'cfg(windows)'.dependencies]
 honker-core = { path = "../../honker-core", version = "0.4.0", features = ["bundled-sqlite"] }


### PR DESCRIPTION
## What changed

- upgrades `rusqlite` from 0.39 to 0.40.1 in `honker-core`, `honker-extension`, and every Rust-backed binding
- refreshes the tracked workspace and `honker-rs` lockfiles together
- keeps every crate on one `libsqlite3-sys` version, avoiding Cargo's native `sqlite3` links conflict

## Why

Dependabot PR #89 updated only the root workspace. The Python and Node bindings and the standalone Rust package still required rusqlite 0.39, so their builds could not resolve a single `libsqlite3-sys` implementation.

Closes #89 by superseding it with a repository-wide migration.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- debug and release `honker-core` suites, including bundled SQLite, kernel watcher, and shm fast path
- release `honker-extension` build
- complete `honker-rs` suite
- fresh-lock compilation of the Python and Node bindings