### PR TITLE
fix: preserve SQLite POSIX locks in watcher backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,25 +75,36 @@ jobs:
             cargo test -p honker-core --locked --lib
           fi
       # Experimental wake backends — see Phase Lighthouse in ROADMAP.md.
-      # These features are NOT compiled into published wheels yet, but
-      # we test them in CI on every platform so we know what's actually
-      # broken before users do. Failures here block Phase Lighthouse,
-      # not the wheel-building jobs below.
+      # Failures here block Phase Lighthouse, not the wheel-building jobs
+      # below.
+      #
+      # macOS uses bundled-sqlite here, and that is load-bearing rather
+      # than incidental. Apple's system libsqlite3 takes its advisory
+      # locks with fcntl(F_OFD_SETLK) — open-file-description locks, which
+      # a foreign close() cannot release. The bindings that ship on macOS
+      # (.NET/SQLitePCLRaw, Go, Ruby, and any bundled build) link an
+      # upstream SQLite that uses plain fcntl(F_SETLK) instead, where a
+      # foreign close drops every lock the process holds on that inode.
+      # Issue #80 is only reproducible — and therefore only *testable* —
+      # against the latter. Running macOS on the system library here would
+      # make kernel_watcher_does_not_release_sqlite_wal_locks pass
+      # vacuously. Linux's system libsqlite3 already uses F_SETLK, so it
+      # stays unbundled and keeps non-bundled build coverage.
       - name: Run honker-core tests (experimental wake backends, debug)
         shell: bash
         run: |
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            cargo test -p honker-core --locked --lib --features bundled-sqlite,kernel-watcher,shm-fast-path
-          else
+          if [ "${{ runner.os }}" = "Linux" ]; then
             cargo test -p honker-core --locked --lib --features kernel-watcher,shm-fast-path
+          else
+            cargo test -p honker-core --locked --lib --features bundled-sqlite,kernel-watcher,shm-fast-path
           fi
       - name: Run honker-core tests (experimental wake backends, release)
         shell: bash
         run: |
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            cargo test -p honker-core --locked --release --lib --features bundled-sqlite,kernel-watcher,shm-fast-path
-          else
+          if [ "${{ runner.os }}" = "Linux" ]; then
             cargo test -p honker-core --locked --release --lib --features kernel-watcher,shm-fast-path
+          else
+            cargo test -p honker-core --locked --release --lib --features bundled-sqlite,kernel-watcher,shm-fast-path
           fi
       - name: Build loadable extension
         run: cargo build --locked --release -p honker-extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,30 @@ stance recorded in the phase entry that drove it.
 
 ## Unreleased — correctness priority fixes
 
+Experimental wake backends:
+
+- **`kernel-watcher` no longer drops SQLite's POSIX locks (#80).** On
+  macOS the kqueue backend held an `O_EVTONLY` descriptor on the main
+  database file and `-shm`, and closed it on `NOTE_DELETE` pruning, on
+  attach failure, and at watcher shutdown. Closing any descriptor for an
+  inode releases every advisory lock the *process* holds on it, and those
+  two files are exactly the ones SQLite locks in WAL mode. The result was
+  a live connection whose `-wal`/`-shm` another process could delete —
+  making the next `COMMIT` return `SQLITE_OK` into an unlinked WAL, where
+  it was silently and permanently lost — or a `-shm` truncated under a
+  live mapping, which is the SIGBUS (exit 138) seen in CI. The backend
+  now watches only the parent directory, `-wal`, and `-journal`: files
+  SQLite opens with `UNIXFILE_NOLOCK` and therefore never locks. WAL
+  commit detection is unchanged. Also applied on the BSDs, where
+  `notify`'s recommended watcher is kqueue-based; Linux (inotify) and
+  Windows are unaffected and unchanged.
+- **`shm-fast-path` has the same defect and is not yet fixed.** Its
+  `probe()` opens and closes `-shm` on every `honker.open()`, and the
+  watcher's own `File` is closed on reopen and at shutdown — each of
+  which releases the process's WAL-index locks, on Linux as well as
+  macOS. Reproduces at 7/20 in the .NET multi-process queue test. Do not
+  select `watcher_backend="shm"`. Tracked separately.
+
 Core (all bindings via `honker_*` SQL / shared extension):
 
 - **Claim/reclaim honors `max_attempts`.** Exhausted reclaimable jobs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,13 +63,17 @@ Experimental wake backends:
   unreferenced, so there is no lock left to drop. PR #43's bounded-read
   protection is unchanged.
 - **The shm fast path is slower than its docs claimed, and is no longer
-  recommended.** PR #43 replaced the mmap load with a bounded read to
-  stop the watcher SIGBUS-ing itself, which was correct but removed the
-  backend's reason to exist. Measured on macOS/arm64 against SQLite
-  3.51.3: `pread` of the WAL-index header ~1.2 us versus ~2.3 us for
-  `PRAGMA data_version`, and both backends sleep 1 ms, so **wake latency
-  is identical**. The remaining win is ~1 us of CPU per millisecond per
-  watched database. Prefer polling unless you have measured otherwise.
+  recommended.** PR #43 replaced the mmap load with a bounded read,
+  citing SIGBUS risk. That risk was overstated for this particular read:
+  SQLite truncates `-shm` to 3 bytes rather than 0, and `iChange` at
+  offset 8 falls inside the partial page POSIX guarantees is readable.
+  The SIGBUS seen in CI came from SQLite's own mapping, because honker
+  was dropping SQLite's DMS lock — the bug fixed above. The bounded read
+  stays regardless, because restoring the mapping would not help:
+  `pread` of the header is ~1.2 us versus ~2.3 us for `PRAGMA
+  data_version` on macOS/arm64, and both backends sleep 1 ms, so **wake
+  latency is identical**. Trading CPU for latency is already available on
+  the polling backend via the poll-interval option. Prefer polling.
 
 Core (all bindings via `honker_*` SQL / shared extension):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,26 @@ Experimental wake backends:
   commit detection is unchanged. Also applied on the BSDs, where
   `notify`'s recommended watcher is kqueue-based; Linux (inotify) and
   Windows are unaffected and unchanged.
-- **`shm-fast-path` has the same defect and is not yet fixed.** Its
-  `probe()` opens and closes `-shm` on every `honker.open()`, and the
-  watcher's own `File` is closed on reopen and at shutdown — each of
-  which releases the process's WAL-index locks, on Linux as well as
-  macOS. Reproduces at 7/20 in the .NET multi-process queue test. Do not
-  select `watcher_backend="shm"`. Tracked separately.
+- **`shm-fast-path` no longer releases SQLite's WAL-index locks (#80).**
+  Same root cause, different code path. Its `probe()` opened and closed
+  `-shm` on every `honker.open()` — after the writer connection already
+  existed, so it dropped the process's WAL-index locks once per open with
+  no churn needed — and the watcher's own descriptor was closed on reopen
+  and at shutdown. Losing those locks doesn't reap the WAL (the database
+  file's SHARED lock still blocks that); it lets a fresh connection win
+  the deadman race and truncate `-shm` under a live mapping, which is the
+  SIGBUS. `-shm` descriptors now come from a registry that opens each
+  inode once and only closes one whose `st_nlink` is 0 — provably
+  unreferenced, so there is no lock left to drop. PR #43's bounded-read
+  protection is unchanged.
+- **The shm fast path is slower than its docs claimed, and is no longer
+  recommended.** PR #43 replaced the mmap load with a bounded read to
+  stop the watcher SIGBUS-ing itself, which was correct but removed the
+  backend's reason to exist. Measured on macOS/arm64 against SQLite
+  3.51.3: `pread` of the WAL-index header ~1.2 us versus ~2.3 us for
+  `PRAGMA data_version`, and both backends sleep 1 ms, so **wake latency
+  is identical**. The remaining win is ~1 us of CPU per millisecond per
+  watched database. Prefer polling unless you have measured otherwise.
 
 Core (all bindings via `honker_*` SQL / shared extension):
 

--- a/honker-core/Cargo.toml
+++ b/honker-core/Cargo.toml
@@ -45,6 +45,11 @@ libc = { version = "0.2", optional = true }
 file-id = "0.2.3"
 
 [dev-dependencies]
+# libc in tests regardless of feature selection: the issue-#80 lock-survival
+# tests probe SQLite's POSIX locks with fcntl(F_GETLK) from a child process,
+# and must run for the shm-fast-path build too (where `libc` is not a
+# regular dependency).
+libc = "0.2"
 # chrono-tz only in tests — lets us exercise DST edge cases with a
 # fixed timezone (US/Eastern) regardless of where tests run.
 chrono-tz = "0.10"

--- a/honker-core/src/kernel_watcher.rs
+++ b/honker-core/src/kernel_watcher.rs
@@ -542,6 +542,7 @@ mod macos {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "macos")]
     use std::path::{Path, PathBuf};
 
     /// Structural guard for issue #80. The kqueue backend holds one

--- a/honker-core/src/kernel_watcher.rs
+++ b/honker-core/src/kernel_watcher.rs
@@ -6,9 +6,15 @@
 //! # Contract
 //!
 //! `on_change()` fires on every relevant filesystem event observed on
-//! the database file, its parent directory, or SQLite sidecar files
-//! (`-wal`, `-shm`, `-journal`). **There is no `PRAGMA data_version`
-//! verification and no safety-net poll.** This means:
+//! the database's parent directory and its rollback/WAL sidecar files.
+//! **There is no `PRAGMA data_version` verification and no safety-net
+//! poll.** This means:
+//!
+//! Which paths are watched is a *safety* decision, not just a coverage
+//! one: any backend that holds a descriptor per watched file must never
+//! open the main database file or `-shm`, because closing that descriptor
+//! releases the whole process's SQLite POSIX locks on it. See
+//! [`macos::candidate_paths`] and issue #80.
 //!
 //! - **Spurious wakes are possible.** Any file change in the directory
 //!   (other apps writing nearby files, the OS touching metadata, etc.)
@@ -90,16 +96,18 @@ pub(crate) fn run_kernel_watch_loop<F>(
         let shm = PathBuf::from(format!("{}-shm", db_path.display()));
         let journal = PathBuf::from(format!("{}-journal", db_path.display()));
 
+        let targets = notify_watch_targets(&watch_dir, &db_path, &wal, &shm, &journal);
+
         let mut watched = HashSet::new();
         let mut attached = 0;
-        for path in [&watch_dir, &db_path, &wal, &shm, &journal] {
+        for path in &targets {
             if attach_watch(&mut watcher, &mut watched, path) {
                 attached += 1;
             }
         }
         if attached == 0 {
             eprintln!(
-                "honker: kernel-watcher couldn't attach to db dir or -wal/-shm. Backend disabled."
+                "honker: kernel-watcher couldn't attach to db dir or -wal/-journal. Backend disabled."
             );
             return;
         }
@@ -121,7 +129,7 @@ pub(crate) fn run_kernel_watch_loop<F>(
         while !stop.load(Ordering::Acquire) {
             match rx.recv_timeout(Duration::from_millis(RX_POLL_MS)) {
                 Ok(Ok(_event)) => {
-                    for path in [&db_path, &wal, &shm, &journal] {
+                    for path in &targets {
                         let _ = attach_watch(&mut watcher, &mut watched, path);
                     }
                     on_change();
@@ -134,7 +142,7 @@ pub(crate) fn run_kernel_watch_loop<F>(
                 _ => {}
             }
             if last_id_check.elapsed() >= Duration::from_millis(IDENTITY_CHECK_MS) {
-                for path in [&db_path, &wal, &shm, &journal] {
+                for path in &targets {
                     let _ = attach_watch(&mut watcher, &mut watched, path);
                 }
                 if check_db_identity(&db_path, initial_id) {
@@ -143,6 +151,64 @@ pub(crate) fn run_kernel_watch_loop<F>(
                 last_id_check = Instant::now();
             }
         }
+    }
+}
+
+/// Paths the `notify` backend attaches watches to.
+///
+/// Which files are safe depends on whether the platform's `notify` backend
+/// keeps a descriptor open per watched file:
+///
+/// * **inotify** (Linux/Android) registers a watch by path on the single
+///   inotify instance fd — it never holds a descriptor on the watched file,
+///   so nothing this crate does can release a SQLite lock. The database
+///   file and `-shm` stay in the set; dropping them would cost detection in
+///   TRUNCATE/PERSIST journal modes for no safety gain.
+/// * **`ReadDirectoryChangesW`** (Windows) watches directories and Windows
+///   does not use POSIX advisory locks at all.
+/// * **kqueue** (the BSDs) holds one `O_EVTONLY` descriptor per watched
+///   file and closes it on unwatch/drop — the same hazard as the hand-rolled
+///   macOS backend below. The database file and `-shm` are excluded there.
+///   See [`macos::candidate_paths`] for the full explanation and issue #80.
+#[cfg(not(target_os = "macos"))]
+fn notify_watch_targets(
+    watch_dir: &Path,
+    db_path: &Path,
+    wal: &Path,
+    shm: &Path,
+    journal: &Path,
+) -> Vec<PathBuf> {
+    // notify::RecommendedWatcher == KqueueWatcher on these targets.
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        target_os = "ios"
+    ))]
+    {
+        let _ = (db_path, shm);
+        vec![
+            watch_dir.to_path_buf(),
+            wal.to_path_buf(),
+            journal.to_path_buf(),
+        ]
+    }
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        target_os = "ios"
+    )))]
+    {
+        vec![
+            watch_dir.to_path_buf(),
+            db_path.to_path_buf(),
+            wal.to_path_buf(),
+            shm.to_path_buf(),
+            journal.to_path_buf(),
+        ]
     }
 }
 
@@ -312,16 +378,55 @@ mod macos {
         }
     }
 
-    fn candidate_paths(db_path: &Path) -> Vec<PathBuf> {
-        let mut paths = Vec::with_capacity(5);
-        if let Some(parent) = db_path.parent() {
-            paths.push(parent.to_path_buf());
+    /// The db's parent directory, normalized. `Path::parent()` returns
+    /// `Some("")` for a bare relative filename like `"a.db"`, and
+    /// `open("")` fails with ENOENT — so map that to `"."`.
+    pub(super) fn watch_dir(db_path: &Path) -> PathBuf {
+        match db_path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+            _ => PathBuf::from("."),
         }
-        paths.push(db_path.to_path_buf());
-        paths.push(PathBuf::from(format!("{}-wal", db_path.display())));
-        paths.push(PathBuf::from(format!("{}-shm", db_path.display())));
-        paths.push(PathBuf::from(format!("{}-journal", db_path.display())));
-        paths
+    }
+
+    /// Paths kqueue may hold an open descriptor on.
+    ///
+    /// # LOCK-BEARING FILES MUST NEVER APPEAR HERE
+    ///
+    /// **Do not add the main database file or `-shm` to this list.**
+    /// kqueue's `EVFILT_VNODE` requires a descriptor per watched file, and
+    /// those descriptors get closed — on `NOTE_DELETE` pruning, on attach
+    /// failure, and at watcher shutdown. On POSIX, `close()` of *any*
+    /// descriptor for an inode releases *every* advisory lock the calling
+    /// process holds on that inode, including locks taken by unrelated
+    /// SQLite connections living in the same process. SQLite's
+    /// `unixInodeInfo` deferred-close list (`setPendingFd` in `os_unix.c`)
+    /// only defers closes of descriptors SQLite itself opened; it cannot
+    /// see ours.
+    ///
+    /// In WAL mode SQLite takes POSIX locks on exactly two files: the main
+    /// database file (a SHARED lock held for the connection's lifetime) and
+    /// `-shm` (the WAL-index locks plus the DMS byte). Dropping either one
+    /// lets another process delete `-wal`/`-shm` out from under a live
+    /// connection — whose next commit then lands in an unlinked WAL and is
+    /// silently lost — or re-run WAL-index recovery and `ftruncate` `-shm`
+    /// under a live mapping, which is SIGBUS. See issue #80.
+    ///
+    /// `-wal` and `-journal` are safe to watch: `os_unix.c` sets
+    /// `UNIXFILE_NOLOCK` for every file whose open type is not
+    /// `SQLITE_OPEN_MAIN_DB`, so they use `nolockIoMethods` and never carry
+    /// a lock. Directories are safe: SQLite opens them only to `fsync`.
+    ///
+    /// Detection is not weakened in WAL mode: every commit appends frames
+    /// to `-wal`, which is exactly what raises `NOTE_WRITE`/`NOTE_EXTEND`.
+    /// Rollback modes signal through `-journal` (DELETE unlinks it,
+    /// TRUNCATE truncates it, PERSIST zeroes its header) and through the
+    /// parent directory.
+    pub(super) fn candidate_paths(db_path: &Path) -> Vec<PathBuf> {
+        vec![
+            watch_dir(db_path),
+            PathBuf::from(format!("{}-wal", db_path.display())),
+            PathBuf::from(format!("{}-journal", db_path.display())),
+        ]
     }
 
     fn attach_path(kq: &Kqueue, path: PathBuf, watched: &mut Vec<WatchedPath>) -> bool {
@@ -378,7 +483,7 @@ mod macos {
         let attached = attach_existing(&kq, &db_path, &mut watched);
         if attached == 0 {
             eprintln!(
-                "honker: kqueue couldn't attach to db dir or database files. Backend disabled."
+                "honker: kqueue couldn't attach to db dir or -wal/-journal. Backend disabled."
             );
             return;
         }
@@ -419,14 +524,77 @@ mod macos {
         }
     }
 
+    /// Probe only the parent directory. Directories carry no SQLite locks,
+    /// so the `close()` below cannot release any — see [`candidate_paths`].
+    /// Probing the database file or `-shm` here would drop this process's
+    /// SQLite locks on every `honker.open()`.
     pub(super) fn probe_kqueue(db_path: &Path) -> Result<(), String> {
         let kq = Kqueue::new()?;
-        let dir = db_path.parent().unwrap_or(Path::new("."));
-        let dir_fd = open_event_fd(dir)?;
+        let dir = watch_dir(db_path);
+        let dir_fd = open_event_fd(&dir)?;
         let result = kq.add_vnode(dir_fd);
         unsafe {
             libc::close(dir_fd);
         }
         result.map_err(|e| format!("can't watch {dir:?}: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    /// Structural guard for issue #80. The kqueue backend holds one
+    /// descriptor per watched path and closes it on prune, on attach
+    /// failure, and at shutdown; on POSIX that close releases every
+    /// advisory lock this process holds on the inode. SQLite locks the
+    /// main database file and `-shm`, so neither may ever be watched.
+    ///
+    /// The behavioral proof lives in
+    /// `lib.rs::tests::kernel_watcher_does_not_release_sqlite_wal_locks`.
+    /// This test is the cheap, platform-independent tripwire that fires
+    /// the moment someone adds a path back to the list.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn candidate_paths_excludes_every_file_sqlite_locks() {
+        let db = Path::new("/tmp/honker-cp/app.db");
+        let paths = super::macos::candidate_paths(db);
+
+        assert!(
+            !paths.contains(&db.to_path_buf()),
+            "the main database file carries SQLite's SHARED lock and must \
+             never be kqueue-watched: {paths:?}"
+        );
+        assert!(
+            !paths.contains(&PathBuf::from("/tmp/honker-cp/app.db-shm")),
+            "-shm carries SQLite's WAL-index and DMS locks and must never \
+             be kqueue-watched: {paths:?}"
+        );
+        // And the wake signal we depend on in WAL mode is still there.
+        assert!(
+            paths.contains(&PathBuf::from("/tmp/honker-cp/app.db-wal")),
+            "-wal is the WAL-mode commit signal and must stay watched: {paths:?}"
+        );
+        assert!(
+            paths.contains(&PathBuf::from("/tmp/honker-cp")),
+            "the parent directory must stay watched: {paths:?}"
+        );
+    }
+
+    /// `Path::parent()` yields `Some("")` for a bare relative filename,
+    /// and `open("")` is ENOENT. The directory watch is load-bearing now
+    /// that the database file itself is not watched, so this must resolve
+    /// to `"."` rather than silently failing to attach.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn bare_relative_db_path_watches_the_current_directory() {
+        assert_eq!(
+            super::macos::watch_dir(Path::new("app.db")),
+            PathBuf::from(".")
+        );
+        assert_eq!(
+            super::macos::watch_dir(Path::new("/var/db/app.db")),
+            PathBuf::from("/var/db")
+        );
     }
 }

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -2476,6 +2476,194 @@ while True:
         }
     }
 
+    // -----------------------------------------------------------------
+    // Issue #80 — the kernel backend must not release SQLite's locks
+    // -----------------------------------------------------------------
+
+    /// Child-process half of the issue-#80 regression test. Inert unless
+    /// `HONKER_ISSUE80_REAP_DB` is set; the parent re-execs this test
+    /// binary with that variable so the open/close happens in a *separate
+    /// process*. That matters: in WAL mode the last connection to close
+    /// deletes `-wal` and `-shm`, but only if it can take an EXCLUSIVE
+    /// lock on the main database file — which the parent's live connection
+    /// is supposed to prevent.
+    #[test]
+    #[cfg(all(unix, feature = "kernel-watcher", feature = "bundled-sqlite"))]
+    fn issue_80_reaper_child() {
+        let Ok(path) = std::env::var("HONKER_ISSUE80_REAP_DB") else {
+            return;
+        };
+        let conn = Connection::open(&path).expect("reaper child: open");
+        let _: i64 = conn
+            .query_row("SELECT count(*) FROM t", [], |r| r.get(0))
+            .expect("reaper child: read");
+    }
+
+    #[cfg(all(unix, feature = "kernel-watcher", feature = "bundled-sqlite"))]
+    fn run_issue_80_reaper_child(db_path: &std::path::Path) {
+        let exe = std::env::current_exe().expect("current_exe");
+        let out = std::process::Command::new(exe)
+            .args([
+                "--exact",
+                "tests::issue_80_reaper_child",
+                "--test-threads=1",
+                "--nocapture",
+            ])
+            .env("HONKER_ISSUE80_REAP_DB", db_path)
+            .output()
+            .expect("spawn reaper child");
+        assert!(
+            out.status.success(),
+            "reaper child failed: {}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    #[cfg(all(unix, feature = "kernel-watcher", feature = "bundled-sqlite"))]
+    enum Issue80Perturbation {
+        /// Reproduce what the pre-fix kqueue backend did: raw
+        /// `open(O_EVTONLY)` + `close()` on the two files SQLite locks.
+        RawCloseLockBearingFiles,
+        /// Spawn the real kernel-watch backend, let it attach, then shut
+        /// it down — while this process's SQLite connection is still open.
+        ///
+        /// Shutdown is the case that matters. The kqueue backend holds its
+        /// descriptors for the watcher's lifetime, so nothing is released
+        /// until something closes them: `WatchedPath::drop` on shutdown,
+        /// `prune_deleted` on `NOTE_DELETE`, or the `attach_path` error
+        /// path. A test that only spawns the watcher and never stops it
+        /// passes against the broken code.
+        RealKernelWatcherThenShutdown,
+    }
+
+    /// Hold a live WAL connection, apply `perturbation`, then let a
+    /// separate process open and close the database. Returns whether
+    /// `-wal` and `-shm` survived — i.e. whether this process still held
+    /// the SQLite locks that are supposed to protect them.
+    #[cfg(all(unix, feature = "kernel-watcher", feature = "bundled-sqlite"))]
+    fn wal_survives_foreign_last_close(perturbation: Issue80Perturbation) -> bool {
+        let tmp = std::env::temp_dir().join(format!(
+            "honker-issue80-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let wal = PathBuf::from(format!("{}-wal", tmp.display()));
+        let shm = PathBuf::from(format!("{}-shm", tmp.display()));
+        for p in [&tmp, &wal, &shm] {
+            let _ = std::fs::remove_file(p);
+        }
+
+        // Live WAL connection: takes a SHARED lock on the db file and the
+        // DMS read lock on -shm, and holds both for its whole lifetime.
+        let conn = open_conn(tmp.to_str().unwrap(), false).unwrap();
+        conn.execute_batch("CREATE TABLE t (x INT)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1)", []).unwrap();
+        let _: i64 = conn
+            .query_row("SELECT count(*) FROM t", [], |r| r.get(0))
+            .unwrap();
+        assert!(wal.exists() && shm.exists(), "setup: -wal/-shm not created");
+
+        match perturbation {
+            Issue80Perturbation::RawCloseLockBearingFiles => {
+                for path in [&tmp, &shm] {
+                    let c = std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(
+                        path.as_os_str(),
+                    ))
+                    .unwrap();
+                    // O_RDONLY, not O_EVTONLY: this arm must compile and
+                    // behave identically on every unix, and the lock-drop
+                    // does not depend on the open mode.
+                    let fd = unsafe { libc::open(c.as_ptr(), libc::O_RDONLY) };
+                    assert!(fd >= 0, "control: could not open {path:?}");
+                    unsafe { libc::close(fd) };
+                }
+            }
+            Issue80Perturbation::RealKernelWatcherThenShutdown => {
+                let watcher = UpdateWatcher::spawn_with_config(
+                    tmp.clone(),
+                    || {},
+                    WatcherConfig::with_backend(WatcherBackend::KernelWatch),
+                );
+                // Let it finish its first attach / reattach passes.
+                std::thread::sleep(Duration::from_millis(200));
+                // Stop it and wait for the thread to exit, so every
+                // descriptor it opened has actually been closed by the
+                // time the reaper runs. `conn` is still open throughout.
+                watcher.join().expect("watcher thread panicked");
+            }
+        }
+
+        assert!(
+            wal.exists() && shm.exists(),
+            "precondition: -wal/-shm vanished before the reaper ran"
+        );
+        run_issue_80_reaper_child(&tmp);
+
+        let survived = wal.exists() && shm.exists();
+
+        drop(conn);
+        for p in [&tmp, &wal, &shm] {
+            let _ = std::fs::remove_file(p);
+        }
+        survived
+    }
+
+    /// Issue #80: the kernel-watch backend must never release this
+    /// process's SQLite POSIX locks.
+    ///
+    /// When it does, another process's last-connection close deletes
+    /// `-wal`/`-shm` out from under our live connection. The connection
+    /// keeps working against unlinked files, so its next `COMMIT` returns
+    /// `SQLITE_OK` and is then invisible to every other process — a
+    /// successful commit that never lands. The SIGBUS seen in CI is the
+    /// same lock loss taking the other branch, where a fresh connection
+    /// wins the DMS race and `ftruncate`s `-shm` under a live mapping.
+    ///
+    /// # This test proves its own sensitivity
+    ///
+    /// It only means something where SQLite uses *process-scoped* POSIX
+    /// locks (`fcntl(F_SETLK)`). Apple's system libsqlite3 uses
+    /// `fcntl(F_OFD_SETLK)` instead — open-file-description locks, which a
+    /// foreign `close()` cannot release — so on a macOS build linked
+    /// against the system library the property is unfalsifiable and a
+    /// green result would mean nothing. The control arm below asserts the
+    /// defect *is* reproducible in this build before trusting the real
+    /// arm. Build with `--features bundled-sqlite` on macOS.
+    ///
+    /// That is why the whole issue-#80 proof is gated on `bundled-sqlite`:
+    /// it is the only feature that guarantees an upstream amalgamation,
+    /// whose `os_unix.c` uses `fcntl(F_SETLK)`. CI runs the experimental
+    /// backends with that feature on macOS and Windows.
+    #[test]
+    #[cfg(all(unix, feature = "kernel-watcher", feature = "bundled-sqlite"))]
+    fn kernel_watcher_does_not_release_sqlite_wal_locks() {
+        let control =
+            wal_survives_foreign_last_close(Issue80Perturbation::RawCloseLockBearingFiles);
+        assert!(
+            !control,
+            "control arm did not reproduce the defect: a raw open()+close() on \
+             the database file and -shm left -wal/-shm intact, so this build \
+             cannot detect issue #80 at all. SQLite {} is linked; Apple's \
+             system libsqlite3 uses F_OFD_SETLK, whose locks survive a foreign \
+             close. Re-run with --features bundled-sqlite.",
+            rusqlite::version()
+        );
+
+        let with_watcher =
+            wal_survives_foreign_last_close(Issue80Perturbation::RealKernelWatcherThenShutdown);
+        assert!(
+            with_watcher,
+            "kernel-watch backend released this process's SQLite locks: another \
+             process deleted -wal/-shm while a live WAL connection was open. \
+             The backend must not hold a descriptor on the database file or \
+             -shm — see kernel_watcher::macos::candidate_paths and issue #80."
+        );
+    }
+
     /// Prove that the shm fast path fires on the same commits as the
     /// baseline `PRAGMA data_version` poller.
     ///

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -2492,11 +2492,23 @@ while True:
     /// switch sits one past the eight lock slots, at 128. On the main
     /// database file, `SHARED_FIRST = PENDING_BYTE + 2` and
     /// `SHARED_SIZE = 510`.
-    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    #[cfg(all(
+        unix,
+        feature = "bundled-sqlite",
+        any(feature = "kernel-watcher", feature = "shm-fast-path")
+    ))]
     const SHM_DMS_BYTE: libc::off_t = 128;
-    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    #[cfg(all(
+        unix,
+        feature = "bundled-sqlite",
+        any(feature = "kernel-watcher", feature = "shm-fast-path")
+    ))]
     const DB_SHARED_FIRST: libc::off_t = 0x4000_0000 + 2;
-    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    #[cfg(all(
+        unix,
+        feature = "bundled-sqlite",
+        any(feature = "kernel-watcher", feature = "shm-fast-path")
+    ))]
     const DB_SHARED_SIZE: libc::off_t = 510;
 
     /// Is any lock held on `[off, off+len)` of `path`?
@@ -2504,7 +2516,11 @@ while True:
     /// Asks for a write lock, so an existing read *or* write lock reports
     /// as a conflict. Must run in a different process than the lock holder:
     /// `F_GETLK` never reports the calling process's own locks.
-    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    #[cfg(all(
+        unix,
+        feature = "bundled-sqlite",
+        any(feature = "kernel-watcher", feature = "shm-fast-path")
+    ))]
     fn lock_is_held(path: &std::path::Path, off: libc::off_t, len: libc::off_t) -> bool {
         let c = std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(path.as_os_str()))
             .unwrap();
@@ -2528,7 +2544,11 @@ while True:
     /// the calling process's own locks — the probe *must* be out-of-process.
     /// Prints one line the parent parses.
     #[test]
-    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    #[cfg(all(
+        unix,
+        feature = "bundled-sqlite",
+        any(feature = "kernel-watcher", feature = "shm-fast-path")
+    ))]
     fn issue_80_lock_probe_child() {
         let Ok(path) = std::env::var("HONKER_ISSUE80_PROBE_DB") else {
             return;
@@ -2541,7 +2561,11 @@ while True:
     }
 
     /// Which of SQLite's two lock-bearing files this process still holds.
-    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    #[cfg(all(
+        unix,
+        feature = "bundled-sqlite",
+        any(feature = "kernel-watcher", feature = "shm-fast-path")
+    ))]
     #[derive(Debug, PartialEq, Eq)]
     struct SqliteLockState {
         /// The `-shm` deadman-switch lock. Held for a WAL connection's life.
@@ -2550,7 +2574,11 @@ while True:
         db_shared: bool,
     }
 
-    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    #[cfg(all(
+        unix,
+        feature = "bundled-sqlite",
+        any(feature = "kernel-watcher", feature = "shm-fast-path")
+    ))]
     fn probe_sqlite_locks_from_another_process(db_path: &std::path::Path) -> SqliteLockState {
         let exe = std::env::current_exe().expect("current_exe");
         let out = std::process::Command::new(exe)
@@ -2585,7 +2613,11 @@ while True:
     /// The control perturbation: raw `open()` + `close()` on the two files
     /// SQLite locks, i.e. what the pre-fix backends did. Every "real
     /// backend" arm is compared against this.
-    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    #[cfg(all(
+        unix,
+        feature = "bundled-sqlite",
+        any(feature = "kernel-watcher", feature = "shm-fast-path")
+    ))]
     fn issue_80_raw_close_lock_bearing_files(db: &std::path::Path) {
         let shm = PathBuf::from(format!("{}-shm", db.display()));
         for path in [db, shm.as_path()] {
@@ -2609,7 +2641,11 @@ while True:
     /// until something closes them. A test that only spawns the watcher
     /// and never stops it passes against the broken code — that mistake
     /// was made once already while writing these tests.
-    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    #[cfg(all(
+        unix,
+        feature = "bundled-sqlite",
+        any(feature = "kernel-watcher", feature = "shm-fast-path")
+    ))]
     fn issue_80_run_backend_then_shutdown(backend: WatcherBackend, db: &std::path::Path) {
         let watcher = UpdateWatcher::spawn_with_config(
             db.to_path_buf(),
@@ -2630,7 +2666,11 @@ while True:
     /// fresh connection win the deadman race and `ftruncate` `-shm` under a
     /// live mapping. A test that watches for reaping alone is blind to the
     /// second, and the shm-fast-path defect is exactly the second.
-    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    #[cfg(all(
+        unix,
+        feature = "bundled-sqlite",
+        any(feature = "kernel-watcher", feature = "shm-fast-path")
+    ))]
     fn sqlite_locks_after(perturb: impl FnOnce(&std::path::Path)) -> SqliteLockState {
         let tmp = std::env::temp_dir().join(format!(
             "honker-issue80-{}-{}",

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -2487,62 +2487,151 @@ while True:
     /// deletes `-wal` and `-shm`, but only if it can take an EXCLUSIVE
     /// lock on the main database file — which the parent's live connection
     /// is supposed to prevent.
-    #[test]
-    #[cfg(all(unix, feature = "kernel-watcher", feature = "bundled-sqlite"))]
-    fn issue_80_reaper_child() {
-        let Ok(path) = std::env::var("HONKER_ISSUE80_REAP_DB") else {
-            return;
-        };
-        let conn = Connection::open(&path).expect("reaper child: open");
-        let _: i64 = conn
-            .query_row("SELECT count(*) FROM t", [], |r| r.get(0))
-            .expect("reaper child: read");
+    /// Byte offsets SQLite locks, from `os_unix.c`.
+    /// `UNIX_SHM_BASE = (22 + SQLITE_SHM_NLOCK) * 4 = 120`; the deadman
+    /// switch sits one past the eight lock slots, at 128. On the main
+    /// database file, `SHARED_FIRST = PENDING_BYTE + 2` and
+    /// `SHARED_SIZE = 510`.
+    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    const SHM_DMS_BYTE: libc::off_t = 128;
+    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    const DB_SHARED_FIRST: libc::off_t = 0x4000_0000 + 2;
+    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    const DB_SHARED_SIZE: libc::off_t = 510;
+
+    /// Is any lock held on `[off, off+len)` of `path`?
+    ///
+    /// Asks for a write lock, so an existing read *or* write lock reports
+    /// as a conflict. Must run in a different process than the lock holder:
+    /// `F_GETLK` never reports the calling process's own locks.
+    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    fn lock_is_held(path: &std::path::Path, off: libc::off_t, len: libc::off_t) -> bool {
+        let c = std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(path.as_os_str()))
+            .unwrap();
+        let fd = unsafe { libc::open(c.as_ptr(), libc::O_RDONLY) };
+        assert!(fd >= 0, "lock probe: could not open {path:?}");
+        let mut fl: libc::flock = unsafe { std::mem::zeroed() };
+        fl.l_type = libc::F_WRLCK as libc::c_short;
+        fl.l_whence = libc::SEEK_SET as libc::c_short;
+        fl.l_start = off;
+        fl.l_len = len;
+        let rc = unsafe { libc::fcntl(fd, libc::F_GETLK, &mut fl) };
+        unsafe { libc::close(fd) };
+        assert_eq!(rc, 0, "lock probe: F_GETLK failed on {path:?}");
+        fl.l_type != libc::F_UNLCK as libc::c_short
     }
 
-    #[cfg(all(unix, feature = "kernel-watcher", feature = "bundled-sqlite"))]
-    fn run_issue_80_reaper_child(db_path: &std::path::Path) {
+    /// Child-process half of the issue-#80 regression tests.
+    ///
+    /// Inert unless `HONKER_ISSUE80_PROBE_DB` is set; the parent re-execs
+    /// this test binary with that variable, because `F_GETLK` never reports
+    /// the calling process's own locks — the probe *must* be out-of-process.
+    /// Prints one line the parent parses.
+    #[test]
+    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    fn issue_80_lock_probe_child() {
+        let Ok(path) = std::env::var("HONKER_ISSUE80_PROBE_DB") else {
+            return;
+        };
+        let db = PathBuf::from(&path);
+        let shm = PathBuf::from(format!("{path}-shm"));
+        let dms = lock_is_held(&shm, SHM_DMS_BYTE, 1);
+        let shared = lock_is_held(&db, DB_SHARED_FIRST, DB_SHARED_SIZE);
+        println!("HONKER_ISSUE80_RESULT shm_dms={dms} db_shared={shared}");
+    }
+
+    /// Which of SQLite's two lock-bearing files this process still holds.
+    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    #[derive(Debug, PartialEq, Eq)]
+    struct SqliteLockState {
+        /// The `-shm` deadman-switch lock. Held for a WAL connection's life.
+        shm_dms: bool,
+        /// The main database file's SHARED lock. Same lifetime in WAL mode.
+        db_shared: bool,
+    }
+
+    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    fn probe_sqlite_locks_from_another_process(db_path: &std::path::Path) -> SqliteLockState {
         let exe = std::env::current_exe().expect("current_exe");
         let out = std::process::Command::new(exe)
             .args([
                 "--exact",
-                "tests::issue_80_reaper_child",
+                "tests::issue_80_lock_probe_child",
                 "--test-threads=1",
                 "--nocapture",
             ])
-            .env("HONKER_ISSUE80_REAP_DB", db_path)
+            .env("HONKER_ISSUE80_PROBE_DB", db_path)
             .output()
-            .expect("spawn reaper child");
-        assert!(
-            out.status.success(),
-            "reaper child failed: {}{}",
-            String::from_utf8_lossy(&out.stdout),
-            String::from_utf8_lossy(&out.stderr)
+            .expect("spawn lock probe child");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        // `contains`, not `starts_with`: under --nocapture libtest prints
+        // the test name without a trailing newline, so the child's own
+        // println lands on the same line.
+        let line = stdout
+            .lines()
+            .find(|l| l.contains("HONKER_ISSUE80_RESULT"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "lock probe child produced no result: {stdout}{}",
+                    String::from_utf8_lossy(&out.stderr)
+                )
+            });
+        SqliteLockState {
+            shm_dms: line.contains("shm_dms=true"),
+            db_shared: line.contains("db_shared=true"),
+        }
+    }
+
+    /// The control perturbation: raw `open()` + `close()` on the two files
+    /// SQLite locks, i.e. what the pre-fix backends did. Every "real
+    /// backend" arm is compared against this.
+    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    fn issue_80_raw_close_lock_bearing_files(db: &std::path::Path) {
+        let shm = PathBuf::from(format!("{}-shm", db.display()));
+        for path in [db, shm.as_path()] {
+            let c =
+                std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(path.as_os_str()))
+                    .unwrap();
+            // O_RDONLY, not O_EVTONLY: this arm must compile and behave
+            // identically on every unix, and the lock-drop does not depend
+            // on the open mode.
+            let fd = unsafe { libc::open(c.as_ptr(), libc::O_RDONLY) };
+            assert!(fd >= 0, "control: could not open {path:?}");
+            unsafe { libc::close(fd) };
+        }
+    }
+
+    /// Spawn `backend`, let it settle, then shut it down — while this
+    /// process's SQLite connection is still open.
+    ///
+    /// Shutdown is the case that matters. Both backends hold their
+    /// descriptors for the watcher's lifetime, so nothing is released
+    /// until something closes them. A test that only spawns the watcher
+    /// and never stops it passes against the broken code — that mistake
+    /// was made once already while writing these tests.
+    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    fn issue_80_run_backend_then_shutdown(backend: WatcherBackend, db: &std::path::Path) {
+        let watcher = UpdateWatcher::spawn_with_config(
+            db.to_path_buf(),
+            || {},
+            WatcherConfig::with_backend(backend),
         );
+        std::thread::sleep(Duration::from_millis(200));
+        watcher.join().expect("watcher thread panicked");
     }
 
-    #[cfg(all(unix, feature = "kernel-watcher", feature = "bundled-sqlite"))]
-    enum Issue80Perturbation {
-        /// Reproduce what the pre-fix kqueue backend did: raw
-        /// `open(O_EVTONLY)` + `close()` on the two files SQLite locks.
-        RawCloseLockBearingFiles,
-        /// Spawn the real kernel-watch backend, let it attach, then shut
-        /// it down — while this process's SQLite connection is still open.
-        ///
-        /// Shutdown is the case that matters. The kqueue backend holds its
-        /// descriptors for the watcher's lifetime, so nothing is released
-        /// until something closes them: `WatchedPath::drop` on shutdown,
-        /// `prune_deleted` on `NOTE_DELETE`, or the `attach_path` error
-        /// path. A test that only spawns the watcher and never stops it
-        /// passes against the broken code.
-        RealKernelWatcherThenShutdown,
-    }
-
-    /// Hold a live WAL connection, apply `perturbation`, then let a
-    /// separate process open and close the database. Returns whether
-    /// `-wal` and `-shm` survived — i.e. whether this process still held
-    /// the SQLite locks that are supposed to protect them.
-    #[cfg(all(unix, feature = "kernel-watcher", feature = "bundled-sqlite"))]
-    fn wal_survives_foreign_last_close(perturbation: Issue80Perturbation) -> bool {
+    /// Hold a live WAL connection, apply `perturb`, then ask another
+    /// process which of SQLite's locks this process still holds.
+    ///
+    /// Asserting the locks directly, rather than a downstream symptom, is
+    /// deliberate. The two ways lock loss shows up are *different*: losing
+    /// the database file's SHARED lock lets another process reap
+    /// `-wal`/`-shm`, while losing only the `-shm` DMS lock instead lets a
+    /// fresh connection win the deadman race and `ftruncate` `-shm` under a
+    /// live mapping. A test that watches for reaping alone is blind to the
+    /// second, and the shm-fast-path defect is exactly the second.
+    #[cfg(all(unix, feature = "bundled-sqlite"))]
+    fn sqlite_locks_after(perturb: impl FnOnce(&std::path::Path)) -> SqliteLockState {
         let tmp = std::env::temp_dir().join(format!(
             "honker-issue80-{}-{}",
             std::process::id(),
@@ -2567,49 +2656,19 @@ while True:
             .unwrap();
         assert!(wal.exists() && shm.exists(), "setup: -wal/-shm not created");
 
-        match perturbation {
-            Issue80Perturbation::RawCloseLockBearingFiles => {
-                for path in [&tmp, &shm] {
-                    let c = std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(
-                        path.as_os_str(),
-                    ))
-                    .unwrap();
-                    // O_RDONLY, not O_EVTONLY: this arm must compile and
-                    // behave identically on every unix, and the lock-drop
-                    // does not depend on the open mode.
-                    let fd = unsafe { libc::open(c.as_ptr(), libc::O_RDONLY) };
-                    assert!(fd >= 0, "control: could not open {path:?}");
-                    unsafe { libc::close(fd) };
-                }
-            }
-            Issue80Perturbation::RealKernelWatcherThenShutdown => {
-                let watcher = UpdateWatcher::spawn_with_config(
-                    tmp.clone(),
-                    || {},
-                    WatcherConfig::with_backend(WatcherBackend::KernelWatch),
-                );
-                // Let it finish its first attach / reattach passes.
-                std::thread::sleep(Duration::from_millis(200));
-                // Stop it and wait for the thread to exit, so every
-                // descriptor it opened has actually been closed by the
-                // time the reaper runs. `conn` is still open throughout.
-                watcher.join().expect("watcher thread panicked");
-            }
-        }
+        perturb(&tmp);
 
         assert!(
             wal.exists() && shm.exists(),
-            "precondition: -wal/-shm vanished before the reaper ran"
+            "precondition: -wal/-shm vanished before the lock probe ran"
         );
-        run_issue_80_reaper_child(&tmp);
-
-        let survived = wal.exists() && shm.exists();
+        let state = probe_sqlite_locks_from_another_process(&tmp);
 
         drop(conn);
         for p in [&tmp, &wal, &shm] {
             let _ = std::fs::remove_file(p);
         }
-        survived
+        state
     }
 
     /// Issue #80: the kernel-watch backend must never release this
@@ -2641,26 +2700,95 @@ while True:
     #[test]
     #[cfg(all(unix, feature = "kernel-watcher", feature = "bundled-sqlite"))]
     fn kernel_watcher_does_not_release_sqlite_wal_locks() {
-        let control =
-            wal_survives_foreign_last_close(Issue80Perturbation::RawCloseLockBearingFiles);
-        assert!(
-            !control,
+        let held = SqliteLockState {
+            shm_dms: true,
+            db_shared: true,
+        };
+
+        let control = sqlite_locks_after(issue_80_raw_close_lock_bearing_files);
+        assert_ne!(
+            control,
+            held,
             "control arm did not reproduce the defect: a raw open()+close() on \
-             the database file and -shm left -wal/-shm intact, so this build \
-             cannot detect issue #80 at all. SQLite {} is linked; Apple's \
+             the database file and -shm left SQLite's locks intact, so this \
+             build cannot detect issue #80 at all. SQLite {} is linked; Apple's \
              system libsqlite3 uses F_OFD_SETLK, whose locks survive a foreign \
              close. Re-run with --features bundled-sqlite.",
             rusqlite::version()
         );
 
-        let with_watcher =
-            wal_survives_foreign_last_close(Issue80Perturbation::RealKernelWatcherThenShutdown);
-        assert!(
-            with_watcher,
-            "kernel-watch backend released this process's SQLite locks: another \
-             process deleted -wal/-shm while a live WAL connection was open. \
-             The backend must not hold a descriptor on the database file or \
-             -shm — see kernel_watcher::macos::candidate_paths and issue #80."
+        let baseline = sqlite_locks_after(|_| {});
+        assert_eq!(
+            baseline, held,
+            "a live WAL connection should hold both the -shm deadman lock and \
+             the database file's SHARED lock; the probe is measuring the wrong \
+             byte ranges"
+        );
+
+        let after = sqlite_locks_after(|db| {
+            issue_80_run_backend_then_shutdown(WatcherBackend::KernelWatch, db)
+        });
+        assert_eq!(
+            after, held,
+            "kernel-watch backend released this process's SQLite locks on \
+             shutdown while a live WAL connection was open. It must not hold a \
+             descriptor on the database file or -shm — see \
+             kernel_watcher::macos::candidate_paths and issue #80."
+        );
+    }
+
+    /// Issue #80, shm-fast-path half: the `-shm` fast path must never
+    /// release this process's SQLite WAL-index locks either.
+    ///
+    /// This backend had the defect at three sites, and `probe()` is the
+    /// worst of them: it ran on *every* `honker.open()`, after the caller's
+    /// writer connection had already created `-wal`/`-shm`, so a plain
+    /// `File::open` + drop dropped the whole process's WAL-index locks
+    /// once per open — no churn or contention needed. The other two are
+    /// the identity-change reopen and the watcher's own shutdown.
+    ///
+    /// Both arms below go through the same sensitivity control as the
+    /// kernel test; see that test for why `bundled-sqlite` is required.
+    #[test]
+    #[cfg(all(unix, feature = "shm-fast-path", feature = "bundled-sqlite"))]
+    fn shm_fast_path_does_not_release_sqlite_wal_locks() {
+        let held = SqliteLockState {
+            shm_dms: true,
+            db_shared: true,
+        };
+
+        let control = sqlite_locks_after(issue_80_raw_close_lock_bearing_files);
+        assert_ne!(
+            control,
+            held,
+            "control arm did not reproduce the defect, so this build cannot \
+             detect issue #80. SQLite {} is linked. Re-run with \
+             --features bundled-sqlite.",
+            rusqlite::version()
+        );
+
+        // probe() alone, with no watcher ever spawned. This is the site
+        // that fired on every honker.open().
+        let after_probe = sqlite_locks_after(|db| {
+            WatcherBackend::ShmFastPath
+                .probe(db)
+                .expect("shm probe should succeed on a live WAL database");
+        });
+        assert_eq!(
+            after_probe, held,
+            "shm-fast-path probe() released this process's SQLite locks. \
+             probe() must acquire its -shm descriptor through the registry, \
+             never File::open + drop — see shm_watcher.rs and issue #80."
+        );
+
+        // Full watcher lifecycle, shut down while the connection is live.
+        let after_watcher = sqlite_locks_after(|db| {
+            issue_80_run_backend_then_shutdown(WatcherBackend::ShmFastPath, db)
+        });
+        assert_eq!(
+            after_watcher, held,
+            "shm-fast-path released this process's SQLite locks on watcher \
+             shutdown while a live WAL connection was open — see issue #80."
         );
     }
 

--- a/honker-core/src/shm_watcher.rs
+++ b/honker-core/src/shm_watcher.rs
@@ -1,7 +1,8 @@
 //! Optional `-shm` fast path (feature = `shm-fast-path`).
 //!
 //! **Experimental.** Weaker correctness contract than the polling
-//! backend, in exchange for sub-millisecond wake latency.
+//! backend, in exchange for slightly lower CPU per tick. Not lower
+//! latency — see "What this backend is actually worth" below.
 //!
 //! # Contract
 //!
@@ -28,31 +29,231 @@
 //!   is read with bounded positional reads instead of mmap so SQLite file
 //!   churn cannot SIGBUS the host process.
 //!
+//! - **`-shm` descriptors are opened once and never closed early.** SQLite
+//!   locks `-shm`, and on POSIX closing any descriptor for an inode drops
+//!   every lock the *process* holds on it. See the registry below and
+//!   issue #80. This is why the backend does not simply `File::open` where
+//!   it needs a read.
+//!
+//! # What this backend is actually worth
+//!
+//! Less than its name suggests, and you should know that before enabling
+//! it. The original design mapped `-shm` and read `iChange` as a load,
+//! which was ~2000x cheaper than `PRAGMA data_version`. That mapping had
+//! to go: SQLite truncates `-shm` to 3 bytes when it re-attaches the WAL
+//! index, and a mapped read past the new end of file is SIGBUS, which
+//! kills the host process. Bounded positional reads replaced it.
+//!
+//! A bounded read is a syscall. Measured on macOS/arm64 against SQLite
+//! 3.51.3: `pread` of the header ~1.2 us, `PRAGMA data_version` ~2.3 us.
+//! Both backends then sleep 1 ms, so **wake latency is identical** — the
+//! only difference is roughly 1 us of CPU per millisecond per watched
+//! database, about 0.1% of a core. Prefer the polling backend unless you
+//! have measured a reason not to.
+//!
 //! Tests assert that wakes fire with sub-millisecond latency in WAL
 //! mode. If a test fails, the backend is broken — not "fall back to
 //! polling and pretend it worked".
 
 use crate::stat_identity;
 use rusqlite::{Connection, OpenFlags};
+use std::collections::HashMap;
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 const WALINDEX_MAX_VERSION: u32 = 3_007_000;
 const ICHANGE_OFFSET: usize = 8;
-/// Same cadence as the polling backend. Shm reads are nearly free; the
-/// win over polling is "PRAGMA -> memory load" (~3.5 us -> ns), not
-/// "1 ms -> 100 us". Going faster would just burn extra sleep syscalls
-/// for latency nobody can perceive.
+/// Same cadence as the polling backend. The win over polling is CPU per
+/// tick, not latency — both sleep 1 ms, so wake latency is identical.
+/// Measured on macOS/arm64 against SQLite 3.51.3: `pread` of the header
+/// is ~1.2 us versus ~2.3 us for `PRAGMA data_version`. That is a much
+/// smaller margin than the original mmap design promised, because a
+/// bounded read is a syscall and a mapped load was not. See the module
+/// docs for why the mapping had to go.
 const POLL_INTERVAL_MS: u64 = 1;
 /// Cadence for the dead-man's switch (db / -shm replacement detection).
 /// Same wall-clock interval as the polling and kernel backends. Tracked
 /// via Instant — tick counting drifts on Windows where 1 ms sleeps round
 /// up to ~15 ms.
 const IDENTITY_CHECK_INTERVAL: Duration = Duration::from_millis(100);
+
+// ---------------------------------------------------------------------
+// `-shm` descriptor registry (issue #80)
+// ---------------------------------------------------------------------
+//
+// SQLite takes POSIX advisory locks on `-shm` (the WAL-index locks and
+// the DMS byte). On POSIX, `close()` of *any* descriptor for an inode
+// releases *every* lock the calling process holds on it — including
+// locks belonging to unrelated SQLite connections in the same process.
+// SQLite's `unixInodeInfo` deferred-close list only defers closes of
+// descriptors SQLite itself opened, so it cannot protect us.
+//
+// So this module must never close a `-shm` descriptor while a connection
+// in this process might still hold locks on that inode. Three call sites
+// used to do exactly that: `probe()` on every `honker.open()`, the
+// identity-change reopen, and the watcher's own shutdown.
+//
+// The rule enforced here:
+//
+//   * open each `-shm` inode at most once per process, and share it;
+//   * never close a descriptor whose inode still has a name;
+//   * reclaim descriptors once `st_nlink == 0`, which proves the inode is
+//     unreferenced. SQLite only unlinks `-shm` while holding an EXCLUSIVE
+//     lock on the database file — i.e. when no connection anywhere is
+//     using that WAL — so at that point there is no lock left to drop.
+//
+// That bounds retention to one descriptor per *live* watched database
+// rather than leaking one per WAL generation.
+
+/// How many `-shm` descriptors this process will retain before giving up.
+/// Only reachable if inodes are churning faster than they can be reclaimed;
+/// failing loudly beats leaking descriptors without limit.
+#[cfg(unix)]
+const MAX_RETAINED_SHM_FDS: usize = 256;
+
+#[cfg(unix)]
+#[derive(Default)]
+struct ShmFdRegistry {
+    /// Current descriptor per `(dev, ino)`, shared by every watcher on it.
+    live: HashMap<(u64, u64), Arc<File>>,
+    /// Descriptors we could not file under a free key (lost an open race).
+    /// Held, not closed, until reclaimable.
+    extra: Vec<Arc<File>>,
+}
+
+#[cfg(unix)]
+fn shm_registry() -> &'static Mutex<ShmFdRegistry> {
+    static REGISTRY: OnceLock<Mutex<ShmFdRegistry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(ShmFdRegistry::default()))
+}
+
+/// `st_nlink` for an already-open file. `0` means the inode has no
+/// remaining directory entry, so nothing can lock it any more.
+#[cfg(unix)]
+fn link_count(file: &File) -> Option<u64> {
+    use std::os::unix::fs::MetadataExt;
+    file.metadata().ok().map(|m| m.nlink())
+}
+
+#[cfg(unix)]
+impl ShmFdRegistry {
+    /// Drop every descriptor whose inode is provably unreferenced and that
+    /// no watcher still holds. Cheap: one `fstat` per retained descriptor,
+    /// run only on acquire.
+    fn reclaim_unlinked(&mut self) {
+        self.live
+            .retain(|_, fd| Arc::strong_count(fd) > 1 || link_count(fd) != Some(0));
+        self.extra
+            .retain(|fd| Arc::strong_count(fd) > 1 || link_count(fd) != Some(0));
+    }
+
+    fn retained(&self) -> usize {
+        self.live.len() + self.extra.len()
+    }
+}
+
+/// Get a shared descriptor for `path`, opening it only if this process
+/// does not already hold one for that inode.
+///
+/// The `stat`-before-`open` step is not an optimization — it is the whole
+/// point. Opening a second descriptor just to discover we already had one
+/// would mean closing it, and that close is the bug.
+#[cfg(unix)]
+fn acquire_shm_fd(path: &Path) -> std::io::Result<Arc<File>> {
+    let existing_id = stat_identity(path).ok();
+    let mut reg = shm_registry().lock().unwrap_or_else(|e| e.into_inner());
+    reg.reclaim_unlinked();
+
+    if let Some(id) = existing_id
+        && let Some(fd) = reg.live.get(&id)
+    {
+        return Ok(Arc::clone(fd));
+    }
+
+    if reg.retained() >= MAX_RETAINED_SHM_FDS {
+        return Err(std::io::Error::other(format!(
+            "shm-fast-path is holding {MAX_RETAINED_SHM_FDS} -shm descriptors it \
+             cannot safely close; refusing to open more. Closing them would \
+             release this process's SQLite WAL-index locks (issue #80)."
+        )));
+    }
+
+    let file = Arc::new(File::open(path)?);
+    // Re-identify from the descriptor: `path` may have been replaced
+    // between the stat above and this open.
+    let id = match stat_identity_of(&file) {
+        Some(id) => id,
+        None => {
+            reg.extra.push(Arc::clone(&file));
+            return Ok(file);
+        }
+    };
+    match reg.live.entry(id) {
+        std::collections::hash_map::Entry::Occupied(slot) => {
+            // Raced with another thread. Keep ours alive rather than
+            // closing it, and hand back the descriptor already on file.
+            let winner = Arc::clone(slot.get());
+            reg.extra.push(file);
+            Ok(winner)
+        }
+        std::collections::hash_map::Entry::Vacant(slot) => {
+            slot.insert(Arc::clone(&file));
+            Ok(file)
+        }
+    }
+}
+
+/// `(dev, ino)` of an open file, matching [`crate::stat_identity`]'s shape.
+#[cfg(unix)]
+fn stat_identity_of(file: &File) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+    let m = file.metadata().ok()?;
+    Some((m.dev(), m.ino()))
+}
+
+/// Windows has no POSIX advisory locks — closing a handle cannot release
+/// another connection's lock — so the retention machinery above is not
+/// needed and would only keep handles alive on a live `-shm`.
+#[cfg(not(unix))]
+fn acquire_shm_fd(path: &Path) -> std::io::Result<Arc<File>> {
+    File::open(path).map(Arc::new)
+}
+
+/// A `-shm` descriptor, the 12-byte WAL-index header read from it, and
+/// that file's `(dev, ino)` at the time of the read.
+type ShmHeaderSnapshot = (Arc<File>, [u8; 12], (u64, u64));
+
+/// Positional read of the WAL-index header. One syscall, and — unlike a
+/// mapping — a file that shrinks underneath us yields `UnexpectedEof`
+/// instead of SIGBUS. That protection came from PR #43 and must stay.
+fn read_wal_index_header(file: &File) -> std::io::Result<[u8; 12]> {
+    let mut header = [0_u8; 12];
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileExt;
+        file.read_exact_at(&mut header, 0)?;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::FileExt;
+        let mut done = 0;
+        while done < header.len() {
+            match file.seek_read(&mut header[done..], done as u64)? {
+                0 => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "-shm shorter than the WAL index header",
+                    ));
+                }
+                n => done += n,
+            }
+        }
+    }
+    Ok(header)
+}
 
 pub(crate) fn run_shm_fast_path_loop<F>(
     db_path: PathBuf,
@@ -118,7 +319,7 @@ pub(crate) fn run_shm_fast_path_loop<F>(
 
     while !stop.load(Ordering::Acquire) {
         std::thread::sleep(Duration::from_millis(POLL_INTERVAL_MS));
-        let current = match read_wal_index_header(&mut f) {
+        let current = match read_wal_index_header(&f) {
             Ok(header) => read_ichange_from_header(&header),
             Err(e) => {
                 if let Some((new_file, new_header, new_id)) = reopen_shm_header(&shm_path) {
@@ -164,13 +365,6 @@ pub(crate) fn run_shm_fast_path_loop<F>(
     }
 }
 
-fn read_wal_index_header(file: &mut File) -> std::io::Result<[u8; 12]> {
-    let mut header = [0_u8; 12];
-    file.seek(SeekFrom::Start(0))?;
-    file.read_exact(&mut header)?;
-    Ok(header)
-}
-
 fn read_ichange_from_header(header: &[u8; 12]) -> u32 {
     u32::from_ne_bytes(
         header[ICHANGE_OFFSET..ICHANGE_OFFSET + 4]
@@ -179,9 +373,16 @@ fn read_ichange_from_header(header: &[u8; 12]) -> u32 {
     )
 }
 
-fn reopen_shm_header(path: &std::path::Path) -> Option<(File, [u8; 12], (u64, u64))> {
-    let mut file = File::open(path).ok()?;
-    let header = read_wal_index_header(&mut file).ok()?;
+/// Re-acquire the current `-shm` descriptor and re-read its header.
+///
+/// Goes through [`acquire_shm_fd`], so the descriptor this replaces is
+/// retained by the registry rather than closed. Closing it here would
+/// release the WAL-index locks of every SQLite connection in this
+/// process — the identity-change path was one of the three sites that
+/// did exactly that before issue #80.
+fn reopen_shm_header(path: &std::path::Path) -> Option<ShmHeaderSnapshot> {
+    let file = acquire_shm_fd(path).ok()?;
+    let header = read_wal_index_header(&file).ok()?;
     let id = stat_identity(path).ok()?;
     Some((file, header, id))
 }
@@ -189,7 +390,7 @@ fn reopen_shm_header(path: &std::path::Path) -> Option<(File, [u8; 12], (u64, u6
 fn wait_for_initial_shm_header(
     path: &std::path::Path,
     stop: &AtomicBool,
-) -> Option<(File, [u8; 12], (u64, u64))> {
+) -> Option<ShmHeaderSnapshot> {
     for _ in 0..200 {
         if stop.load(Ordering::Acquire) {
             return None;
@@ -236,10 +437,14 @@ pub(crate) fn probe(db_path: &std::path::Path) -> Result<(), String> {
         return Err("shm-fast-path requires little-endian platform".into());
     }
     let shm = format!("{}-shm", db_path.display());
-    let mut f = File::open(&shm)
+    // Acquire through the registry, never `File::open` + drop. `probe`
+    // runs at `honker.open()` time, *after* the caller's writer connection
+    // has already created -wal/-shm, so a bare open+close here released
+    // this process's SQLite WAL-index locks on every single open.
+    let f = acquire_shm_fd(std::path::Path::new(&shm))
         .map_err(|e| format!("-shm unavailable ({e}). WAL mode + open connection required."))?;
     let header =
-        read_wal_index_header(&mut f).map_err(|e| format!("-shm too small or unreadable: {e}"))?;
+        read_wal_index_header(&f).map_err(|e| format!("-shm too small or unreadable: {e}"))?;
     let iv = u32::from_ne_bytes(header[0..4].try_into().unwrap());
     if iv != WALINDEX_MAX_VERSION {
         return Err(format!(

--- a/honker-core/src/shm_watcher.rs
+++ b/honker-core/src/shm_watcher.rs
@@ -39,17 +39,27 @@
 //!
 //! Less than its name suggests, and you should know that before enabling
 //! it. The original design mapped `-shm` and read `iChange` as a load,
-//! which was ~2000x cheaper than `PRAGMA data_version`. That mapping had
-//! to go: SQLite truncates `-shm` to 3 bytes when it re-attaches the WAL
-//! index, and a mapped read past the new end of file is SIGBUS, which
-//! kills the host process. Bounded positional reads replaced it.
+//! which was ~2000x cheaper than `PRAGMA data_version`. PR #43 replaced
+//! that mapping with bounded positional reads, citing SIGBUS risk.
 //!
-//! A bounded read is a syscall. Measured on macOS/arm64 against SQLite
-//! 3.51.3: `pread` of the header ~1.2 us, `PRAGMA data_version` ~2.3 us.
-//! Both backends then sleep 1 ms, so **wake latency is identical** — the
-//! only difference is roughly 1 us of CPU per millisecond per watched
-//! database, about 0.1% of a core. Prefer the polling backend unless you
-//! have measured a reason not to.
+//! That risk was overstated for *this* read. SQLite's only shrink of
+//! `-shm` truncates it to 3 bytes, not 0 — deliberately — and `iChange`
+//! sits at offset 8, inside the zero-filled partial page that POSIX
+//! guarantees is readable. Only whole pages past the end of the object
+//! fault, and this module never touches those. The SIGBUS actually seen
+//! in CI came from *SQLite's own* mapping, which spans regions at 32 KiB
+//! and beyond, and it happened because this crate was dropping SQLite's
+//! DMS lock — issue #80, fixed by the registry above.
+//!
+//! The bounded read stays anyway: it costs ~1 us, it removes the need to
+//! reason about page boundaries at all, and restoring the mapping would
+//! not help. A bounded read is a syscall (~1.2 us here versus ~2.3 us for
+//! `PRAGMA data_version` on macOS/arm64), but both backends then sleep
+//! 1 ms, so **wake latency is identical**. The mapping would only pay off
+//! paired with a much tighter poll interval — and that trade is already
+//! available on the polling backend via `WatcherConfig::poll_interval`,
+//! without a second backend. Prefer polling unless you have measured a
+//! reason not to.
 //!
 //! Tests assert that wakes fire with sub-millisecond latency in WAL
 //! mode. If a test fails, the backend is broken — not "fall back to


### PR DESCRIPTION
## What changed

- makes the macOS kernel watcher observe only parent directories, so it never opens or closes SQLite's database, WAL, or SHM files
- introduces a process-wide SHM descriptor registry so shm-fast-path probes, reopen paths, and shutdown cannot close a descriptor while SQLite may hold process-scoped POSIX locks
- adds subprocess-based regression tests that directly prove the database SHARED lock and SHM deadman-switch lock survive both watcher lifecycles
- runs the lock-sensitive proof against bundled SQLite on macOS, where the regression is falsifiable
- documents the correctness fix and the SHM descriptor-lifetime tradeoff

## Root cause

POSIX record locks are process-scoped: closing any descriptor for the same file can release locks held by SQLite through another descriptor. The kernel watcher opened SQLite-owned files on macOS, and shm-fast-path independently opened and closed `-shm`. Either path could silently invalidate SQLite's WAL locking protocol.

Closes #80.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- bundled-SQLite baseline suite
- debug and release kernel-watcher + shm-fast-path suites
- `kernel_watcher_does_not_release_sqlite_wal_locks`
- `shm_fast_path_does_not_release_sqlite_wal_locks`
- release extension build
- complete standalone Rust binding suite
- retested after the notify 8 and rusqlite 0.40 dependency merges