### PR TITLE
Bump every binding to 0.5.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "honker-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "honker-extension"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "honker-core",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 # Every language binding lives in its own submodule repo and opts
 # out of this workspace via its own `[workspace]` table. Each pulls
-# `honker-core` via `path = "../../honker-core", version = "0.4.0"` so
+# `honker-core` via `path = "../../honker-core", version = "0.5.0"` so
 # the path resolves when submoduled and the version falls back when
 # the binding is consumed standalone from its registry (PyPI, npm,
 # crates.io, etc.).

--- a/honker-core/Cargo.toml
+++ b/honker-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honker-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "Shared Rust foundation for Honker bindings (SQLite loadable extension, PyO3, napi-rs, and friends). Not intended for direct use."
 license = "MIT OR Apache-2.0"

--- a/honker-extension/Cargo.toml
+++ b/honker-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honker-extension"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "SQLite loadable extension for Honker. Adds honker_* SQL functions (queues, streams, scheduler, pub/sub) to any SQLite client."
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ crate-type = ["cdylib"]
 # Using both `path` and `version` lets Cargo publish this crate to
 # crates.io referencing the real honker-core = "0.2" while still
 # using the in-tree source for local builds.
-honker-core = { path = "../honker-core", version = "0.4.0", default-features = false }
+honker-core = { path = "../honker-core", version = "0.5.0", default-features = false }
 # "loadable_extension" feature makes rusqlite usable from inside a
 # sqlite3_extension_init entry point.
 rusqlite = { version = "0.40.1", features = ["functions", "hooks", "loadable_extension"] }

--- a/packages/honker-bun/bun.lock
+++ b/packages/honker-bun/bun.lock
@@ -4,12 +4,26 @@
   "workspaces": {
     "": {
       "name": "@russellthehippo/honker-bun",
+      "optionalDependencies": {
+        "@russellthehippo/honker-ext-darwin-arm64": "0.4.6",
+        "@russellthehippo/honker-ext-darwin-x64": "0.4.6",
+        "@russellthehippo/honker-ext-linux-arm64-gnu": "0.4.6",
+        "@russellthehippo/honker-ext-linux-x64-gnu": "0.4.6",
+      },
       "peerDependencies": {
         "typescript": "^5",
       },
     },
   },
   "packages": {
+    "@russellthehippo/honker-ext-darwin-arm64": ["@russellthehippo/honker-ext-darwin-arm64@0.4.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WAGssCw2kA5Qlbv2c0PzNwpx9BLmB2Rmf4aovQjGXxP8kI496o2y5VnTnTKBgOi0TWvVLYVYa1PKfrng/UC8sg=="],
+
+    "@russellthehippo/honker-ext-darwin-x64": ["@russellthehippo/honker-ext-darwin-x64@0.4.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-gGlEGPgiFbysF/NFb88PYY8PMZjXI6T7oqH2O2FSRu5ktwkSQUyELID9G/zC9Wi5blw/Hx1iTsI3hQl1rcRfkQ=="],
+
+    "@russellthehippo/honker-ext-linux-arm64-gnu": ["@russellthehippo/honker-ext-linux-arm64-gnu@0.4.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-1SpEfmAlvG9dgIXFHkYWHdp8cyaqZdnEoupmVvuOe7ecXwQUzNCeBsATFGD737fE+BfrrV0yUPI3cfx07uB5AQ=="],
+
+    "@russellthehippo/honker-ext-linux-x64-gnu": ["@russellthehippo/honker-ext-linux-x64-gnu@0.4.6", "", { "os": "linux", "cpu": "x64" }, "sha512-cqD9kAn01tTNdIM+DxJ1ZlNuCan7PM2hO1ZXxSmPkR5SZ93APz+4SKLvmnBkWtVKz4Z95W0yzUY6Lmag6uCG+g=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
   }
 }

--- a/packages/honker-dotnet/src/Honker/Honker.csproj
+++ b/packages/honker-dotnet/src/Honker/Honker.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Honker</RootNamespace>
     <IsPackable>true</IsPackable>
     <PackageId>Honker</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>Russell Romney</Authors>
     <Description>SQLite queue, notify/listen, streams, scheduler, and outbox bindings for .NET via the Honker loadable extension.</Description>
     <PackageTags>sqlite;queue;pubsub;notify;listen;stream;outbox;scheduler</PackageTags>

--- a/packages/honker-ex/mix.exs
+++ b/packages/honker-ex/mix.exs
@@ -4,7 +4,7 @@ defmodule Honker.MixProject do
   def project do
     [
       app: :honker,
-      version: "0.4.0",
+      version: "0.5.0",
       elixir: "~> 1.17",
       description:
         "Durable queues, streams, pub/sub, and scheduler on SQLite. " <>

--- a/packages/honker-jvm/pom.xml
+++ b/packages/honker-jvm/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>dev.honker</groupId>
   <artifactId>honker</artifactId>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <name>honker-jvm</name>
   <description>JVM binding for Honker queues, streams, pub/sub, scheduler, locks, and rate limits on SQLite.</description>
 

--- a/packages/honker-kotlin/pom.xml
+++ b/packages/honker-kotlin/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>dev.honker</groupId>
   <artifactId>honker-kotlin</artifactId>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <name>honker-kotlin</name>
   <description>Kotlin convenience wrappers for Honker JVM.</description>
 

--- a/packages/honker-node/Cargo.toml
+++ b/packages/honker-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honker-node"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
@@ -26,7 +26,7 @@ shm-fast-path = ["honker-core/shm-fast-path"]
 # inside the main honker repo (whether directly or as a submodule).
 # Standalone hacking on this repo alone requires honker-core on
 # crates.io (future) or a manual path override in .cargo/config.toml.
-honker-core = { path = "../../honker-core", version = "0.4.0" }
+honker-core = { path = "../../honker-core", version = "0.5.0" }
 napi = { version = "3.2", features = ["async", "serde-json", "tokio_rt"] }
 napi-derive = "3.2"
 parking_lot = "0.12.5"
@@ -35,7 +35,7 @@ serde_json = "1.0"
 tokio = { version = "1.52.1", features = ["rt", "rt-multi-thread"] }
 
 [target.'cfg(windows)'.dependencies]
-honker-core = { path = "../../honker-core", version = "0.4.0", features = ["bundled-sqlite"] }
+honker-core = { path = "../../honker-core", version = "0.5.0", features = ["bundled-sqlite"] }
 
 [build-dependencies]
 napi-build = "2.2"

--- a/packages/honker-node/package-lock.json
+++ b/packages/honker-node/package-lock.json
@@ -1599,28 +1599,132 @@
       }
     },
     "node_modules/@russellthehippo/honker-ext-darwin-arm64": {
-      "optional": true
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-ext-darwin-arm64/-/honker-ext-darwin-arm64-0.4.6.tgz",
+      "integrity": "sha512-WAGssCw2kA5Qlbv2c0PzNwpx9BLmB2Rmf4aovQjGXxP8kI496o2y5VnTnTKBgOi0TWvVLYVYa1PKfrng/UC8sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@russellthehippo/honker-ext-darwin-x64": {
-      "optional": true
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-ext-darwin-x64/-/honker-ext-darwin-x64-0.4.6.tgz",
+      "integrity": "sha512-gGlEGPgiFbysF/NFb88PYY8PMZjXI6T7oqH2O2FSRu5ktwkSQUyELID9G/zC9Wi5blw/Hx1iTsI3hQl1rcRfkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@russellthehippo/honker-ext-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-ext-linux-arm64-gnu/-/honker-ext-linux-arm64-gnu-0.4.6.tgz",
+      "integrity": "sha512-1SpEfmAlvG9dgIXFHkYWHdp8cyaqZdnEoupmVvuOe7ecXwQUzNCeBsATFGD737fE+BfrrV0yUPI3cfx07uB5AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@russellthehippo/honker-ext-linux-x64-gnu": {
-      "optional": true
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-ext-linux-x64-gnu/-/honker-ext-linux-x64-gnu-0.4.6.tgz",
+      "integrity": "sha512-cqD9kAn01tTNdIM+DxJ1ZlNuCan7PM2hO1ZXxSmPkR5SZ93APz+4SKLvmnBkWtVKz4Z95W0yzUY6Lmag6uCG+g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@russellthehippo/honker-node-darwin-arm64": {
-      "optional": true
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-darwin-arm64/-/honker-node-darwin-arm64-0.4.6.tgz",
+      "integrity": "sha512-l9ALQhs+ZMRcsrR8tSKqy85vFeHmzpKqJYXXK2pUlziHU5RMq3M0OkcciY9qXtBzkLdpSUnVGMIiarLrZ5WohA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@russellthehippo/honker-node-darwin-x64": {
-      "optional": true
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-darwin-x64/-/honker-node-darwin-x64-0.4.6.tgz",
+      "integrity": "sha512-rznG+u1XSBkc12F+BOpfTbj8soS5Dk3HJkuSvSj1WS9lF75YV+VWHKOLXAsqTA0xHEskTwC4mK0y8h0Yu4sXCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@russellthehippo/honker-node-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-linux-arm64-gnu/-/honker-node-linux-arm64-gnu-0.4.6.tgz",
+      "integrity": "sha512-oPHRQGB0jQjuPv3tyU4gExF+jXfkikB5+f54xKAC1nsIo4/2+lOWk6ZppSKsUxil1lrNFv4wO3vlG+C0qk2dvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@russellthehippo/honker-node-linux-x64-gnu": {
-      "optional": true
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-linux-x64-gnu/-/honker-node-linux-x64-gnu-0.4.6.tgz",
+      "integrity": "sha512-2gRx171U1J3b0xylDVxgxDj3OOg0hv2VKQE7vXyEfpPVsIklkAcoIm2mjnotYt8CYW7PB3EjNKsmOIjxKOP2pw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",

--- a/packages/honker-rs/Cargo.lock
+++ b/packages/honker-rs/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "honker"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "honker-core",
  "parking_lot",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "honker-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "file-id",

--- a/packages/honker-rs/Cargo.toml
+++ b/packages/honker-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honker"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "SQLite-native task runtime: durable queues, streams, pub/sub, and scheduler. Ergonomic Rust wrapper over honker-core."
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ shm-fast-path = ["honker-core/shm-fast-path"]
 # `path` resolves when this repo is a submodule inside the main
 # honker repo; `version` is what Cargo uses when honker-rs is
 # consumed from crates.io.
-honker-core = { path = "../../honker-core", version = "0.4.0" }
+honker-core = { path = "../../honker-core", version = "0.5.0" }
 rusqlite = { version = "0.40.1", features = ["functions"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -31,7 +31,7 @@ thiserror = "2"
 parking_lot = "0.12"
 
 [target.'cfg(windows)'.dependencies]
-honker-core = { path = "../../honker-core", version = "0.4.0", features = ["bundled-sqlite"] }
+honker-core = { path = "../../honker-core", version = "0.5.0", features = ["bundled-sqlite"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/packages/honker-ruby/lib/honker/version.rb
+++ b/packages/honker-ruby/lib/honker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Honker
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/packages/honker/Cargo.toml
+++ b/packages/honker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honker-py"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "PyO3 bindings for honker — the Rust cdylib behind the `honker` PyPI package. Not published to crates.io; built by maturin."
 license = "MIT OR Apache-2.0"
@@ -27,10 +27,10 @@ kernel-watcher = ["honker-core/kernel-watcher"]
 shm-fast-path = ["honker-core/shm-fast-path"]
 
 [dependencies]
-honker-core = { path = "../../honker-core", version = "0.4.0" }
+honker-core = { path = "../../honker-core", version = "0.5.0" }
 parking_lot = "0.12.5"
 pyo3 = { version = "0.28.3", features = ["extension-module", "abi3-py311"] }
 rusqlite = { version = "0.40.1", features = ["functions", "hooks"] }
 
 [target.'cfg(windows)'.dependencies]
-honker-core = { path = "../../honker-core", version = "0.4.0", features = ["bundled-sqlite"] }
+honker-core = { path = "../../honker-core", version = "0.5.0", features = ["bundled-sqlite"] }

--- a/packages/honker/pyproject.toml
+++ b/packages/honker/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "honker"
-version = "0.4.0"
+version = "0.5.0"
 description = "Durable queues, streams, pub/sub, and cron scheduler on SQLite. One file, zero servers."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/proof/orm/jvm/pom.xml
+++ b/scripts/proof/orm/jvm/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <honker.version>0.4.0</honker.version>
+    <honker.version>0.5.0</honker.version>
     <sqlite-jdbc.version>3.53.2.1</sqlite-jdbc.version>
     <hibernate.version>6.6.4.Final</hibernate.version>
     <jooq.version>3.19.18</jooq.version>


### PR DESCRIPTION
Every registry carries **0.4.0 from 2026-07-09**. Since then the repo's 0.4.0 has changed and is not installable anywhere.

## What is stranded at 0.4.0

| | |
|---|---|
| #96 | POSIX locks preserved in watcher backends |
| #102 | WAL conversion race — retry instead of failing the open |
| #101 | Whole REAL arguments accepted for integer SQL params |
| #100 | `extension_path()` (Python, Ruby, Elixir), `HonkerExtension.Locate()` (.NET) |

A registry will not let you republish over an existing version, so shipping any of it needs a new number.

## Why minor

Nothing was removed or resignatured — verified by diffing the public surface of every binding against the commit the 0.4.0 release was cut from. So not a major.

Not a patch either: #100 added public API to four bindings, and that API is the whole fix for russellromney/honker#99. A patch bump tells users there is nothing new to find, which is the opposite of what this release is for.

The one wart is that node and bun already shipped this same work as 0.4.6 / 0.4.2. Those were mis-numbered; matching the mistake isn't worth it.

## Scope

Crates (`honker-core`, `honker-extension`, `honker`), the Python / Ruby / Elixir / .NET packages, the JVM and Kotlin poms, and the lockfiles. `packages/honker`'s lock was stale at `honker-core` 0.2.4.

Publishing is manual for every language — none of the `release-*` workflows contain a publish step; they build and prove, then upload artifacts. This PR only moves the numbers.