### PR TITLE
Accept whole REAL arguments for integer SQL parameters

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -22,6 +22,31 @@ extension.
 | JVM `dev.honker:honker` | local + clean consumer | yes | yes | yes | yes | yes | shared JVM watcher |
 | Kotlin `dev.honker:honker-kotlin` | local + clean consumer | wrapper | Flow wrapper | wrapper | wrapper | wrapper | JVM wrapper |
 
+## Argument Types
+
+The `honker_*` SQL functions take their integer arguments the way
+SQLite's C API does: an `INTEGER` is used as-is, and a `REAL` holding a
+whole number is converted. `sqlite3_value_int64` has always behaved
+this way, so a C implementation of these functions would too.
+
+This is a deliberate guarantee, not an accident of the Rust wrapper.
+`rusqlite`'s `Context::get` type-checks strictly and rejects `REAL`,
+which is stricter than SQLite itself; `honker_ops::arg_i64` restores
+the documented behavior.
+
+It matters because dynamically typed clients bind what their language
+gives them. `better-sqlite3` binds **every** JavaScript number as
+`REAL` — whole ones included — because a JS `Number` is an IEEE-754
+double, and it offers `BigInt` as the explicit integer signal. So
+`honker_enqueue(..., priority, max_attempts, ...)` from Drizzle,
+Kysely, or plain better-sqlite3 arrives entirely as `REAL`.
+
+A `REAL` that is not a whole number is an error, and so are infinities,
+NaN, and values outside the range of a 64-bit integer. SQLite would
+truncate `2.7` to `2`; we do not. Rounding a job id or a retry count
+hides a caller's bug, and this is the one place being stricter than
+SQLite earns the inconsistency. The error names the value and why.
+
 ## Watcher Backends
 
 The stable backend is `PRAGMA data_version`. It is the default across

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -20,7 +20,7 @@
 
 use rusqlite::Connection;
 use rusqlite::functions::{Context, FunctionFlags};
-use rusqlite::types::{Type, ValueRef};
+use rusqlite::types::ValueRef;
 use serde_json::{Value, json};
 
 /// Read an integer argument, accepting the REAL that dynamically typed
@@ -56,7 +56,7 @@ fn real_to_i64(f: f64, idx: usize) -> rusqlite::Result<i64> {
     // 2^63 exactly; i64::MAX as f64 rounds *up* to it, so compare
     // against the power of two and exclude the top end.
     const LIMIT: f64 = 9_223_372_036_854_775_808.0;
-    if f.fract() == 0.0 && f >= -LIMIT && f < LIMIT {
+    if f.fract() == 0.0 && (-LIMIT..LIMIT).contains(&f) {
         return Ok(f as i64);
     }
 

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -57,13 +57,28 @@ fn real_to_i64(f: f64, idx: usize) -> rusqlite::Result<i64> {
     // against the power of two and exclude the top end.
     const LIMIT: f64 = 9_223_372_036_854_775_808.0;
     if f.fract() == 0.0 && f >= -LIMIT && f < LIMIT {
-        Ok(f as i64)
-    } else {
-        Err(rusqlite::Error::InvalidFunctionParameterType(
-            idx,
-            Type::Real,
-        ))
+        return Ok(f as i64);
     }
+
+    // "Invalid function parameter type Real" is useless here: the type
+    // is fine, the value is not. Say which value and why, because the
+    // caller is often an ORM and the number came from somewhere else.
+    let why = if f.is_nan() {
+        "not a number".to_string()
+    } else if f.is_infinite() {
+        "infinite".to_string()
+    } else if f.fract() != 0.0 {
+        format!("{f} has a fractional part")
+    } else {
+        format!("{f:e} is outside the range of a 64-bit integer")
+    };
+    Err(rusqlite::Error::UserFunctionError(Box::new(
+        std::io::Error::other(format!(
+            "honker: argument {idx} must be a whole number, but {why}. \
+             Whole values bind fine even when the client sends them as \
+             REAL, which better-sqlite3 does for every JavaScript number."
+        )),
+    )))
 }
 
 /// Wrap a Displayable error for SQLite scalar-function returns.
@@ -1784,9 +1799,10 @@ mod real_arg_tests {
                 |r| r.get::<_, i64>(0),
             )
             .unwrap_err();
+        let msg = err.to_string();
         assert!(
-            err.to_string().contains("Real"),
-            "expected a Real type error, got: {err}"
+            msg.contains("must be a whole number") && msg.contains("fractional part"),
+            "expected a message naming the value and why, got: {err}"
         );
     }
 

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -19,8 +19,52 @@
 //! tested once and inherited by every consumer.
 
 use rusqlite::Connection;
-use rusqlite::functions::FunctionFlags;
+use rusqlite::functions::{Context, FunctionFlags};
+use rusqlite::types::{Type, ValueRef};
 use serde_json::{Value, json};
+
+/// Read an integer argument, accepting the REAL that dynamically typed
+/// clients send for whole numbers.
+///
+/// `better-sqlite3` binds every JavaScript number as SQLite REAL, whole
+/// ones included. So `honker_enqueue(..., priority, max_attempts, ...)`
+/// called from Drizzle or Kysely arrives as REAL and used to fail with
+/// "Invalid function parameter type Real". SQLite is dynamically typed
+/// and these are integer arguments; refusing `3.0` because it arrived
+/// as a double was our bug, not the caller's.
+///
+/// A REAL with a fractional part is still an error. Truncating `1.5` to
+/// `1` would hide a real mistake, and a job id is not a rounding
+/// candidate.
+pub fn arg_i64(ctx: &Context<'_>, idx: usize) -> rusqlite::Result<i64> {
+    match ctx.get_raw(idx) {
+        ValueRef::Real(f) => real_to_i64(f, idx),
+        // Integer, and everything else, keep rusqlite's own behavior.
+        _ => ctx.get::<i64>(idx),
+    }
+}
+
+/// Nullable form of [`arg_i64`]. NULL stays None.
+pub fn arg_opt_i64(ctx: &Context<'_>, idx: usize) -> rusqlite::Result<Option<i64>> {
+    match ctx.get_raw(idx) {
+        ValueRef::Real(f) => real_to_i64(f, idx).map(Some),
+        _ => ctx.get::<Option<i64>>(idx),
+    }
+}
+
+fn real_to_i64(f: f64, idx: usize) -> rusqlite::Result<i64> {
+    // 2^63 exactly; i64::MAX as f64 rounds *up* to it, so compare
+    // against the power of two and exclude the top end.
+    const LIMIT: f64 = 9_223_372_036_854_775_808.0;
+    if f.fract() == 0.0 && f >= -LIMIT && f < LIMIT {
+        Ok(f as i64)
+    } else {
+        Err(rusqlite::Error::InvalidFunctionParameterType(
+            idx,
+            Type::Real,
+        ))
+    }
+}
 
 /// Wrap a Displayable error for SQLite scalar-function returns.
 fn to_sql_err<E: std::fmt::Display>(e: E) -> rusqlite::Error {
@@ -40,8 +84,8 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     conn.create_scalar_function("honker_claim_batch", 4, FunctionFlags::SQLITE_UTF8, |ctx| {
         let queue: String = ctx.get(0)?;
         let worker_id: String = ctx.get(1)?;
-        let n: i64 = ctx.get(2)?;
-        let timeout_s: i64 = ctx.get(3)?;
+        let n: i64 = arg_i64(ctx, 2)?;
+        let timeout_s: i64 = arg_i64(ctx, 3)?;
         let db = unsafe { ctx.get_connection() }?;
         claim_batch(&db, &queue, &worker_id, n, timeout_s).map_err(to_sql_err)
     })?;
@@ -82,7 +126,7 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
         |ctx| {
             let name: String = ctx.get(0)?;
             let owner: String = ctx.get(1)?;
-            let ttl: i64 = ctx.get(2)?;
+            let ttl: i64 = arg_i64(ctx, 2)?;
             let db = unsafe { ctx.get_connection() }?;
             lock_acquire(&db, &name, &owner, ttl).map_err(to_sql_err)
         },
@@ -107,7 +151,7 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     conn.create_scalar_function("honker_lock_renew", 3, FunctionFlags::SQLITE_UTF8, |ctx| {
         let name: String = ctx.get(0)?;
         let owner: String = ctx.get(1)?;
-        let ttl: i64 = ctx.get(2)?;
+        let ttl: i64 = arg_i64(ctx, 2)?;
         let db = unsafe { ctx.get_connection() }?;
         lock_renew(&db, &name, &owner, ttl).map_err(to_sql_err)
     })?;
@@ -118,8 +162,8 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
         FunctionFlags::SQLITE_UTF8,
         |ctx| {
             let name: String = ctx.get(0)?;
-            let limit: i64 = ctx.get(1)?;
-            let per: i64 = ctx.get(2)?;
+            let limit: i64 = arg_i64(ctx, 1)?;
+            let per: i64 = arg_i64(ctx, 2)?;
             let db = unsafe { ctx.get_connection() }?;
             rate_limit_try(&db, &name, limit, per).map_err(to_sql_err)
         },
@@ -130,7 +174,7 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
         1,
         FunctionFlags::SQLITE_UTF8,
         |ctx| {
-            let older_than_s: i64 = ctx.get(0)?;
+            let older_than_s: i64 = arg_i64(ctx, 0)?;
             let db = unsafe { ctx.get_connection() }?;
             rate_limit_sweep(&db, older_than_s).map_err(to_sql_err)
         },
@@ -152,8 +196,8 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
             let queue: String = ctx.get(1)?;
             let cron_expr: String = ctx.get(2)?;
             let payload: String = ctx.get(3)?;
-            let priority: i64 = ctx.get(4)?;
-            let expires_s: Option<i64> = ctx.get(5)?;
+            let priority: i64 = arg_i64(ctx, 4)?;
+            let expires_s: Option<i64> = arg_opt_i64(ctx, 5)?;
             let db = unsafe { ctx.get_connection() }?;
             scheduler_register(
                 &db, &name, &queue, &cron_expr, &payload, priority, expires_s, 3,
@@ -170,9 +214,9 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
             let queue: String = ctx.get(1)?;
             let cron_expr: String = ctx.get(2)?;
             let payload: String = ctx.get(3)?;
-            let priority: i64 = ctx.get(4)?;
-            let expires_s: Option<i64> = ctx.get(5)?;
-            let max_attempts: i64 = ctx.get(6)?;
+            let priority: i64 = arg_i64(ctx, 4)?;
+            let expires_s: Option<i64> = arg_opt_i64(ctx, 5)?;
+            let max_attempts: i64 = arg_i64(ctx, 6)?;
             let db = unsafe { ctx.get_connection() }?;
             scheduler_register(
                 &db,
@@ -212,7 +256,7 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
         1,
         FunctionFlags::SQLITE_UTF8,
         |ctx| {
-            let now_unix: i64 = ctx.get(0)?;
+            let now_unix: i64 = arg_i64(ctx, 0)?;
             let db = unsafe { ctx.get_connection() }?;
             scheduler_tick(&db, now_unix).map_err(to_sql_err)
         },
@@ -282,9 +326,9 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
             let name: String = ctx.get(0)?;
             let cron_expr: Option<String> = ctx.get(1)?;
             let payload: Option<String> = ctx.get(2)?;
-            let priority: Option<i64> = ctx.get(3)?;
-            let expires_s_arg: Option<i64> = ctx.get(4)?;
-            let touch_expires: i64 = ctx.get(5)?;
+            let priority: Option<i64> = arg_opt_i64(ctx, 3)?;
+            let expires_s_arg: Option<i64> = arg_opt_i64(ctx, 4)?;
+            let touch_expires: i64 = arg_i64(ctx, 5)?;
             let db = unsafe { ctx.get_connection() }?;
             let expires_s = if touch_expires != 0 {
                 Some(expires_s_arg)
@@ -311,11 +355,11 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
             let name: String = ctx.get(0)?;
             let cron_expr: Option<String> = ctx.get(1)?;
             let payload: Option<String> = ctx.get(2)?;
-            let priority: Option<i64> = ctx.get(3)?;
-            let expires_s_arg: Option<i64> = ctx.get(4)?;
-            let touch_expires: i64 = ctx.get(5)?;
-            let max_attempts_arg: Option<i64> = ctx.get(6)?;
-            let touch_max_attempts: i64 = ctx.get(7)?;
+            let priority: Option<i64> = arg_opt_i64(ctx, 3)?;
+            let expires_s_arg: Option<i64> = arg_opt_i64(ctx, 4)?;
+            let touch_expires: i64 = arg_i64(ctx, 5)?;
+            let max_attempts_arg: Option<i64> = arg_opt_i64(ctx, 6)?;
+            let touch_max_attempts: i64 = arg_i64(ctx, 7)?;
             let db = unsafe { ctx.get_connection() }?;
             let expires_s = if touch_expires != 0 {
                 Some(expires_s_arg)
@@ -341,15 +385,15 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     )?;
 
     conn.create_scalar_function("honker_result_save", 3, FunctionFlags::SQLITE_UTF8, |ctx| {
-        let job_id: i64 = ctx.get(0)?;
+        let job_id: i64 = arg_i64(ctx, 0)?;
         let value: String = ctx.get(1)?;
-        let ttl_s: i64 = ctx.get(2)?;
+        let ttl_s: i64 = arg_i64(ctx, 2)?;
         let db = unsafe { ctx.get_connection() }?;
         result_save(&db, job_id, &value, ttl_s).map_err(to_sql_err)
     })?;
 
     conn.create_scalar_function("honker_result_get", 1, FunctionFlags::SQLITE_UTF8, |ctx| {
-        let job_id: i64 = ctx.get(0)?;
+        let job_id: i64 = arg_i64(ctx, 0)?;
         let db = unsafe { ctx.get_connection() }?;
         result_get(&db, job_id).map_err(to_sql_err)
     })?;
@@ -373,11 +417,11 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     conn.create_scalar_function("honker_enqueue", 7, FunctionFlags::SQLITE_UTF8, |ctx| {
         let queue: String = ctx.get(0)?;
         let payload: String = ctx.get(1)?;
-        let run_at: Option<i64> = ctx.get(2)?;
-        let delay: Option<i64> = ctx.get(3)?;
-        let priority: i64 = ctx.get(4)?;
-        let max_attempts: i64 = ctx.get(5)?;
-        let expires: Option<i64> = ctx.get(6)?;
+        let run_at: Option<i64> = arg_opt_i64(ctx, 2)?;
+        let delay: Option<i64> = arg_opt_i64(ctx, 3)?;
+        let priority: i64 = arg_i64(ctx, 4)?;
+        let max_attempts: i64 = arg_i64(ctx, 5)?;
+        let expires: Option<i64> = arg_opt_i64(ctx, 6)?;
         let db = unsafe { ctx.get_connection() }?;
         enqueue(
             &db,
@@ -395,7 +439,7 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     // honker_ack(job_id, worker_id) -> 1 if ack'd, 0 if claim expired /
     // not ours.
     conn.create_scalar_function("honker_ack", 2, FunctionFlags::SQLITE_UTF8, |ctx| {
-        let job_id: i64 = ctx.get(0)?;
+        let job_id: i64 = arg_i64(ctx, 0)?;
         let worker_id: String = ctx.get(1)?;
         let db = unsafe { ctx.get_connection() }?;
         ack(&db, job_id, &worker_id).map_err(to_sql_err)
@@ -407,9 +451,9 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     // to pending. Fires a notify on the queue's channel on successful
     // pending-flip (so waiting workers wake).
     conn.create_scalar_function("honker_retry", 4, FunctionFlags::SQLITE_UTF8, |ctx| {
-        let job_id: i64 = ctx.get(0)?;
+        let job_id: i64 = arg_i64(ctx, 0)?;
         let worker_id: String = ctx.get(1)?;
-        let delay_s: i64 = ctx.get(2)?;
+        let delay_s: i64 = arg_i64(ctx, 2)?;
         let error: String = ctx.get(3)?;
         let db = unsafe { ctx.get_connection() }?;
         retry(&db, job_id, &worker_id, delay_s, &error).map_err(to_sql_err)
@@ -418,7 +462,7 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     // honker_fail(job_id, worker_id, error) -> 1 if failed-to-dead, 0 if
     // not our claim.
     conn.create_scalar_function("honker_fail", 3, FunctionFlags::SQLITE_UTF8, |ctx| {
-        let job_id: i64 = ctx.get(0)?;
+        let job_id: i64 = arg_i64(ctx, 0)?;
         let worker_id: String = ctx.get(1)?;
         let error: String = ctx.get(2)?;
         let db = unsafe { ctx.get_connection() }?;
@@ -428,9 +472,9 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     // honker_heartbeat(job_id, worker_id, extend_s) -> 1 if extended, 0
     // if not our claim.
     conn.create_scalar_function("honker_heartbeat", 3, FunctionFlags::SQLITE_UTF8, |ctx| {
-        let job_id: i64 = ctx.get(0)?;
+        let job_id: i64 = arg_i64(ctx, 0)?;
         let worker_id: String = ctx.get(1)?;
-        let extend_s: i64 = ctx.get(2)?;
+        let extend_s: i64 = arg_i64(ctx, 2)?;
         let db = unsafe { ctx.get_connection() }?;
         heartbeat(&db, job_id, &worker_id, extend_s).map_err(to_sql_err)
     })?;
@@ -438,14 +482,14 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     // honker_cancel(job_id) -> 1 if a pending/processing row was removed,
     // 0 otherwise. Idempotent on missing.
     conn.create_scalar_function("honker_cancel", 1, FunctionFlags::SQLITE_UTF8, |ctx| {
-        let job_id: i64 = ctx.get(0)?;
+        let job_id: i64 = arg_i64(ctx, 0)?;
         let db = unsafe { ctx.get_connection() }?;
         cancel(&db, job_id).map_err(to_sql_err)
     })?;
 
     // honker_get_job(job_id) -> JSON object on hit, empty string on miss.
     conn.create_scalar_function("honker_get_job", 1, FunctionFlags::SQLITE_UTF8, |ctx| {
-        let job_id: i64 = ctx.get(0)?;
+        let job_id: i64 = arg_i64(ctx, 0)?;
         let db = unsafe { ctx.get_connection() }?;
         get_job(&db, job_id).map_err(to_sql_err)
     })?;
@@ -460,7 +504,7 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
         FunctionFlags::SQLITE_UTF8 | FunctionFlags::SQLITE_DETERMINISTIC,
         |ctx| {
             let expr: String = ctx.get(0)?;
-            let from_unix: i64 = ctx.get(1)?;
+            let from_unix: i64 = arg_i64(ctx, 1)?;
             super::cron::next_after_unix(&expr, from_unix).map_err(to_sql_err)
         },
     )?;
@@ -491,8 +535,8 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
         FunctionFlags::SQLITE_UTF8,
         |ctx| {
             let topic: String = ctx.get(0)?;
-            let offset: i64 = ctx.get(1)?;
-            let limit: i64 = ctx.get(2)?;
+            let offset: i64 = arg_i64(ctx, 1)?;
+            let limit: i64 = arg_i64(ctx, 2)?;
             let db = unsafe { ctx.get_connection() }?;
             stream_read_since(&db, &topic, offset, limit).map_err(to_sql_err)
         },
@@ -509,7 +553,7 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
         |ctx| {
             let consumer: String = ctx.get(0)?;
             let topic: String = ctx.get(1)?;
-            let offset: i64 = ctx.get(2)?;
+            let offset: i64 = arg_i64(ctx, 2)?;
             let db = unsafe { ctx.get_connection() }?;
             stream_save_offset(&db, &consumer, &topic, offset).map_err(to_sql_err)
         },
@@ -1673,4 +1717,159 @@ pub fn stream_get_offset(conn: &Connection, consumer: &str, topic: &str) -> rusq
 
 fn now_unix(conn: &Connection) -> rusqlite::Result<i64> {
     conn.query_row("SELECT unixepoch()", [], |r| r.get(0))
+}
+
+#[cfg(test)]
+mod real_arg_tests {
+    use crate::{attach_honker_functions, bootstrap_honker_schema};
+    use rusqlite::Connection;
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        attach_honker_functions(&conn).unwrap();
+        bootstrap_honker_schema(&conn).unwrap();
+        conn
+    }
+
+    // better-sqlite3 binds every JavaScript number as REAL, so this is
+    // the exact shape a Drizzle or Kysely caller sends. Before the
+    // arg_i64 coercion this failed with "Invalid function parameter
+    // type Real at index 4".
+    #[test]
+    fn enqueue_accepts_real_priority_and_max_attempts() {
+        let conn = db();
+        let id: i64 = conn
+            .query_row(
+                "SELECT honker_enqueue('emails', '{}', NULL, NULL, ?1, ?2, NULL)",
+                (0.0_f64, 3.0_f64),
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(id > 0);
+    }
+
+    #[test]
+    fn ack_accepts_a_real_job_id() {
+        let conn = db();
+        let id: i64 = conn
+            .query_row(
+                "SELECT honker_enqueue('emails', '{}', NULL, NULL, 0, 3, NULL)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let _: String = conn
+            .query_row(
+                "SELECT honker_claim_batch('emails', 'w1', 8, 300)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+
+        let acked: i64 = conn
+            .query_row("SELECT honker_ack(?1, 'w1')", [id as f64], |r| r.get(0))
+            .unwrap();
+        assert_eq!(acked, 1, "a REAL job id must ack the same row");
+    }
+
+    // Coercion is not rounding. A fractional argument is a caller
+    // mistake and has to stay an error.
+    #[test]
+    fn fractional_reals_are_still_rejected() {
+        let conn = db();
+        let err = conn
+            .query_row(
+                "SELECT honker_enqueue('emails', '{}', NULL, NULL, ?1, 3, NULL)",
+                [1.5_f64],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("Real"),
+            "expected a Real type error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn null_optional_args_stay_none() {
+        let conn = db();
+        // expires is the argument where None and Some(0) actually
+        // differ in the stored row: `expires.map(|e| now + e)` writes
+        // NULL for None and `now` for Some(0). run_at and delay both
+        // collapse to `now` either way, so neither can discriminate.
+        let id: i64 = conn
+            .query_row(
+                "SELECT honker_enqueue('emails', '{}', NULL, NULL, 0, 3, NULL)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let expires_at: Option<i64> = conn
+            .query_row(
+                "SELECT expires_at FROM _honker_live WHERE id = ?1",
+                [id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            expires_at, None,
+            "a NULL expires argument must stay None, not become Some(0)"
+        );
+    }
+
+    #[test]
+    fn whole_real_delay_coerces() {
+        let conn = db();
+        let now: i64 = conn
+            .query_row("SELECT unixepoch()", [], |r| r.get(0))
+            .unwrap();
+        let id: i64 = conn
+            .query_row(
+                "SELECT honker_enqueue('emails', '{}', NULL, ?1, 0, 3, NULL)",
+                [30.0_f64],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let run_at: i64 = conn
+            .query_row("SELECT run_at FROM _honker_live WHERE id = ?1", [id], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert!(
+            (run_at - (now + 30)).abs() <= 1,
+            "a REAL delay of 30.0 must schedule now + 30, got {run_at} (now = {now})"
+        );
+    }
+
+    // The bounds in real_to_i64 are the part most likely to be wrong,
+    // so pin every edge rather than trusting the comparison reads right.
+    #[test]
+    fn real_bounds_are_exact() {
+        let conn = db();
+        let probe = |v: f64| -> Result<i64, rusqlite::Error> {
+            conn.query_row("SELECT honker_ack(?1, 'w1')", [v], |r| r.get::<_, i64>(0))
+        };
+
+        // 2^63 is not representable as i64; i64::MAX as f64 rounds up to
+        // it, which is why the check is `f < LIMIT` and not `<=`.
+        assert!(
+            probe(9_223_372_036_854_775_808.0).is_err(),
+            "2^63 must reject"
+        );
+        // Largest f64 strictly below 2^63.
+        assert!(
+            probe(9_223_372_036_854_774_784.0).is_ok(),
+            "2^63-1024 must pass"
+        );
+        // -2^63 is exactly i64::MIN and must pass.
+        assert!(
+            probe(-9_223_372_036_854_775_808.0).is_ok(),
+            "-2^63 must pass"
+        );
+        assert!(probe(f64::INFINITY).is_err(), "infinity must reject");
+        assert!(probe(f64::NEG_INFINITY).is_err(), "-infinity must reject");
+        assert!(probe(f64::NAN).is_err(), "NaN must reject");
+        // Negative zero is whole and must coerce to 0, not error.
+        assert!(probe(-0.0).is_ok(), "-0.0 must pass");
+    }
 }

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -42,6 +42,9 @@ mod kernel_watcher;
 mod shm_watcher;
 
 pub use honker_ops::attach_honker_functions;
+// Shared by the loadable extension's own watcher SQL functions so every
+// honker_* function coerces integer arguments the same way.
+pub use honker_ops::{arg_i64, arg_opt_i64};
 
 use parking_lot::{Condvar, Mutex};
 use rusqlite::functions::FunctionFlags;

--- a/honker-extension/src/lib.rs
+++ b/honker-extension/src/lib.rs
@@ -108,7 +108,7 @@ fn attach_watcher_sql_functions(conn: &Connection) -> Result<()> {
         |ctx| {
             let db_path: String = ctx.get(0)?;
             let backend: Option<String> = ctx.get(1)?;
-            let poll_interval_ms: Option<i64> = ctx.get(2)?;
+            let poll_interval_ms: Option<i64> = honker_core::arg_opt_i64(ctx, 2)?;
             let poll_interval_ms = poll_interval_ms.map(|ms| ms.max(0) as u64);
             let handle = open_watcher_handle(&db_path, backend.as_deref(), poll_interval_ms)
                 .map_err(|e| {
@@ -124,8 +124,8 @@ fn attach_watcher_sql_functions(conn: &Connection) -> Result<()> {
         2,
         FunctionFlags::SQLITE_UTF8,
         |ctx| {
-            let id: i64 = ctx.get(0)?;
-            let timeout_ms: i64 = ctx.get(1)?;
+            let id: i64 = honker_core::arg_i64(ctx, 0)?;
+            let timeout_ms: i64 = honker_core::arg_i64(ctx, 1)?;
             let Some(handle) = SQL_WATCHERS.lock().unwrap().remove(&(id as u64)) else {
                 return Ok(-1);
             };
@@ -149,7 +149,7 @@ fn attach_watcher_sql_functions(conn: &Connection) -> Result<()> {
         1,
         FunctionFlags::SQLITE_UTF8,
         |ctx| {
-            let id: i64 = ctx.get(0)?;
+            let id: i64 = honker_core::arg_i64(ctx, 0)?;
             if let Some(handle) = SQL_WATCHERS.lock().unwrap().remove(&(id as u64)) {
                 handle.shared.unsubscribe(handle.sub_id);
                 let _ = handle.shared.close();


### PR DESCRIPTION
Split out of #100 so the semantics change to `honker-core` gets its own review. #100 depends on this.

## The problem

`better-sqlite3` binds **every** JavaScript number as SQLite `REAL`, whole ones included. Only `BigInt` binds `INTEGER`. So the `Queue` wrapper currently published on honker.dev fails on its first call:

```
honker_enqueue('emails', '{}', NULL, NULL, 0, 3, NULL)
-> Invalid function parameter type Real at index 4
```

It hits every integer argument a JS client passes — job ids, `priority`, `max_attempts`, delays, claim batch sizes. Found while testing the packaged extension against better-sqlite3 for real, not by reading.

## Why coercing is the right fix, not an antipattern

SQLite's own built-in scalar functions already do this:

```
sqlite> SELECT substr('hello', 2.0, 3.0);   -- ell
sqlite> SELECT char(65.0);                  -- A
```

So `honker_*` refusing `3.0` didn't make us stricter than SQLite — it made us inconsistent with every other function on the same connection. This is conformance with the host language's convention.

The alternatives are worse. Docs-only (`CAST` / `BigInt`) leaves the published wrapper broken and hands a permanent footgun to every dynamically-typed client. Fixing it in the bindings is impossible — the ORM path has no binding in the loop, which is the entire point of #99. SQLite dispatches scalar functions on arity only, so type overloads aren't available.

## One deliberate divergence

SQLite *truncates* `2.7` to `2`. We reject it. Rounding a job id would hide a caller bug, and this is the one spot where being stricter than SQLite is worth the inconsistency. Calling it out because it cuts against the conformance argument above.

## Scope

Strictly widening. TEXT, BLOB, and NULL-into-a-non-nullable all produce the same errors as before; no currently-working caller in any binding changes behavior. 41 argument reads in `honker-core` plus 4 in the extension's watcher functions.

## Proof

Six tests, each broken and restored to confirm it catches something real:

- deleting the `Real` arms of `arg_i64`/`arg_opt_i64` → coercion tests fail, fractional-rejection still passes
- relaxing `f < LIMIT` to `f <= LIMIT` → `real_bounds_are_exact` fails on 2^63
- collapsing NULL to `Some(0)` → `null_optional_args_stay_none` fails

That last test took three attempts to write honestly. `run_at` and `delay` both resolve to `now` whether the argument is `None` or `Some(0)`, so neither can discriminate — only `expires` can, because it writes NULL vs `now`. The first two versions passed against a deliberately broken `arg_opt_i64`.

Bounds pinned explicitly: 2^63 rejects, 2^63−1024 passes, −2^63 passes, ±infinity and NaN reject, −0.0 coerces to 0.

## Review note

`arg_i64`/`arg_opt_i64` are exported from `honker-core` so `honker-extension` can call them, which puts a `rusqlite::functions::Context` in the public surface and pins consumers to rusqlite 0.40. They release together so it's defensible, but `#[doc(hidden)]` or a `pub mod internal` may say it better. Flagging rather than deciding.