### PR TITLE
Fix the source gem's vendored workspace lints

### DIFF
--- a/scripts/copy-ruby-sources.sh
+++ b/scripts/copy-ruby-sources.sh
@@ -18,6 +18,21 @@ done
 # Make the vendored extension crate its own workspace root so cargo does
 # not attach it to an enclosing Cargo.toml when the gem is built from
 # inside this repo.
+# Both crates inherit `[lints] workspace = true` from the repo root.
+# Inside the gem there is no such root: the line below makes the
+# vendored honker-extension its own workspace, and an empty
+# `[workspace]` defines no `workspace.lints` to inherit. Cargo then
+# refuses to parse the manifest and the gem fails to build on install.
+# Drop the inheritance instead of duplicating the root's clippy config
+# here, which would silently drift from it. Lints are a dev-time
+# concern; someone compiling the gem does not need ours.
+for crate in honker-extension honker-core; do
+  manifest="$DEST/$crate/Cargo.toml"
+  grep -q '^\[lints\]$' "$manifest" || { echo "no [lints] in $crate; the vendoring fix is stale" >&2; exit 1; }
+  sed -i.bak '/^\[lints\]$/,/^workspace = true$/d' "$manifest"
+  rm -f "$manifest.bak"
+done
+
 printf '\n[workspace]\n' >> "$DEST/honker-extension/Cargo.toml"
 
 echo "vendored honker-extension and honker-core into $DEST"


### PR DESCRIPTION
Blocks the Ruby 0.5.0 release. Found by dispatching `release-ruby.yml` before publishing anything.

## The failure

```
ERROR: Failed to build gem native extension.
error: failed to parse manifest at .../honker-0.5.0/ext/honker/honker-extension/Cargo.toml
  error inheriting `lints` from workspace root manifest's `workspace.lints`
```

`scripts/copy-ruby-sources.sh` vendors `honker-extension` and `honker-core` into the gem and appends `[workspace]` to the vendored extension so it stands alone. But both crates carry `[lints] workspace = true`, and that appended table defines no `workspace.lints` to inherit.

The source gem compiles its native extension **on install**, so this isn't cosmetic — `gem install honker` fails for anyone not landing on a prebuilt platform gem.

## The fix

Strip the inheritance during vendoring. The alternative — copying the root's clippy config into the script — drifts from the root silently the first time someone edits `[workspace.lints]`. Lints are a dev-time concern and the person compiling the gem doesn't need ours.

The script now aborts if `[lints]` ever stops being present, so the fix can't quietly become a no-op.

## Verified

Reproduced locally: with `[lints] workspace = true` restored, `cargo metadata` fails with the identical error; with the fix, the manifest parses standalone.

## Not released broken

`[lints]` came in with #78's lint gate, which landed **after** 0.4.0 was published on 2026-07-09. So no published gem has this — 0.5.0 would have been the first.