### PR TITLE
test: prove documented ORM SQL surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,7 +435,7 @@ jobs:
 
   binding-smoke:
     name: binding smoke · ubuntu aggregate
-    timeout-minutes: 12
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # ORM guide snippets are generated from the proof programs below.
+          # Initialize the docs submodule so sync_docs.py can prove the code
+          # shown to users is byte-for-byte the code this job executes.
+          submodules: true
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -539,8 +544,10 @@ jobs:
       # notify, scheduler, lock, rate limit, result) plus an ORM-owned
       # transaction that commits and rolls back a business write with
       # honker_enqueue.
-      - name: ORM surface catalog is complete
-        run: python3 scripts/proof/orm/check_surface.py
+      - name: ORM docs execute the exact checked-in examples
+        run: |
+          python3 scripts/proof/orm/sync_docs.py --check
+          python3 scripts/proof/orm/check_surface.py
       - name: ORM · Go (database/sql, GORM)
         env:
           HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,7 @@ jobs:
           # uv venv does not ship pip, so install the way the rest of
           # this job does.
           uv pip install --python "$VENV_PY" --quiet sqlalchemy sqlmodel django
+          python scripts/proof/orm/check_surface.py
 
           # These recipes need an interpreter whose sqlite3 was built
           # with SQLITE_ENABLE_LOAD_EXTENSION. The python.org macOS
@@ -271,7 +272,7 @@ jobs:
           fi
 
           failed=0
-          for scenario in scripts/proof/orm/python/*.py; do
+          for scenario in scripts/proof/orm/python/*_orm.py; do
             name="$(basename "$scenario" .py)"
             rm -f "$RUNNER_TEMP/orm-$name.db"
             if HONKER_TEST_DB="$RUNNER_TEMP/orm-$name.db" python "$scenario"; then
@@ -532,17 +533,22 @@ jobs:
           mix deps.get
           mix test
       # ---- Documented ORM recipes -------------------------------------
-      # One scenario per integration named in guides/orm/*.mdx, written
-      # the way the page shows it. These fail when a documented recipe
-      # stops working, which is the point: the docs promise these, so CI
-      # has to hold them to it.
+      # One scenario per integration named in guides/orm/*.mdx. Each one
+      # loads the extension the way the page shows, then runs the shared
+      # SQL surface in scripts/proof/orm/surface.json (queue, stream,
+      # notify, scheduler, lock, rate limit, result) plus an ORM-owned
+      # transaction that commits and rolls back a business write with
+      # honker_enqueue.
+      - name: ORM surface catalog is complete
+        run: python3 scripts/proof/orm/check_surface.py
       - name: ORM · Go (database/sql, GORM)
         env:
           HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+          HONKER_ORM_SURFACE: ${{ github.workspace }}/scripts/proof/orm/surface.json
         run: |
           work="$RUNNER_TEMP/orm-go"
           mkdir -p "$work"
-          cp scripts/proof/orm/go/main.go "$work/"
+          cp scripts/proof/orm/go/main.go scripts/proof/orm/surface.json "$work/"
           cd "$work"
           cat > go.mod <<'GOMOD'
           module honkerormproof
@@ -551,7 +557,7 @@ jobs:
           GOMOD
           go mod edit -replace github.com/russellromney/honker-go="$GITHUB_WORKSPACE/packages/honker-go"
           go mod tidy
-          HONKER_TEST_DB="$work/orm.db" go run .
+          HONKER_TEST_DB="$work/orm.db" HONKER_ORM_SURFACE="$work/surface.json" go run .
 
       - name: ORM · Rust (sqlx)
         env:
@@ -559,18 +565,33 @@ jobs:
         run: |
           HONKER_TEST_DB="$RUNNER_TEMP/orm-sqlx.db" \
             cargo run --release --manifest-path scripts/proof/orm/rust/Cargo.toml
+      - name: ORM · Rust (SeaORM)
+        env:
+          HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+        run: |
+          HONKER_TEST_DB="$RUNNER_TEMP/orm-seaorm.db" \
+            cargo run --release --manifest-path scripts/proof/orm/rust/seaorm/Cargo.toml
+      - name: ORM · Rust (Diesel)
+        env:
+          HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+        run: |
+          HONKER_TEST_DB="$RUNNER_TEMP/orm-diesel.db" \
+            cargo run --release --manifest-path scripts/proof/orm/rust/diesel/Cargo.toml
 
       - name: ORM · .NET (Microsoft.Data.Sqlite)
         env:
           HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+          HONKER_ORM_SURFACE: ${{ github.workspace }}/scripts/proof/orm/surface.json
         run: |
           HONKER_TEST_DB="$RUNNER_TEMP/orm-dotnet.db" \
+            HONKER_ORM_SURFACE="$GITHUB_WORKSPACE/scripts/proof/orm/surface.json" \
             dotnet run --project scripts/proof/orm/dotnet/OrmProof.csproj
 
       - name: ORM · Elixir (Ecto)
         working-directory: packages/honker-ex
         env:
           HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+          HONKER_ORM_SURFACE: ${{ github.workspace }}/scripts/proof/orm/surface.json
         run: |
           mix compile
           HONKER_TEST_DB="$RUNNER_TEMP/orm-ecto.db" \
@@ -580,6 +601,7 @@ jobs:
       - name: ORM · C++ (framework-owned sqlite3)
         env:
           HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+          HONKER_ORM_SURFACE: ${{ github.workspace }}/scripts/proof/orm/surface.json
         run: |
           g++ -std=c++17 scripts/proof/orm/cpp/orm_proof.cpp -lsqlite3 \
             -o "$RUNNER_TEMP/orm-cpp"
@@ -589,6 +611,7 @@ jobs:
         working-directory: packages/honker-ruby
         env:
           HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+          HONKER_ORM_SURFACE: ${{ github.workspace }}/scripts/proof/orm/surface.json
         run: |
           export BUNDLE_GEMFILE="$GITHUB_WORKSPACE/scripts/proof/orm/ruby/Gemfile"
           bundle install
@@ -647,6 +670,7 @@ jobs:
         working-directory: scripts/proof/orm/jvm
         env:
           HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+          HONKER_ORM_SURFACE: ${{ github.workspace }}/scripts/proof/orm/surface.json
         run: |
           HONKER_TEST_DB="$RUNNER_TEMP/orm-jvm.db" \
             mvn -B -q compile exec:java -Dexec.mainClass=dev.honker.ormproof.OrmProof
@@ -654,6 +678,7 @@ jobs:
         working-directory: scripts/proof/orm/jvm
         env:
           HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+          HONKER_ORM_SURFACE: ${{ github.workspace }}/scripts/proof/orm/surface.json
         run: |
           HONKER_TEST_DB="$RUNNER_TEMP/orm-kotlin.db" \
             mvn -B -q compile exec:java -Dexec.mainClass=dev.honker.ormproof.ExposedProof

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ packages/honker-node/libhonker_ext.*
 # Standalone ORM proof project build output
 scripts/proof/orm/rust/target/
 scripts/proof/orm/rust/Cargo.lock
+scripts/proof/orm/rust/diesel/target/
+scripts/proof/orm/rust/diesel/Cargo.lock
+scripts/proof/orm/rust/seaorm/target/
+scripts/proof/orm/rust/seaorm/Cargo.lock
 scripts/proof/orm/dotnet/bin/
 scripts/proof/orm/dotnet/obj/
 scripts/proof/orm/jvm/target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,13 +36,18 @@ users reach for the extension.
   always `sqlite3_honkerext_init`; the accessor never loads native code.
 
 Proof: `scripts/proof/node-orm-extension.sh` installs the packed
-tarballs into a clean project with `better-sqlite3` and round-trips
-enqueue → claim → ack through raw SQL, with every numeric argument
-bound rather than written as a literal. Both `ci.yml` and
-`release-node.yml` call it, so PRs run the same check that gates a
-release. It reads nothing from `target/release` and has no skip path,
-unlike `tests/test_extension_interop.py`, which skips when the build
-tree is empty and is how this shipped broken.
+tarballs into a clean project with `better-sqlite3` and runs the
+shared ORM SQL surface (queue, stream, notify, scheduler, lock, rate
+limit, result) plus an ORM-owned commit/rollback of a business write
+with `honker_enqueue`. Every numeric argument is bound rather than
+written as a literal. Both `ci.yml` and `release-node.yml` call it,
+so PRs run the same check that gates a release. It reads nothing from
+`target/release` and has no skip path, unlike
+`tests/test_extension_interop.py`, which skips when the build tree is
+empty and is how this shipped broken. The same surface catalog drives
+every other documented ORM recipe in CI, including the Rust sqlx, SeaORM,
+and Diesel recipes. Toasty is documented as unable to load SQLite
+extensions today, so it has no recipe and no CI proof.
 
 Publish order, which the `optionalDependencies` pins require: the four
 `honker-ext-*` packages first, then `honker-node@0.4.6` and

--- a/packages/honker-dotnet/src/Honker/Database.cs
+++ b/packages/honker-dotnet/src/Honker/Database.cs
@@ -6,7 +6,11 @@ namespace Honker;
 
 public sealed class Database : IDisposable
 {
+    // _gate protects individual uses of the shared connection. A transaction
+    // needs the stronger gate for its whole lifetime so an unrelated worker
+    // command cannot run on the connection between Begin and Commit/Rollback.
     private readonly object _gate = new();
+    private readonly SemaphoreSlim _transactionGate = new(1, 1);
     private readonly SqliteConnection _connection;
     private readonly Dictionary<(string Name, QueueOptions Options), Queue> _queues = new();
     private readonly Dictionary<string, Stream> _streams = new(StringComparer.Ordinal);
@@ -137,9 +141,18 @@ public sealed class Database : IDisposable
 
     public HonkerTransaction BeginTransaction()
     {
-        lock (_gate)
+        _transactionGate.Wait();
+        try
         {
-            return new HonkerTransaction(this, _connection.BeginTransaction(deferred: false));
+            lock (_gate)
+            {
+                return new HonkerTransaction(this, _connection.BeginTransaction(deferred: false));
+            }
+        }
+        catch
+        {
+            _transactionGate.Release();
+            throw;
         }
     }
 
@@ -189,11 +202,11 @@ public sealed class Database : IDisposable
         }
 
         var sql = $"DELETE FROM _honker_notifications WHERE {string.Join(" OR ", clauses)}";
-        lock (_gate)
+        return WithConnection(null, () =>
         {
             using var command = SqliteHelpers.CreateCommand(_connection, null, sql, args);
             return command.ExecuteNonQuery();
-        }
+        });
     }
 
     public bool TryRateLimit(string name, int limit, int perSeconds)
@@ -269,16 +282,16 @@ public sealed class Database : IDisposable
 
     internal object? ExecuteScalar(string sql, HonkerTransaction? transaction, params object?[] args)
     {
-        lock (_gate)
+        return WithConnection(transaction, () =>
         {
             using var command = SqliteHelpers.CreateCommand(_connection, transaction?.Inner, sql, args);
             return command.ExecuteScalar();
-        }
+        });
     }
 
     internal IReadOnlyList<IReadOnlyDictionary<string, object?>> QueryInternal(string sql, HonkerTransaction? transaction, params object?[] args)
     {
-        lock (_gate)
+        return WithConnection(transaction, () =>
         {
             using var command = SqliteHelpers.CreateCommand(_connection, transaction?.Inner, sql, args);
             using var reader = command.ExecuteReader();
@@ -296,16 +309,16 @@ public sealed class Database : IDisposable
             }
 
             return rows;
-        }
+        });
     }
 
     internal void ExecuteNonQuery(string sql, HonkerTransaction? transaction, params object?[] args)
     {
-        lock (_gate)
+        WithConnection(transaction, () =>
         {
             using var command = SqliteHelpers.CreateCommand(_connection, transaction?.Inner, sql, args);
             command.ExecuteNonQuery();
-        }
+        });
     }
 
     internal void WithLock(Action action)
@@ -314,6 +327,44 @@ public sealed class Database : IDisposable
         {
             action();
         }
+    }
+
+    internal void EndTransaction()
+    {
+        _transactionGate.Release();
+    }
+
+    private T WithConnection<T>(HonkerTransaction? transaction, Func<T> action)
+    {
+        if (transaction is not null)
+        {
+            lock (_gate)
+            {
+                return action();
+            }
+        }
+
+        _transactionGate.Wait();
+        try
+        {
+            lock (_gate)
+            {
+                return action();
+            }
+        }
+        finally
+        {
+            _transactionGate.Release();
+        }
+    }
+
+    private void WithConnection(HonkerTransaction? transaction, Action action)
+    {
+        WithConnection(transaction, () =>
+        {
+            action();
+            return true;
+        });
     }
 
     public void Dispose()

--- a/packages/honker-dotnet/src/Honker/Database.cs
+++ b/packages/honker-dotnet/src/Honker/Database.cs
@@ -11,6 +11,10 @@ public sealed class Database : IDisposable
     // command cannot run on the connection between Begin and Commit/Rollback.
     private readonly object _gate = new();
     private readonly SemaphoreSlim _transactionGate = new(1, 1);
+    // Managed thread id of the thread holding an open transaction, 0 when
+    // none. Read before waiting on _transactionGate so a command issued from
+    // that same thread fails instead of blocking on a gate only it can free.
+    private int _transactionOwner;
     private readonly SqliteConnection _connection;
     private readonly Dictionary<(string Name, QueueOptions Options), Queue> _queues = new();
     private readonly Dictionary<string, Stream> _streams = new(StringComparer.Ordinal);
@@ -142,6 +146,7 @@ public sealed class Database : IDisposable
     public HonkerTransaction BeginTransaction()
     {
         _transactionGate.Wait();
+        Volatile.Write(ref _transactionOwner, Environment.CurrentManagedThreadId);
         try
         {
             lock (_gate)
@@ -151,6 +156,7 @@ public sealed class Database : IDisposable
         }
         catch
         {
+            Volatile.Write(ref _transactionOwner, 0);
             _transactionGate.Release();
             throw;
         }
@@ -331,6 +337,7 @@ public sealed class Database : IDisposable
 
     internal void EndTransaction()
     {
+        Volatile.Write(ref _transactionOwner, 0);
         _transactionGate.Release();
     }
 
@@ -342,6 +349,17 @@ public sealed class Database : IDisposable
             {
                 return action();
             }
+        }
+
+        if (Volatile.Read(ref _transactionOwner) == Environment.CurrentManagedThreadId)
+        {
+            // Only this thread can release the gate, and it is here rather than
+            // at Commit/Rollback, so waiting would never return. Before the
+            // gate existed ADO.NET raised on this; keep it loud.
+            throw new InvalidOperationException(
+                "A Honker transaction is open on this thread. Pass it to the call " +
+                "(for example enqueue(..., transaction: tx)) instead of running " +
+                "outside it; waiting for the transaction to end would deadlock.");
         }
 
         _transactionGate.Wait();

--- a/packages/honker-dotnet/src/Honker/HonkerTransaction.cs
+++ b/packages/honker-dotnet/src/Honker/HonkerTransaction.cs
@@ -7,6 +7,7 @@ public sealed class HonkerTransaction : IDisposable
 {
     private readonly Database _database;
     private bool _completed;
+    private bool _gateReleased;
 
     internal HonkerTransaction(Database database, SqliteTransaction inner)
     {
@@ -44,6 +45,7 @@ public sealed class HonkerTransaction : IDisposable
             Inner.Commit();
             _completed = true;
         });
+        ReleaseGate();
     }
 
     public void Rollback()
@@ -53,18 +55,38 @@ public sealed class HonkerTransaction : IDisposable
             Inner.Rollback();
             _completed = true;
         });
+        ReleaseGate();
     }
 
     public void Dispose()
     {
-        _database.WithLock(() =>
+        try
         {
-            if (!_completed)
+            _database.WithLock(() =>
             {
-                Inner.Rollback();
-            }
+                if (!_completed)
+                {
+                    Inner.Rollback();
+                    _completed = true;
+                }
 
-            Inner.Dispose();
-        });
+                Inner.Dispose();
+            });
+        }
+        finally
+        {
+            ReleaseGate();
+        }
+    }
+
+    private void ReleaseGate()
+    {
+        if (_gateReleased)
+        {
+            return;
+        }
+
+        _gateReleased = true;
+        _database.EndTransaction();
     }
 }

--- a/packages/honker-dotnet/tests/Honker.Tests/OutboxLockTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/OutboxLockTests.cs
@@ -76,8 +76,7 @@ public sealed class OutboxLockTests
         }
         finally
         {
-            cts.Cancel();
-            await Task.WhenAll(worker.ContinueWith(_ => Task.CompletedTask));
+            await StopWorkerAsync(worker, cts);
         }
 
         Assert.Equal(["1", "2"], delivered);
@@ -121,12 +120,32 @@ public sealed class OutboxLockTests
         }
         finally
         {
-            cts.Cancel();
-            await Task.WhenAll(worker.ContinueWith(_ => Task.CompletedTask));
+            await StopWorkerAsync(worker, cts);
         }
 
         Assert.True(Volatile.Read(ref calls) >= 3);
         Assert.Equal(0, Scalar(db, "SELECT COUNT(*) AS c FROM _honker_jobs WHERE queue=@p0", "_outbox:retry"));
+    }
+
+    [Fact]
+    public async Task DatabaseSerializesCommandsForTransactionLifetime()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        using var tx = db.BeginTransaction();
+        using var started = new ManualResetEventSlim();
+
+        var concurrent = Task.Run(() =>
+        {
+            started.Set();
+            return Scalar(db, "SELECT 1");
+        });
+        started.Wait();
+        await Task.Delay(50);
+        Assert.False(concurrent.IsCompleted, "a command escaped the active transaction lifetime");
+
+        tx.Commit();
+        Assert.Equal(1, await concurrent.WaitAsync(TimeSpan.FromSeconds(2)));
     }
 
     [Fact]
@@ -182,8 +201,7 @@ public sealed class OutboxLockTests
         }
         finally
         {
-            cts.Cancel();
-            await Task.WhenAll(worker.ContinueWith(_ => Task.CompletedTask));
+            await StopWorkerAsync(worker, cts);
         }
 
         Assert.Equal([1], delivered);
@@ -240,8 +258,7 @@ public sealed class OutboxLockTests
         }
         finally
         {
-            cts.Cancel();
-            await Task.WhenAll(worker.ContinueWith(_ => Task.CompletedTask));
+            await StopWorkerAsync(worker, cts);
         }
 
         var row = db.Query("SELECT state, attempts, last_error FROM _honker_jobs WHERE queue=@p0", "_outbox:dead")[0];
@@ -272,8 +289,7 @@ public sealed class OutboxLockTests
         }
         finally
         {
-            cts.Cancel();
-            await Task.WhenAll(worker.ContinueWith(_ => Task.CompletedTask));
+            await StopWorkerAsync(worker, cts);
         }
 
         Assert.Equal([1], delivered);
@@ -305,6 +321,19 @@ public sealed class OutboxLockTests
     {
         var rows = db.Query(sql, args);
         return Convert.ToInt64(rows[0].Values.First() ?? 0L);
+    }
+
+    private static async Task StopWorkerAsync(Task worker, CancellationTokenSource cts)
+    {
+        cts.Cancel();
+        try
+        {
+            await worker;
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            // Expected while stopping an idle worker.
+        }
     }
 
     private static async Task WaitUntilAsync(

--- a/packages/honker-dotnet/tests/Honker.Tests/OutboxLockTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/OutboxLockTests.cs
@@ -128,6 +128,37 @@ public sealed class OutboxLockTests
     }
 
     [Fact]
+    public void CommandOutsideAnOpenTransactionOnTheSameThreadRaises()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        var q = db.Queue("emails");
+
+        // The transaction gate is held for the transaction's lifetime and only
+        // this thread can release it, so a command that forgets to pass the
+        // transaction would wait on itself forever. It has to raise instead.
+        // Whole scenario runs on one background thread so the test thread can
+        // fail on a timeout rather than hanging the suite.
+        var attempt = Task.Run(() =>
+        {
+            using var tx = db.BeginTransaction();
+            try
+            {
+                q.Enqueue(new { a = 1 });   // no transaction argument
+                return null;
+            }
+            catch (InvalidOperationException ex)
+            {
+                return ex.Message;
+            }
+        });
+
+        Assert.True(attempt.Wait(TimeSpan.FromSeconds(5)),
+            "deadlocked: the command waited on a gate only its own thread could release");
+        Assert.Contains("transaction is open on this thread", attempt.Result);
+    }
+
+    [Fact]
     public async Task DatabaseSerializesCommandsForTransactionLifetime()
     {
         using var harness = TestHarness.Create();

--- a/scripts/proof/node-orm-extension.sh
+++ b/scripts/proof/node-orm-extension.sh
@@ -3,9 +3,10 @@
 # *packaged* Honker extension.
 #
 # Packs honker-node and its honker-ext-<platform> package, installs both
-# into a clean project alongside better-sqlite3, and round-trips
-# enqueue -> claim -> ack through raw SQL. Nothing here reads
-# target/release, and there is no skip path: a missing extension fails.
+# into a clean project alongside better-sqlite3/Drizzle/Kysely, and runs
+# the shared ORM SQL surface plus an ORM-owned commit/rollback. Nothing
+# here reads target/release, and there is no skip path: a missing
+# extension fails.
 #
 # Shared by ci.yml (every PR) and release-node.yml (tags) so the proof
 # that gates a release is the same one PRs run.
@@ -57,15 +58,16 @@ npm install --no-audit --no-fund --no-save "$root_tgz" "$ext_tgz" >/dev/null
 # imports from the importing file's own directory, so running them from
 # the repo would not see the packages installed here — and a user's
 # scenario file lives in their project anyway.
-cp "$ROOT"/scripts/proof/orm/js/*.mjs "$app/"
+cp "$ROOT"/scripts/proof/orm/js/*.mjs "$ROOT"/scripts/proof/orm/surface.json "$app/"
 
 failed=0
-for scenario in "$app"/*.mjs; do
-  name="$(basename "$scenario" .mjs)"
-  if HONKER_PLATFORM="$PLATFORM" node "$scenario"; then
+for scenario in better-sqlite3 drizzle kysely; do
+  rm -f "$app/$scenario.db"
+  if HONKER_PLATFORM="$PLATFORM" HONKER_TEST_DB="$app/$scenario.db" \
+    HONKER_ORM_SURFACE="$app/surface.json" node "$app/$scenario.mjs"; then
     :
   else
-    echo "FAIL $name" >&2
+    echo "FAIL $scenario" >&2
     failed=1
   fi
 done

--- a/scripts/proof/orm/check_surface.py
+++ b/scripts/proof/orm/check_surface.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Fail if an ORM proof drops a documented SQL function or atomicity."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[2]
+CATALOG = HERE / "surface.json"
+
+JSON_RUNNERS = [
+    ROOT / "scripts/proof/orm/python/surface.py",
+    ROOT / "scripts/proof/orm/js/surface.mjs",
+    ROOT / "scripts/proof/orm/go/main.go",
+    ROOT / "scripts/proof/orm/rust/catalog.rs",
+    ROOT / "scripts/proof/orm/rust/src/main.rs",
+    ROOT / "scripts/proof/orm/rust/diesel/src/main.rs",
+    ROOT / "scripts/proof/orm/rust/seaorm/src/main.rs",
+    ROOT / "scripts/proof/orm/dotnet/Program.cs",
+    ROOT / "scripts/proof/orm/elixir/ecto_proof.exs",
+    ROOT / "scripts/proof/orm/ruby/active_record_proof.rb",
+    ROOT / "scripts/proof/orm/jvm/src/main/java/dev/honker/ormproof/Surface.java",
+    ROOT / "scripts/proof/orm/cpp/orm_proof.cpp",
+]
+
+ATOMICITY_FILES = [
+    ROOT / "scripts/proof/orm/python/sqlalchemy_orm.py",
+    ROOT / "scripts/proof/orm/python/sqlmodel_orm.py",
+    ROOT / "scripts/proof/orm/python/django_orm.py",
+    ROOT / "scripts/proof/orm/js/better-sqlite3.mjs",
+    ROOT / "scripts/proof/orm/js/drizzle.mjs",
+    ROOT / "scripts/proof/orm/js/kysely.mjs",
+    ROOT / "scripts/proof/orm/go/main.go",
+    ROOT / "scripts/proof/orm/rust/src/main.rs",
+    ROOT / "scripts/proof/orm/rust/diesel/src/main.rs",
+    ROOT / "scripts/proof/orm/rust/seaorm/src/main.rs",
+    ROOT / "scripts/proof/orm/dotnet/Program.cs",
+    ROOT / "scripts/proof/orm/elixir/ecto_proof.exs",
+    ROOT / "scripts/proof/orm/ruby/active_record_proof.rb",
+    ROOT / "scripts/proof/orm/cpp/orm_proof.cpp",
+    ROOT / "scripts/proof/orm/jvm/src/main/java/dev/honker/ormproof/OrmProof.java",
+    ROOT / "scripts/proof/orm/jvm/src/main/kotlin/dev/honker/ormproof/ExposedProof.kt",
+]
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    catalog = json.loads(CATALOG.read_text())
+    required = catalog["functions"]
+    joined = "\n".join(step["sql"] for step in catalog["steps"])
+    missing_from_catalog = [name for name in required if name not in joined]
+    if missing_from_catalog:
+        fail(f"surface.json does not call {missing_from_catalog}")
+
+    extra = []
+    for step in catalog["steps"]:
+        for token in step["sql"].replace("(", " ").replace(")", " ").split():
+            if token.startswith("honker_") or token == "notify":
+                if token not in required and token != "honker_bootstrap":
+                    extra.append(token)
+    if extra:
+        fail(f"surface.json calls functions not listed: {sorted(set(extra))}")
+
+    for path in JSON_RUNNERS:
+        text = path.read_text()
+        if (
+            "surface.json" not in text
+            and "HONKER_ORM_SURFACE" not in text
+            and "catalog.rs" not in text
+        ):
+            fail(f"{path} does not load surface.json")
+
+    for path in ATOMICITY_FILES:
+        text = path.read_text()
+        if "orders" not in text:
+            fail(f"{path} does not create an orders table for atomicity")
+        lowered = text.lower()
+        if "rollback" not in lowered:
+            fail(f"{path} does not prove rollback")
+
+    print(f"PASS orm-surface ({len(required)} functions, {len(ATOMICITY_FILES)} atomicity proofs)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/proof/orm/cpp/orm_proof.cpp
+++ b/scripts/proof/orm/cpp/orm_proof.cpp
@@ -1,16 +1,184 @@
-// Framework-owned sqlite3, as guides/orm/cpp.mdx shows it: Honker as a
-// helper over a sqlite3* the surrounding data layer owns, with the
-// business write and the enqueue on the same transaction.
+// Framework-owned sqlite3, as guides/orm/cpp.mdx shows it.
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
 #include <sqlite3.h>
 #include <string>
+#include <unordered_map>
+#include <vector>
+
+using json = nlohmann::json;
 
 static void must(int rc, sqlite3* db, const char* what) {
     if (rc != SQLITE_OK && rc != SQLITE_ROW && rc != SQLITE_DONE) {
         std::fprintf(stderr, "%s: %s\n", what, db ? sqlite3_errmsg(db) : "(no db)");
         std::exit(1);
+    }
+}
+
+static std::string catalog_path() {
+    if (const char* env = std::getenv("HONKER_ORM_SURFACE")) {
+        return env;
+    }
+    if (std::ifstream("surface.json")) return "surface.json";
+    if (std::ifstream("scripts/proof/orm/surface.json")) return "scripts/proof/orm/surface.json";
+    std::fprintf(stderr, "surface.json not found; set HONKER_ORM_SURFACE\n");
+    std::exit(1);
+}
+
+static std::string as_text(const json& v) {
+    if (v.is_null()) return "";
+    if (v.is_string()) return v.get<std::string>();
+    if (v.is_number_integer()) return std::to_string(v.get<long long>());
+    return v.dump();
+}
+
+static long long as_int(const json& v) {
+    if (v.is_number_integer()) return v.get<long long>();
+    if (v.is_number_float()) return static_cast<long long>(v.get<double>());
+    if (v.is_string()) return std::stoll(v.get<std::string>());
+    std::fprintf(stderr, "expected int, got %s\n", v.dump().c_str());
+    std::exit(1);
+}
+
+static json resolve(const json& token, const std::string& prefix,
+                    const std::unordered_map<std::string, json>& vars) {
+    if (!token.is_string()) return token;
+    auto s = token.get<std::string>();
+    if (s.rfind("$ns:", 0) == 0) return prefix + "_" + s.substr(4);
+    if (s.rfind("$json:", 0) == 0) {
+        json ids = json::array();
+        std::string keys = s.substr(6);
+        size_t start = 0;
+        while (start <= keys.size()) {
+            auto comma = keys.find(',', start);
+            auto key = keys.substr(start, comma == std::string::npos ? std::string::npos : comma - start);
+            ids.push_back(as_int(vars.at(key)));
+            if (comma == std::string::npos) break;
+            start = comma + 1;
+        }
+        return ids.dump();
+    }
+    if (!s.empty() && s[0] == '$') return vars.at(s.substr(1));
+    return s;
+}
+
+static std::string resolve_text(std::string text, const std::string& prefix,
+                                const std::unordered_map<std::string, json>& vars) {
+    for (const auto& [k, v] : vars) {
+        auto needle = "$" + k;
+        size_t pos = 0;
+        auto repl = as_text(v);
+        while ((pos = text.find(needle, pos)) != std::string::npos) {
+            text.replace(pos, needle.size(), repl);
+            pos += repl.size();
+        }
+    }
+    auto ns = std::string("$ns:");
+    size_t pos = 0;
+    auto repl = prefix + "_";
+    while ((pos = text.find(ns, pos)) != std::string::npos) {
+        text.replace(pos, ns.size(), repl);
+        pos += repl.size();
+    }
+    return text;
+}
+
+static json scalar(sqlite3* db, const std::string& sql, const std::vector<json>& args) {
+    sqlite3_stmt* stmt = nullptr;
+    must(sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr), db, sql.c_str());
+    for (int i = 0; i < static_cast<int>(args.size()); i++) {
+        const auto& a = args[i];
+        if (a.is_null()) {
+            sqlite3_bind_null(stmt, i + 1);
+        } else if (a.is_number_integer()) {
+            sqlite3_bind_int64(stmt, i + 1, a.get<long long>());
+        } else if (a.is_string()) {
+            auto s = a.get<std::string>();
+            sqlite3_bind_text(stmt, i + 1, s.c_str(), -1, SQLITE_TRANSIENT);
+        } else {
+            std::fprintf(stderr, "cannot bind %s\n", a.dump().c_str());
+            std::exit(1);
+        }
+    }
+    int rc = sqlite3_step(stmt);
+    json out = nullptr;
+    if (rc == SQLITE_ROW) {
+        switch (sqlite3_column_type(stmt, 0)) {
+            case SQLITE_INTEGER:
+                out = sqlite3_column_int64(stmt, 0);
+                break;
+            case SQLITE_FLOAT:
+                out = static_cast<long long>(sqlite3_column_double(stmt, 0));
+                break;
+            case SQLITE_NULL:
+                out = nullptr;
+                break;
+            default: {
+                const unsigned char* t = sqlite3_column_text(stmt, 0);
+                out = t ? reinterpret_cast<const char*>(t) : "";
+                break;
+            }
+        }
+    } else if (rc != SQLITE_DONE) {
+        std::fprintf(stderr, "step: %s\n", sqlite3_errmsg(db));
+        std::exit(1);
+    }
+    sqlite3_finalize(stmt);
+    return out;
+}
+
+static void check(const json& expect, const json& result, const std::string& prefix,
+                  const std::unordered_map<std::string, json>& vars) {
+    auto kind = expect.at("kind").get<std::string>();
+    if (kind == "int_gt") {
+        if (!(as_int(result) > expect.at("n").get<long long>())) {
+            throw std::runtime_error("got " + result.dump());
+        }
+    } else if (kind == "int_eq") {
+        if (as_int(result) != expect.at("n").get<long long>()) {
+            throw std::runtime_error("got " + result.dump());
+        }
+    } else if (kind == "int_ge") {
+        if (as_int(result) < expect.at("n").get<long long>()) {
+            throw std::runtime_error("got " + result.dump());
+        }
+    } else if (kind == "int_gt_ref") {
+        if (!(as_int(result) > as_int(vars.at(expect.at("ref").get<std::string>())))) {
+            throw std::runtime_error("got " + result.dump());
+        }
+    } else if (kind == "eq_ref") {
+        if (as_int(result) != as_int(vars.at(expect.at("ref").get<std::string>()))) {
+            throw std::runtime_error("got " + result.dump());
+        }
+    } else if (kind == "json_len") {
+        auto parsed = json::parse(as_text(result));
+        if (static_cast<int>(parsed.size()) != expect.at("n").get<int>()) {
+            throw std::runtime_error("got " + result.dump());
+        }
+    } else if (kind == "json_id_eq_ref") {
+        auto parsed = json::parse(as_text(result));
+        auto refn = as_int(vars.at(expect.at("ref").get<std::string>()));
+        if (parsed.size() != 1 || as_int(parsed[0].at("id")) != refn) {
+            throw std::runtime_error("got " + result.dump());
+        }
+    } else if (kind == "contains") {
+        auto needle = resolve_text(expect.at("s").get<std::string>(), prefix, vars);
+        if (as_text(result).find(needle) == std::string::npos) {
+            throw std::runtime_error(needle + " not in " + result.dump());
+        }
+    } else if (kind == "empty_string") {
+        if (as_text(result) != "") {
+            throw std::runtime_error("expected empty string, got " + result.dump());
+        }
+    } else if (kind == "is_null") {
+        if (!result.is_null()) {
+            throw std::runtime_error("expected NULL, got " + result.dump());
+        }
+    } else {
+        throw std::runtime_error("unknown expect kind " + kind);
     }
 }
 
@@ -26,65 +194,107 @@ int main() {
     must(sqlite3_open(db_path, &db), db, "open");
     must(sqlite3_enable_load_extension(db, 1), db, "enable_load_extension");
     char* err = nullptr;
-    // No entry point argument: filename derivation is part of the
-    // contract the docs rely on.
     if (sqlite3_load_extension(db, ext, nullptr, &err) != SQLITE_OK) {
         std::fprintf(stderr, "load_extension: %s\n", err ? err : "(unknown)");
         return 1;
     }
     must(sqlite3_exec(db, "SELECT honker_bootstrap()", nullptr, nullptr, nullptr), db, "bootstrap");
 
-    must(sqlite3_exec(db, "BEGIN IMMEDIATE", nullptr, nullptr, nullptr), db, "begin");
+    std::ifstream in(catalog_path());
+    json catalog = json::parse(in);
+    std::unordered_map<std::string, json> vars;
+    for (const auto& step : catalog.at("steps")) {
+        auto id = step.at("id").get<std::string>();
+        std::vector<json> args;
+        for (const auto& a : step.at("args")) {
+            args.push_back(resolve(a, "cp", vars));
+        }
+        json result;
+        try {
+            result = scalar(db, step.at("sql").get<std::string>(), args);
+        } catch (const std::exception& e) {
+            std::fprintf(stderr, "%s failed: %s\n", id.c_str(), e.what());
+            return 1;
+        }
+        if (step.contains("store")) {
+            vars[step.at("store").get<std::string>()] = result;
+        }
+        if (step.contains("expect")) {
+            try {
+                check(step.at("expect"), result, "cp", vars);
+            } catch (const std::exception& e) {
+                std::fprintf(stderr, "%s: %s\n", id.c_str(), e.what());
+                return 1;
+            }
+        }
+    }
 
+    must(sqlite3_exec(db, "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)",
+                      nullptr, nullptr, nullptr),
+         db, "create orders");
+    must(sqlite3_exec(db, "BEGIN IMMEDIATE", nullptr, nullptr, nullptr), db, "begin");
+    must(sqlite3_exec(db, "INSERT INTO orders (id, user_id) VALUES (42, 1)", nullptr, nullptr, nullptr),
+         db, "insert");
     sqlite3_stmt* stmt = nullptr;
-    // Bound parameters, so the C API's own binding is exercised.
-    must(sqlite3_prepare_v2(
-             db, "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)", -1, &stmt, nullptr),
-         db, "prepare enqueue");
-    sqlite3_bind_text(stmt, 1, "emails", -1, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 2, R"({"to":"alice@example.com"})", -1, SQLITE_TRANSIENT);
+    must(sqlite3_prepare_v2(db, "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)", -1, &stmt, nullptr),
+         db, "enqueue");
+    sqlite3_bind_text(stmt, 1, "cp_atomic", -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 2, R"({"order_id":42})", -1, SQLITE_TRANSIENT);
     sqlite3_bind_int64(stmt, 3, 0);
     sqlite3_bind_int64(stmt, 4, 3);
     if (sqlite3_step(stmt) != SQLITE_ROW) {
         std::fprintf(stderr, "enqueue: %s\n", sqlite3_errmsg(db));
         return 1;
     }
-    sqlite3_int64 id = sqlite3_column_int64(stmt, 0);
+    sqlite3_int64 committed = sqlite3_column_int64(stmt, 0);
     sqlite3_finalize(stmt);
-    if (id <= 0) {
-        std::fprintf(stderr, "expected a job id, got %lld\n", (long long)id);
-        return 1;
-    }
-
     must(sqlite3_exec(db, "COMMIT", nullptr, nullptr, nullptr), db, "commit");
 
-    must(sqlite3_prepare_v2(db, "SELECT honker_claim_batch(?, ?, ?, ?)", -1, &stmt, nullptr),
-         db, "prepare claim");
-    sqlite3_bind_text(stmt, 1, "emails", -1, SQLITE_TRANSIENT);
-    sqlite3_bind_text(stmt, 2, "w1", -1, SQLITE_TRANSIENT);
-    sqlite3_bind_int64(stmt, 3, 8);
-    sqlite3_bind_int64(stmt, 4, 300);
-    if (sqlite3_step(stmt) != SQLITE_ROW) {
-        std::fprintf(stderr, "claim: %s\n", sqlite3_errmsg(db));
-        return 1;
-    }
-    std::string claimed = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+    sqlite3_int64 n = 0;
+    must(sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM orders WHERE id = 42", -1, &stmt, nullptr), db, "count");
+    sqlite3_step(stmt);
+    n = sqlite3_column_int64(stmt, 0);
     sqlite3_finalize(stmt);
-    if (claimed.find("\"id\":" + std::to_string(id)) == std::string::npos) {
-        std::fprintf(stderr, "claimed the wrong job: %s\n", claimed.c_str());
+    if (n != 1) {
+        std::fprintf(stderr, "missing committed order\n");
         return 1;
     }
 
-    must(sqlite3_prepare_v2(db, "SELECT honker_ack(?, ?)", -1, &stmt, nullptr), db, "prepare ack");
-    sqlite3_bind_int64(stmt, 1, id);
-    sqlite3_bind_text(stmt, 2, "w1", -1, SQLITE_TRANSIENT);
-    if (sqlite3_step(stmt) != SQLITE_ROW || sqlite3_column_int(stmt, 0) != 1) {
-        std::fprintf(stderr, "ack must match the claim\n");
+    must(sqlite3_exec(db, "BEGIN IMMEDIATE", nullptr, nullptr, nullptr), db, "begin rollback");
+    must(sqlite3_exec(db, "INSERT INTO orders (id, user_id) VALUES (43, 1)", nullptr, nullptr, nullptr),
+         db, "insert rollback");
+    must(sqlite3_prepare_v2(db, "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)", -1, &stmt, nullptr),
+         db, "enqueue rollback");
+    sqlite3_bind_text(stmt, 1, "cp_atomic", -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 2, R"({"order_id":43})", -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int64(stmt, 3, 0);
+    sqlite3_bind_int64(stmt, 4, 3);
+    sqlite3_step(stmt);
+    sqlite3_int64 rolled = sqlite3_column_int64(stmt, 0);
+    sqlite3_finalize(stmt);
+    must(sqlite3_exec(db, "ROLLBACK", nullptr, nullptr, nullptr), db, "rollback");
+
+    must(sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM orders WHERE id = 43", -1, &stmt, nullptr), db, "count rb");
+    sqlite3_step(stmt);
+    n = sqlite3_column_int64(stmt, 0);
+    sqlite3_finalize(stmt);
+    if (n != 0) {
+        std::fprintf(stderr, "rollback left an order\n");
         return 1;
     }
+    must(sqlite3_prepare_v2(db, "SELECT honker_get_job(?)", -1, &stmt, nullptr), db, "get rolled");
+    sqlite3_bind_int64(stmt, 1, rolled);
+    sqlite3_step(stmt);
+    const unsigned char* job = sqlite3_column_text(stmt, 0);
+    std::string job_s = job ? reinterpret_cast<const char*>(job) : "";
     sqlite3_finalize(stmt);
+    if (!job_s.empty()) {
+        std::fprintf(stderr, "rollback left a job\n");
+        return 1;
+    }
+    (void)committed;
+
     sqlite3_close(db);
-
     std::printf("PASS cpp-framework-owned-sqlite3\n");
     return 0;
 }

--- a/scripts/proof/orm/cpp/orm_proof.cpp
+++ b/scripts/proof/orm/cpp/orm_proof.cpp
@@ -1,4 +1,5 @@
 // Framework-owned sqlite3, as guides/orm/cpp.mdx shows it.
+// docs:start example
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
@@ -298,3 +299,4 @@ int main() {
     std::printf("PASS cpp-framework-owned-sqlite3\n");
     return 0;
 }
+// docs:end example

--- a/scripts/proof/orm/dotnet/Program.cs
+++ b/scripts/proof/orm/dotnet/Program.cs
@@ -1,4 +1,5 @@
 // Framework-owned Microsoft.Data.Sqlite, as guides/orm/dotnet.mdx describes.
+// docs:start example
 using System.Text.Json;
 using Honker;
 using Microsoft.Data.Sqlite;
@@ -236,3 +237,4 @@ static void ProveAtomicity(SqliteConnection conn)
         if (AsText(job.ExecuteScalar()) != "") throw new Exception("rollback left a job");
     }
 }
+// docs:end example

--- a/scripts/proof/orm/dotnet/Program.cs
+++ b/scripts/proof/orm/dotnet/Program.cs
@@ -1,6 +1,4 @@
-// Framework-owned Microsoft.Data.Sqlite, as guides/orm/dotnet.mdx
-// describes for the EF Core case: Honker SQL running through a
-// connection the application owns, loaded via HonkerExtension.Locate().
+// Framework-owned Microsoft.Data.Sqlite, as guides/orm/dotnet.mdx describes.
 using System.Text.Json;
 using Honker;
 using Microsoft.Data.Sqlite;
@@ -12,50 +10,229 @@ using var conn = new SqliteConnection($"Data Source={dbPath}");
 conn.Open();
 conn.EnableExtensions(true);
 conn.LoadExtension(HonkerExtension.Locate());
-
 using (var boot = conn.CreateCommand())
 {
     boot.CommandText = "SELECT honker_bootstrap()";
     boot.ExecuteScalar();
 }
 
-// Bound parameters throughout, so Microsoft.Data.Sqlite's own binding
-// is what is exercised rather than inlined literals.
-long id;
-using (var cmd = conn.CreateCommand())
-{
-    cmd.CommandText = "SELECT honker_enqueue($q, $p, NULL, NULL, $prio, $max, NULL)";
-    cmd.Parameters.AddWithValue("$q", "emails");
-    cmd.Parameters.AddWithValue("$p", JsonSerializer.Serialize(new { to = "alice@example.com" }));
-    cmd.Parameters.AddWithValue("$prio", 0);
-    cmd.Parameters.AddWithValue("$max", 3);
-    id = Convert.ToInt64(cmd.ExecuteScalar());
-}
-if (id <= 0) throw new Exception($"expected a job id, got {id}");
-
-string claimedJson;
-using (var cmd = conn.CreateCommand())
-{
-    cmd.CommandText = "SELECT honker_claim_batch($q, $w, $n, $t)";
-    cmd.Parameters.AddWithValue("$q", "emails");
-    cmd.Parameters.AddWithValue("$w", "w1");
-    cmd.Parameters.AddWithValue("$n", 8);
-    cmd.Parameters.AddWithValue("$t", 300);
-    claimedJson = (string)cmd.ExecuteScalar()!;
-}
-using var claimed = JsonDocument.Parse(claimedJson);
-if (claimed.RootElement.GetArrayLength() != 1)
-    throw new Exception($"expected one claimed job, got {claimedJson}");
-if (claimed.RootElement[0].GetProperty("id").GetInt64() != id)
-    throw new Exception($"claimed the wrong job: {claimedJson}");
-
-using (var cmd = conn.CreateCommand())
-{
-    cmd.CommandText = "SELECT honker_ack($id, $w)";
-    cmd.Parameters.AddWithValue("$id", id);
-    cmd.Parameters.AddWithValue("$w", "w1");
-    if (Convert.ToInt64(cmd.ExecuteScalar()) != 1)
-        throw new Exception("ack must match the claim");
-}
-
+RunSurface(conn, "dn");
+ProveAtomicity(conn);
 Console.WriteLine("PASS dotnet-microsoft-data-sqlite");
+
+static string CatalogPath()
+{
+    var env = Environment.GetEnvironmentVariable("HONKER_ORM_SURFACE");
+    if (!string.IsNullOrEmpty(env))
+    {
+        if (!File.Exists(env)) throw new FileNotFoundException(env);
+        return env;
+    }
+    var cwd = Directory.GetCurrentDirectory();
+    for (var dir = cwd; dir != null; dir = Directory.GetParent(dir)?.FullName)
+    {
+        foreach (var rel in new[] { "surface.json", "scripts/proof/orm/surface.json" })
+        {
+            var p = Path.Combine(dir, rel);
+            if (File.Exists(p)) return p;
+        }
+    }
+    throw new FileNotFoundException("surface.json not found; set HONKER_ORM_SURFACE");
+}
+
+static object? Resolve(JsonElement token, string prefix, Dictionary<string, object?> vars)
+{
+    if (token.ValueKind == JsonValueKind.Null) return null;
+    if (token.ValueKind == JsonValueKind.Number) return token.GetInt64();
+    if (token.ValueKind != JsonValueKind.String) throw new Exception($"bad arg {token}");
+    var s = token.GetString()!;
+    if (s.StartsWith("$ns:")) return prefix + "_" + s[4..];
+    if (s.StartsWith("$json:"))
+    {
+        var ids = s[6..].Split(',').Select(k => Convert.ToInt64(vars[k])).ToArray();
+        return JsonSerializer.Serialize(ids);
+    }
+    if (s.StartsWith('$')) return vars[s[1..]];
+    return s;
+}
+
+static string AsText(object? v) => v is null or DBNull ? "" : Convert.ToString(v) ?? "";
+
+static long AsInt(object? v) => Convert.ToInt64(v);
+
+static string ResolveText(string text, string prefix, Dictionary<string, object?> vars)
+{
+    var outText = text;
+    foreach (var (k, v) in vars) outText = outText.Replace("$" + k, AsText(v));
+    return outText.Replace("$ns:", prefix + "_");
+}
+
+static object? Scalar(SqliteConnection conn, string sql, IReadOnlyList<object?> args)
+{
+    using var cmd = conn.CreateCommand();
+    var named = sql;
+    var n = 0;
+    var built = "";
+    foreach (var ch in named)
+    {
+        if (ch == '?')
+        {
+            built += $"$p{n}";
+            n++;
+        }
+        else built += ch;
+    }
+    cmd.CommandText = built;
+    for (var i = 0; i < args.Count; i++)
+        cmd.Parameters.AddWithValue($"$p{i}", args[i] ?? DBNull.Value);
+    var result = cmd.ExecuteScalar();
+    return result is DBNull ? null : result;
+}
+
+static void Check(JsonElement expect, object? result, string prefix, Dictionary<string, object?> vars)
+{
+    var kind = expect.GetProperty("kind").GetString();
+    switch (kind)
+    {
+        case "int_gt":
+            if (!(AsInt(result) > expect.GetProperty("n").GetInt64())) throw new Exception($"got {result}");
+            break;
+        case "int_eq":
+            if (AsInt(result) != expect.GetProperty("n").GetInt64()) throw new Exception($"got {result}");
+            break;
+        case "int_ge":
+            if (AsInt(result) < expect.GetProperty("n").GetInt64()) throw new Exception($"got {result}");
+            break;
+        case "int_gt_ref":
+            if (!(AsInt(result) > AsInt(vars[expect.GetProperty("ref").GetString()!]))) throw new Exception($"got {result}");
+            break;
+        case "eq_ref":
+            if (AsInt(result) != AsInt(vars[expect.GetProperty("ref").GetString()!])) throw new Exception($"got {result}");
+            break;
+        case "json_len":
+            if (JsonDocument.Parse(AsText(result)).RootElement.GetArrayLength() != expect.GetProperty("n").GetInt32())
+                throw new Exception($"got {result}");
+            break;
+        case "json_id_eq_ref":
+        {
+            using var doc = JsonDocument.Parse(AsText(result));
+            if (doc.RootElement.GetArrayLength() != 1) throw new Exception($"got {result}");
+            if (doc.RootElement[0].GetProperty("id").GetInt64() != AsInt(vars[expect.GetProperty("ref").GetString()!]))
+                throw new Exception($"got {result}");
+            break;
+        }
+        case "contains":
+        {
+            var needle = ResolveText(expect.GetProperty("s").GetString()!, prefix, vars);
+            if (!AsText(result).Contains(needle)) throw new Exception($"{needle} not in {result}");
+            break;
+        }
+        case "empty_string":
+            if (AsText(result) != "") throw new Exception($"expected empty string, got {result}");
+            break;
+        case "is_null":
+            if (result is not null) throw new Exception($"expected NULL, got {result}");
+            break;
+        default:
+            throw new Exception($"unknown expect kind {kind}");
+    }
+}
+
+static void RunSurface(SqliteConnection conn, string prefix)
+{
+    using var doc = JsonDocument.Parse(File.ReadAllText(CatalogPath()));
+    var vars = new Dictionary<string, object?>();
+    foreach (var step in doc.RootElement.GetProperty("steps").EnumerateArray())
+    {
+        var id = step.GetProperty("id").GetString()!;
+        var sql = step.GetProperty("sql").GetString()!;
+        var args = step.GetProperty("args").EnumerateArray().Select(a => Resolve(a, prefix, vars)).ToList();
+        object? result;
+        try { result = Scalar(conn, sql, args); }
+        catch (Exception ex) { throw new Exception($"{id} failed: {ex.Message}", ex); }
+        if (step.TryGetProperty("store", out var store) && store.GetString() is { } name)
+            vars[name] = result;
+        if (step.TryGetProperty("expect", out var expect))
+        {
+            try { Check(expect, result, prefix, vars); }
+            catch (Exception ex) { throw new Exception($"{id}: {ex.Message}", ex); }
+        }
+    }
+}
+
+static void ProveAtomicity(SqliteConnection conn)
+{
+    using (var cmd = conn.CreateCommand())
+    {
+        cmd.CommandText = "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)";
+        cmd.ExecuteNonQuery();
+    }
+
+    using (var tx = conn.BeginTransaction())
+    {
+        using (var ins = conn.CreateCommand())
+        {
+            ins.Transaction = tx;
+            ins.CommandText = "INSERT INTO orders (id, user_id) VALUES ($id, $uid)";
+            ins.Parameters.AddWithValue("$id", 42);
+            ins.Parameters.AddWithValue("$uid", 1);
+            ins.ExecuteNonQuery();
+        }
+        long jobId;
+        using (var enq = conn.CreateCommand())
+        {
+            enq.Transaction = tx;
+            enq.CommandText = "SELECT honker_enqueue($q, $p, NULL, NULL, $prio, $max, NULL)";
+            enq.Parameters.AddWithValue("$q", "dn_atomic");
+            enq.Parameters.AddWithValue("$p", JsonSerializer.Serialize(new { order_id = 42 }));
+            enq.Parameters.AddWithValue("$prio", 0);
+            enq.Parameters.AddWithValue("$max", 3);
+            jobId = Convert.ToInt64(enq.ExecuteScalar());
+        }
+        tx.Commit();
+
+        using var check = conn.CreateCommand();
+        check.CommandText = "SELECT COUNT(*) FROM orders WHERE id = 42";
+        if (Convert.ToInt64(check.ExecuteScalar()) != 1) throw new Exception("missing committed order");
+        using var job = conn.CreateCommand();
+        job.CommandText = "SELECT honker_get_job($id)";
+        job.Parameters.AddWithValue("$id", jobId);
+        if (!AsText(job.ExecuteScalar()).Contains("order_id")) throw new Exception("missing committed job");
+    }
+
+    long rolled;
+    using (var tx = conn.BeginTransaction())
+    {
+        using (var ins = conn.CreateCommand())
+        {
+            ins.Transaction = tx;
+            ins.CommandText = "INSERT INTO orders (id, user_id) VALUES ($id, $uid)";
+            ins.Parameters.AddWithValue("$id", 43);
+            ins.Parameters.AddWithValue("$uid", 1);
+            ins.ExecuteNonQuery();
+        }
+        using (var enq = conn.CreateCommand())
+        {
+            enq.Transaction = tx;
+            enq.CommandText = "SELECT honker_enqueue($q, $p, NULL, NULL, $prio, $max, NULL)";
+            enq.Parameters.AddWithValue("$q", "dn_atomic");
+            enq.Parameters.AddWithValue("$p", JsonSerializer.Serialize(new { order_id = 43 }));
+            enq.Parameters.AddWithValue("$prio", 0);
+            enq.Parameters.AddWithValue("$max", 3);
+            rolled = Convert.ToInt64(enq.ExecuteScalar());
+        }
+        tx.Rollback();
+    }
+
+    using (var check = conn.CreateCommand())
+    {
+        check.CommandText = "SELECT COUNT(*) FROM orders WHERE id = 43";
+        if (Convert.ToInt64(check.ExecuteScalar()) != 0) throw new Exception("rollback left an order");
+    }
+    using (var job = conn.CreateCommand())
+    {
+        job.CommandText = "SELECT honker_get_job($id)";
+        job.Parameters.AddWithValue("$id", rolled);
+        if (AsText(job.ExecuteScalar()) != "") throw new Exception("rollback left a job");
+    }
+}

--- a/scripts/proof/orm/elixir/ecto_proof.exs
+++ b/scripts/proof/orm/elixir/ecto_proof.exs
@@ -1,7 +1,4 @@
-# Ecto, as guides/orm/elixir.mdx shows it: exqlite's :load_extensions
-# on the Repo, then honker_bootstrap once at start.
-#
-# Run with: elixir ecto_proof.exs   (deps supplied by Mix.install)
+# Ecto, as guides/orm/elixir.mdx shows it.
 
 Mix.install([
   {:ecto_sql, "~> 3.12"},
@@ -25,33 +22,151 @@ Application.put_env(:proof, Proof.Repo,
 {:ok, _} = Proof.Repo.start_link()
 Ecto.Adapters.SQL.query!(Proof.Repo, "SELECT honker_bootstrap()", [])
 
-# Every value passed as a bound parameter, never inlined, so Ecto's own
-# parameter handling is what gets exercised.
-payload = ~s({"to":"alice@example.com"})
+catalog_path =
+  System.get_env("HONKER_ORM_SURFACE") ||
+    Path.expand("../surface.json", Path.dirname(__ENV__.file))
 
-%{rows: [[id]]} =
-  Ecto.Adapters.SQL.query!(
-    Proof.Repo,
-    "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
-    ["emails", payload, 0, 3]
-  )
+catalog = catalog_path |> File.read!() |> Jason.decode!()
 
-true = is_integer(id) and id > 0
+defmodule Surface do
+  def as_int(v) when is_integer(v), do: v
+  def as_int(v) when is_float(v), do: trunc(v)
+  def as_int(v) when is_binary(v), do: String.to_integer(v)
+  def as_int(v), do: raise("expected int, got #{inspect(v)}")
 
-%{rows: [[claimed_json]]} =
-  Ecto.Adapters.SQL.query!(
-    Proof.Repo,
-    "SELECT honker_claim_batch(?, ?, ?, ?)",
-    ["emails", "w1", 8, 300]
-  )
+  def as_text(nil), do: ""
+  def as_text(v) when is_binary(v), do: v
+  def as_text(v), do: to_string(v)
 
-claimed = Jason.decode!(claimed_json)
-1 = length(claimed)
-^id = claimed |> hd() |> Map.fetch!("id")
+  def resolve("$ns:" <> name, prefix, _vars), do: prefix <> "_" <> name
 
-%{rows: [[acked]]} =
-  Ecto.Adapters.SQL.query!(Proof.Repo, "SELECT honker_ack(?, ?)", [id, "w1"])
+  def resolve("$json:" <> keys, _prefix, vars) do
+    keys
+    |> String.split(",")
+    |> Enum.map(fn k -> as_int(Map.fetch!(vars, k)) end)
+    |> Jason.encode!()
+  end
 
-1 = acked
+  def resolve("$" <> name, _prefix, vars), do: Map.fetch!(vars, name)
+  def resolve(token, _prefix, _vars), do: token
+
+  def resolve_text(text, prefix, vars) do
+    Enum.reduce(vars, text, fn {k, v}, acc ->
+      String.replace(acc, "$" <> k, as_text(v))
+    end)
+    |> String.replace("$ns:", prefix <> "_")
+  end
+
+  def check(%{"kind" => "int_gt", "n" => n}, result, _, _) do
+    true = as_int(result) > n
+  end
+
+  def check(%{"kind" => "int_eq", "n" => n}, result, _, _) do
+    true = as_int(result) == n
+  end
+
+  def check(%{"kind" => "int_ge", "n" => n}, result, _, _) do
+    true = as_int(result) >= n
+  end
+
+  def check(%{"kind" => "int_gt_ref", "ref" => ref}, result, _, vars) do
+    true = as_int(result) > as_int(Map.fetch!(vars, ref))
+  end
+
+  def check(%{"kind" => "eq_ref", "ref" => ref}, result, _, vars) do
+    true = as_int(result) == as_int(Map.fetch!(vars, ref))
+  end
+
+  def check(%{"kind" => "json_len", "n" => n}, result, _, _) do
+    true = length(Jason.decode!(as_text(result))) == n
+  end
+
+  def check(%{"kind" => "json_id_eq_ref", "ref" => ref}, result, _, vars) do
+    [job] = Jason.decode!(as_text(result))
+    true = as_int(job["id"]) == as_int(Map.fetch!(vars, ref))
+  end
+
+  def check(%{"kind" => "contains", "s" => s}, result, prefix, vars) do
+    true = String.contains?(as_text(result), resolve_text(s, prefix, vars))
+  end
+
+  def check(%{"kind" => "empty_string"}, result, _, _) do
+    true = as_text(result) == ""
+  end
+
+  def check(%{"kind" => "is_null"}, result, _, _) do
+    true = is_nil(result)
+  end
+
+  def run(catalog, prefix) do
+    Enum.reduce(catalog["steps"], %{}, fn step, vars ->
+      args = Enum.map(step["args"], &resolve(&1, prefix, vars))
+
+      %{rows: [[result]]} =
+        try do
+          Ecto.Adapters.SQL.query!(Proof.Repo, step["sql"], args)
+        rescue
+          e -> raise "#{step["id"]} failed: #{Exception.message(e)}"
+        end
+
+      vars = if step["store"], do: Map.put(vars, step["store"], result), else: vars
+
+      if step["expect"] do
+        try do
+          check(step["expect"], result, prefix, vars)
+        rescue
+          e -> raise "#{step["id"]}: #{Exception.message(e)}"
+        end
+      end
+
+      vars
+    end)
+  end
+end
+
+Surface.run(catalog, "ec")
+
+Ecto.Adapters.SQL.query!(
+  Proof.Repo,
+  "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)",
+  []
+)
+
+{:ok, job_id} =
+  Proof.Repo.transaction(fn ->
+    Ecto.Adapters.SQL.query!(Proof.Repo, "INSERT INTO orders (id, user_id) VALUES (?, ?)", [42, 1])
+
+    %{rows: [[id]]} =
+      Ecto.Adapters.SQL.query!(
+        Proof.Repo,
+        "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+        ["ec_atomic", ~s({"order_id":42}), 0, 3]
+      )
+
+    id
+  end)
+
+%{rows: [[1]]} = Ecto.Adapters.SQL.query!(Proof.Repo, "SELECT COUNT(*) FROM orders WHERE id = ?", [42])
+%{rows: [[job]]} = Ecto.Adapters.SQL.query!(Proof.Repo, "SELECT honker_get_job(?)", [job_id])
+true = is_binary(job) and String.contains?(job, "order_id")
+
+rolled =
+  case Proof.Repo.transaction(fn ->
+         Ecto.Adapters.SQL.query!(Proof.Repo, "INSERT INTO orders (id, user_id) VALUES (?, ?)", [43, 1])
+
+         %{rows: [[id]]} =
+           Ecto.Adapters.SQL.query!(
+             Proof.Repo,
+             "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+             ["ec_atomic", ~s({"order_id":43}), 0, 3]
+           )
+
+         Proof.Repo.rollback({:rollback, id})
+       end) do
+    {:error, {:rollback, id}} -> id
+  end
+
+%{rows: [[0]]} = Ecto.Adapters.SQL.query!(Proof.Repo, "SELECT COUNT(*) FROM orders WHERE id = ?", [43])
+%{rows: [[""]]} = Ecto.Adapters.SQL.query!(Proof.Repo, "SELECT honker_get_job(?)", [rolled])
 
 IO.puts("PASS ecto")

--- a/scripts/proof/orm/elixir/ecto_proof.exs
+++ b/scripts/proof/orm/elixir/ecto_proof.exs
@@ -1,4 +1,5 @@
 # Ecto, as guides/orm/elixir.mdx shows it.
+# docs:start example
 
 Mix.install([
   {:ecto_sql, "~> 3.12"},
@@ -170,3 +171,4 @@ rolled =
 %{rows: [[""]]} = Ecto.Adapters.SQL.query!(Proof.Repo, "SELECT honker_get_job(?)", [rolled])
 
 IO.puts("PASS ecto")
+# docs:end example

--- a/scripts/proof/orm/go/main.go
+++ b/scripts/proof/orm/go/main.go
@@ -1,9 +1,4 @@
 // database/sql and GORM, as guides/orm/go.mdx shows them.
-//
-// Both go through the mattn/go-sqlite3 driver variant registered with
-// the Extensions field, which is the documented wiring. GORM is not a
-// separate loading path — it wraps database/sql — but it is documented
-// separately, so it is proven separately rather than assumed.
 package main
 
 import (
@@ -11,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	honker "github.com/russellromney/honker-go"
 	sqlite3 "github.com/mattn/go-sqlite3"
@@ -18,9 +15,23 @@ import (
 	"gorm.io/gorm"
 )
 
-type job struct {
-	ID      int64  `json:"id"`
-	Payload string `json:"payload"`
+type expect struct {
+	Kind string   `json:"kind"`
+	N    *float64 `json:"n"`
+	S    string   `json:"s"`
+	Ref  string   `json:"ref"`
+}
+
+type step struct {
+	ID     string  `json:"id"`
+	SQL    string  `json:"sql"`
+	Args   []any   `json:"args"`
+	Store  string  `json:"store"`
+	Expect *expect `json:"expect"`
+}
+
+type catalog struct {
+	Steps []step `json:"steps"`
 }
 
 func init() {
@@ -34,47 +45,343 @@ func init() {
 	})
 }
 
-// roundTrip runs enqueue -> claim -> ack with every value bound, never
-// inlined, so the driver's own parameter binding is what is exercised.
-func roundTrip(exec func(string, ...any) (*sql.Row, error), label string) error {
-	row, err := exec("SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)", label, `{"to":"alice"}`, 0, 3)
+func catalogPath() string {
+	if p := os.Getenv("HONKER_ORM_SURFACE"); p != "" {
+		return p
+	}
+	for _, p := range []string{"surface.json", "scripts/proof/orm/surface.json"} {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	fmt.Fprintln(os.Stderr, "surface.json not found; set HONKER_ORM_SURFACE")
+	os.Exit(1)
+	return ""
+}
+
+func asInt(v any) (int64, error) {
+	switch t := v.(type) {
+	case int:
+		return int64(t), nil
+	case int32:
+		return int64(t), nil
+	case int64:
+		return t, nil
+	case float64:
+		return int64(t), nil
+	case json.Number:
+		return t.Int64()
+	case []byte:
+		return strconv.ParseInt(string(t), 10, 64)
+	case string:
+		return strconv.ParseInt(t, 10, 64)
+	default:
+		return 0, fmt.Errorf("expected int, got %T %v", v, v)
+	}
+}
+
+func asText(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	default:
+		return fmt.Sprint(t)
+	}
+}
+
+func resolve(token any, prefix string, vars map[string]any) (any, error) {
+	s, ok := token.(string)
+	if !ok {
+		return token, nil
+	}
+	if strings.HasPrefix(s, "$ns:") {
+		return prefix + "_" + s[4:], nil
+	}
+	if strings.HasPrefix(s, "$json:") {
+		keys := strings.Split(s[6:], ",")
+		ids := make([]int64, len(keys))
+		for i, k := range keys {
+			n, err := asInt(vars[k])
+			if err != nil {
+				return nil, err
+			}
+			ids[i] = n
+		}
+		b, err := json.Marshal(ids)
+		return string(b), err
+	}
+	if strings.HasPrefix(s, "$") {
+		return vars[s[1:]], nil
+	}
+	return s, nil
+}
+
+func resolveText(text, prefix string, vars map[string]any) string {
+	out := text
+	for k, v := range vars {
+		out = strings.ReplaceAll(out, "$"+k, asText(v))
+	}
+	return strings.ReplaceAll(out, "$ns:", prefix+"_")
+}
+
+func check(exp expect, result any, prefix string, vars map[string]any) error {
+	switch exp.Kind {
+	case "int_gt":
+		n, err := asInt(result)
+		if err != nil || n <= int64(*exp.N) {
+			return fmt.Errorf("got %v", result)
+		}
+	case "int_eq":
+		n, err := asInt(result)
+		if err != nil || n != int64(*exp.N) {
+			return fmt.Errorf("got %v", result)
+		}
+	case "int_ge":
+		n, err := asInt(result)
+		if err != nil || n < int64(*exp.N) {
+			return fmt.Errorf("got %v", result)
+		}
+	case "int_gt_ref":
+		n, err := asInt(result)
+		ref, rerr := asInt(vars[exp.Ref])
+		if err != nil || rerr != nil || n <= ref {
+			return fmt.Errorf("got %v", result)
+		}
+	case "eq_ref":
+		n, err := asInt(result)
+		ref, rerr := asInt(vars[exp.Ref])
+		if err != nil || rerr != nil || n != ref {
+			return fmt.Errorf("got %v", result)
+		}
+	case "json_len":
+		var parsed []any
+		if err := json.Unmarshal([]byte(asText(result)), &parsed); err != nil {
+			return err
+		}
+		if len(parsed) != int(*exp.N) {
+			return fmt.Errorf("got %v", result)
+		}
+	case "json_id_eq_ref":
+		var parsed []map[string]any
+		if err := json.Unmarshal([]byte(asText(result)), &parsed); err != nil {
+			return err
+		}
+		ref, err := asInt(vars[exp.Ref])
+		if err != nil {
+			return err
+		}
+		if len(parsed) != 1 {
+			return fmt.Errorf("got %v", result)
+		}
+		id, err := asInt(parsed[0]["id"])
+		if err != nil || id != ref {
+			return fmt.Errorf("got %v", result)
+		}
+	case "contains":
+		needle := resolveText(exp.S, prefix, vars)
+		if !strings.Contains(asText(result), needle) {
+			return fmt.Errorf("%q not in %v", needle, result)
+		}
+	case "empty_string":
+		if asText(result) != "" {
+			return fmt.Errorf("expected empty string, got %v", result)
+		}
+	case "is_null":
+		if result != nil {
+			return fmt.Errorf("expected NULL, got %v", result)
+		}
+	default:
+		return fmt.Errorf("unknown expect kind %s", exp.Kind)
+	}
+	return nil
+}
+
+func runSurface(scalar func(string, ...any) (any, error), prefix string) error {
+	raw, err := os.ReadFile(catalogPath())
 	if err != nil {
 		return err
 	}
-	var id int64
-	if err := row.Scan(&id); err != nil {
+	var cat catalog
+	if err := json.Unmarshal(raw, &cat); err != nil {
 		return err
 	}
-	if id <= 0 {
-		return fmt.Errorf("expected a job id, got %d", id)
+	vars := map[string]any{}
+	for _, st := range cat.Steps {
+		args := make([]any, len(st.Args))
+		for i, a := range st.Args {
+			args[i], err = resolve(a, prefix, vars)
+			if err != nil {
+				return fmt.Errorf("%s: %w", st.ID, err)
+			}
+		}
+		result, err := scalar(st.SQL, args...)
+		if err != nil {
+			return fmt.Errorf("%s failed: %w", st.ID, err)
+		}
+		if st.Store != "" {
+			vars[st.Store] = result
+		}
+		if st.Expect != nil {
+			if err := check(*st.Expect, result, prefix, vars); err != nil {
+				return fmt.Errorf("%s: %w", st.ID, err)
+			}
+		}
+	}
+	return nil
+}
+
+func stdScalar(db *sql.DB) func(string, ...any) (any, error) {
+	return func(q string, args ...any) (any, error) {
+		var v any
+		if err := db.QueryRow(q, args...).Scan(&v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	}
+}
+
+func gormScalar(db *gorm.DB) func(string, ...any) (any, error) {
+	return func(q string, args ...any) (any, error) {
+		var v any
+		if err := db.Raw(q, args...).Row().Scan(&v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	}
+}
+
+func stdAtomicity(db *sql.DB, queue string, commitID, rollbackID int) error {
+	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS orders (id INTEGER PRIMARY KEY, user_id INTEGER)"); err != nil {
+		return err
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec("INSERT INTO orders (id, user_id) VALUES (?, ?)", commitID, 1); err != nil {
+		tx.Rollback()
+		return err
+	}
+	var jobID int64
+	if err := tx.QueryRow(
+		"SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+		queue, fmt.Sprintf(`{"order_id":%d}`, commitID), 0, 3,
+	).Scan(&jobID); err != nil {
+		tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	var n int
+	if err := db.QueryRow("SELECT COUNT(*) FROM orders WHERE id = ?", commitID).Scan(&n); err != nil {
+		return err
+	}
+	if n != 1 {
+		return fmt.Errorf("expected committed order %d", commitID)
+	}
+	var job string
+	if err := db.QueryRow("SELECT honker_get_job(?)", jobID).Scan(&job); err != nil {
+		return err
+	}
+	if !strings.Contains(job, "order_id") {
+		return fmt.Errorf("missing committed job")
 	}
 
-	row, err = exec("SELECT honker_claim_batch(?, ?, ?, ?)", label, "w1", 8, 300)
+	tx, err = db.Begin()
 	if err != nil {
 		return err
 	}
-	var claimedJSON string
-	if err := row.Scan(&claimedJSON); err != nil {
+	if _, err := tx.Exec("INSERT INTO orders (id, user_id) VALUES (?, ?)", rollbackID, 1); err != nil {
+		tx.Rollback()
 		return err
 	}
-	var claimed []job
-	if err := json.Unmarshal([]byte(claimedJSON), &claimed); err != nil {
+	var rolled int64
+	if err := tx.QueryRow(
+		"SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+		queue, fmt.Sprintf(`{"order_id":%d}`, rollbackID), 0, 3,
+	).Scan(&rolled); err != nil {
+		tx.Rollback()
 		return err
 	}
-	if len(claimed) != 1 || claimed[0].ID != id {
-		return fmt.Errorf("expected to claim job %d, got %s", id, claimedJSON)
+	if err := tx.Rollback(); err != nil {
+		return err
+	}
+	if err := db.QueryRow("SELECT COUNT(*) FROM orders WHERE id = ?", rollbackID).Scan(&n); err != nil {
+		return err
+	}
+	if n != 0 {
+		return fmt.Errorf("rollback left order %d", rollbackID)
+	}
+	if err := db.QueryRow("SELECT honker_get_job(?)", rolled).Scan(&job); err != nil {
+		return err
+	}
+	if job != "" {
+		return fmt.Errorf("rollback left job %q", job)
+	}
+	return nil
+}
+
+func gormAtomicity(db *gorm.DB, queue string, commitID, rollbackID int) error {
+	if err := db.Exec("CREATE TABLE IF NOT EXISTS orders (id INTEGER PRIMARY KEY, user_id INTEGER)").Error; err != nil {
+		return err
+	}
+	var jobID int64
+	err := db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("INSERT INTO orders (id, user_id) VALUES (?, ?)", commitID, 1).Error; err != nil {
+			return err
+		}
+		return tx.Raw(
+			"SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+			queue, fmt.Sprintf(`{"order_id":%d}`, commitID), 0, 3,
+		).Scan(&jobID).Error
+	})
+	if err != nil {
+		return err
+	}
+	var n int64
+	if err := db.Raw("SELECT COUNT(*) FROM orders WHERE id = ?", commitID).Scan(&n).Error; err != nil {
+		return err
+	}
+	if n != 1 {
+		return fmt.Errorf("expected committed order %d", commitID)
+	}
+	var job string
+	if err := db.Raw("SELECT honker_get_job(?)", jobID).Scan(&job).Error; err != nil {
+		return err
+	}
+	if !strings.Contains(job, "order_id") {
+		return fmt.Errorf("missing committed job")
 	}
 
-	row, err = exec("SELECT honker_ack(?, ?)", id, "w1")
-	if err != nil {
+	var rolled int64
+	_ = db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("INSERT INTO orders (id, user_id) VALUES (?, ?)", rollbackID, 1).Error; err != nil {
+			return err
+		}
+		if err := tx.Raw(
+			"SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+			queue, fmt.Sprintf(`{"order_id":%d}`, rollbackID), 0, 3,
+		).Scan(&rolled).Error; err != nil {
+			return err
+		}
+		return fmt.Errorf("rollback")
+	})
+	if err := db.Raw("SELECT COUNT(*) FROM orders WHERE id = ?", rollbackID).Scan(&n).Error; err != nil {
 		return err
 	}
-	var ok int
-	if err := row.Scan(&ok); err != nil {
+	if n != 0 {
+		return fmt.Errorf("rollback left order %d", rollbackID)
+	}
+	if err := db.Raw("SELECT honker_get_job(?)", rolled).Scan(&job).Error; err != nil {
 		return err
 	}
-	if ok != 1 {
-		return fmt.Errorf("ack must match the claim, got %d", ok)
+	if job != "" {
+		return fmt.Errorf("rollback left job %q", job)
 	}
 	return nil
 }
@@ -86,7 +393,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// database/sql
 	stdDB, err := sql.Open("sqlite3_honker", "file:"+dbPath)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "database/sql open:", err)
@@ -96,15 +402,17 @@ func main() {
 		fmt.Fprintln(os.Stderr, "bootstrap:", err)
 		os.Exit(1)
 	}
-	stdExec := func(q string, args ...any) (*sql.Row, error) { return stdDB.QueryRow(q, args...), nil }
-	if err := roundTrip(stdExec, "emails_std"); err != nil {
+	if err := runSurface(stdScalar(stdDB), "gs"); err != nil {
 		fmt.Fprintln(os.Stderr, "FAIL database/sql:", err)
+		os.Exit(1)
+	}
+	if err := stdAtomicity(stdDB, "gs_atomic", 42, 43); err != nil {
+		fmt.Fprintln(os.Stderr, "FAIL database/sql atomicity:", err)
 		os.Exit(1)
 	}
 	fmt.Println("PASS go-database-sql")
 	stdDB.Close()
 
-	// GORM over the same registered driver
 	gormDB, err := gorm.Open(
 		sqlite.Dialector{DriverName: "sqlite3_honker", DSN: "file:" + dbPath},
 		&gorm.Config{},
@@ -113,9 +421,12 @@ func main() {
 		fmt.Fprintln(os.Stderr, "gorm open:", err)
 		os.Exit(1)
 	}
-	gormExec := func(q string, args ...any) (*sql.Row, error) { return gormDB.Raw(q, args...).Row(), nil }
-	if err := roundTrip(gormExec, "emails_gorm"); err != nil {
+	if err := runSurface(gormScalar(gormDB), "gg"); err != nil {
 		fmt.Fprintln(os.Stderr, "FAIL gorm:", err)
+		os.Exit(1)
+	}
+	if err := gormAtomicity(gormDB, "gg_atomic", 52, 53); err != nil {
+		fmt.Fprintln(os.Stderr, "FAIL gorm atomicity:", err)
 		os.Exit(1)
 	}
 	fmt.Println("PASS go-gorm")

--- a/scripts/proof/orm/go/main.go
+++ b/scripts/proof/orm/go/main.go
@@ -1,4 +1,5 @@
 // database/sql and GORM, as guides/orm/go.mdx shows them.
+// docs:start example
 package main
 
 import (
@@ -9,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	honker "github.com/russellromney/honker-go"
 	sqlite3 "github.com/mattn/go-sqlite3"
+	honker "github.com/russellromney/honker-go"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -431,3 +432,5 @@ func main() {
 	}
 	fmt.Println("PASS go-gorm")
 }
+
+// docs:end example

--- a/scripts/proof/orm/js/better-sqlite3.mjs
+++ b/scripts/proof/orm/js/better-sqlite3.mjs
@@ -1,4 +1,5 @@
 // better-sqlite3, exactly as guides/orm/javascript.mdx shows it.
+// docs:start example
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import Database from 'better-sqlite3';
@@ -53,3 +54,4 @@ assert.equal(db.prepare('SELECT honker_get_job(?) AS job').get(rolled).job, '');
 
 db.close();
 console.log('PASS better-sqlite3');
+// docs:end example

--- a/scripts/proof/orm/js/better-sqlite3.mjs
+++ b/scripts/proof/orm/js/better-sqlite3.mjs
@@ -1,7 +1,9 @@
 // better-sqlite3, exactly as guides/orm/javascript.mdx shows it.
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import Database from 'better-sqlite3';
 import { extensionPath, extensionInfo } from '@russellthehippo/honker-node/extension';
+import { run } from './surface.mjs';
 
 const info = extensionInfo();
 assert.equal(info.entrypoint, 'sqlite3_honkerext_init');
@@ -11,25 +13,43 @@ assert.match(
   `expected the packaged extension, resolved ${info.path}`,
 );
 
-const db = new Database(':memory:');
+const dbPath = process.env.HONKER_TEST_DB;
+if (!dbPath) throw new Error('HONKER_TEST_DB is required');
+fs.rmSync(dbPath, { force: true });
+
+const db = new Database(dbPath);
 db.loadExtension(extensionPath());
 db.prepare('SELECT honker_bootstrap()').run();
 
-// Every numeric argument bound, never a SQL literal. better-sqlite3
-// binds JS numbers as REAL; literals would sidestep that entirely.
-const payload = JSON.stringify({ to: 'alice@example.com' });
-const { id } = db
-  .prepare('SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL) AS id')
-  .get('emails', payload, 0, 3);
-assert.ok(id > 0, `expected a job id, got ${id}`);
+await run((sql, args) => {
+  const row = db.prepare(sql).get(...args);
+  return row ? Object.values(row)[0] : null;
+}, 'b3');
 
-const claimed = JSON.parse(
-  db.prepare('SELECT honker_claim_batch(?, ?, ?, ?) AS jobs').get('emails', 'w1', 8, 300).jobs,
-);
-assert.equal(claimed.length, 1);
-assert.equal(claimed[0].id, id);
-assert.equal(JSON.parse(claimed[0].payload).to, 'alice@example.com');
+db.exec('CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)');
+const committed = db.transaction(() => {
+  db.prepare('INSERT INTO orders (id, user_id) VALUES (?, ?)').run(42, 1);
+  return db
+    .prepare('SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL) AS id')
+    .get('b3_atomic', JSON.stringify({ order_id: 42 }), 0, 3).id;
+})();
+assert.equal(db.prepare('SELECT COUNT(*) AS n FROM orders WHERE id = 42').get().n, 1);
+assert.match(db.prepare('SELECT honker_get_job(?) AS job').get(committed).job, /order_id/);
 
-assert.equal(db.prepare('SELECT honker_ack(?, ?) AS ok').get(id, 'w1').ok, 1);
+let rolled;
+try {
+  db.transaction(() => {
+    db.prepare('INSERT INTO orders (id, user_id) VALUES (?, ?)').run(43, 1);
+    rolled = db
+      .prepare('SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL) AS id')
+      .get('b3_atomic', JSON.stringify({ order_id: 43 }), 0, 3).id;
+    throw new Error('rollback');
+  })();
+} catch (err) {
+  if (err.message !== 'rollback') throw err;
+}
+assert.equal(db.prepare('SELECT COUNT(*) AS n FROM orders WHERE id = 43').get().n, 0);
+assert.equal(db.prepare('SELECT honker_get_job(?) AS job').get(rolled).job, '');
+
 db.close();
 console.log('PASS better-sqlite3');

--- a/scripts/proof/orm/js/drizzle.mjs
+++ b/scripts/proof/orm/js/drizzle.mjs
@@ -1,4 +1,5 @@
 // Drizzle ORM, exactly as guides/orm/javascript.mdx shows it.
+// docs:start example
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import Database from 'better-sqlite3';
@@ -60,3 +61,4 @@ assert.equal(db.get(sql`SELECT honker_get_job(${rolled}) AS job`).job, '');
 
 sqlite.close();
 console.log('PASS drizzle');
+// docs:end example

--- a/scripts/proof/orm/js/drizzle.mjs
+++ b/scripts/proof/orm/js/drizzle.mjs
@@ -1,29 +1,62 @@
-// Drizzle ORM, exactly as guides/orm/javascript.mdx shows it: the
-// sql`` template with interpolated values, which is where Drizzle's
-// own parameter binding sits.
+// Drizzle ORM, exactly as guides/orm/javascript.mdx shows it.
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { sql } from 'drizzle-orm';
 import { extensionPath } from '@russellthehippo/honker-node/extension';
+import { run } from './surface.mjs';
 
-const sqlite = new Database(':memory:');
+const dbPath = process.env.HONKER_TEST_DB;
+if (!dbPath) throw new Error('HONKER_TEST_DB is required');
+fs.rmSync(dbPath, { force: true });
+
+const sqlite = new Database(dbPath);
 sqlite.loadExtension(extensionPath());
 sqlite.prepare('SELECT honker_bootstrap()').run();
 const db = drizzle(sqlite);
 
-const payload = JSON.stringify({ to: 'alice@example.com' });
-const { id } = db.get(sql`
-  SELECT honker_enqueue(${'emails'}, ${payload}, NULL, ${null}, ${0}, ${3}, NULL) AS id
-`);
-assert.ok(id > 0, `expected a job id, got ${id}`);
+function bound(query, args) {
+  const parts = query.split('?');
+  if (parts.length - 1 !== args.length) {
+    throw new Error(`bind mismatch: ${parts.length - 1} placeholders, ${args.length} args`);
+  }
+  let frag = sql.raw(parts[0]);
+  for (let i = 0; i < args.length; i++) {
+    frag = sql`${frag}${args[i]}${sql.raw(parts[i + 1])}`;
+  }
+  return frag;
+}
 
-const claimed = JSON.parse(
-  db.get(sql`SELECT honker_claim_batch(${'emails'}, ${'w1'}, ${8}, ${300}) AS jobs`).jobs,
-);
-assert.equal(claimed.length, 1);
-assert.equal(claimed[0].id, id);
+await run((query, args) => {
+  const row = db.get(bound(query, args));
+  return row ? Object.values(row)[0] : null;
+}, 'dr');
 
-assert.equal(db.get(sql`SELECT honker_ack(${id}, ${'w1'}) AS ok`).ok, 1);
+db.run(sql.raw('CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)'));
+const committed = db.transaction((tx) => {
+  tx.run(sql`INSERT INTO orders (id, user_id) VALUES (${42}, ${1})`);
+  return tx.get(sql`
+    SELECT honker_enqueue(${'dr_atomic'}, ${JSON.stringify({ order_id: 42 })}, NULL, ${null}, ${0}, ${3}, NULL) AS id
+  `).id;
+});
+assert.equal(db.get(sql`SELECT COUNT(*) AS n FROM orders WHERE id = ${42}`).n, 1);
+assert.match(db.get(sql`SELECT honker_get_job(${committed}) AS job`).job, /order_id/);
+
+let rolled;
+try {
+  db.transaction((tx) => {
+    tx.run(sql`INSERT INTO orders (id, user_id) VALUES (${43}, ${1})`);
+    rolled = tx.get(sql`
+      SELECT honker_enqueue(${'dr_atomic'}, ${JSON.stringify({ order_id: 43 })}, NULL, ${null}, ${0}, ${3}, NULL) AS id
+    `).id;
+    throw new Error('rollback');
+  });
+} catch (err) {
+  if (err.message !== 'rollback') throw err;
+}
+assert.equal(db.get(sql`SELECT COUNT(*) AS n FROM orders WHERE id = ${43}`).n, 0);
+assert.equal(db.get(sql`SELECT honker_get_job(${rolled}) AS job`).job, '');
+
 sqlite.close();
 console.log('PASS drizzle');

--- a/scripts/proof/orm/js/kysely.mjs
+++ b/scripts/proof/orm/js/kysely.mjs
@@ -1,4 +1,5 @@
 // Kysely, exactly as guides/orm/javascript.mdx shows it.
+// docs:start example
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import Database from 'better-sqlite3';
@@ -66,3 +67,4 @@ assert.equal(rolledJob.rows[0].job, '');
 
 await db.destroy();
 console.log('PASS kysely');
+// docs:end example

--- a/scripts/proof/orm/js/kysely.mjs
+++ b/scripts/proof/orm/js/kysely.mjs
@@ -1,29 +1,68 @@
 // Kysely, exactly as guides/orm/javascript.mdx shows it.
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import Database from 'better-sqlite3';
 import { Kysely, SqliteDialect, sql } from 'kysely';
 import { extensionPath } from '@russellthehippo/honker-node/extension';
+import { run } from './surface.mjs';
 
-const sqlite = new Database(':memory:');
+const dbPath = process.env.HONKER_TEST_DB;
+if (!dbPath) throw new Error('HONKER_TEST_DB is required');
+fs.rmSync(dbPath, { force: true });
+
+const sqlite = new Database(dbPath);
 sqlite.loadExtension(extensionPath());
 sqlite.prepare('SELECT honker_bootstrap()').run();
 const db = new Kysely({ dialect: new SqliteDialect({ database: sqlite }) });
 
-const payload = JSON.stringify({ to: 'alice@example.com' });
-const enqueued = await sql`
-  SELECT honker_enqueue(${'emails'}, ${payload}, NULL, ${null}, ${0}, ${3}, NULL) AS id
-`.execute(db);
-const id = enqueued.rows[0].id;
-assert.ok(id > 0, `expected a job id, got ${id}`);
+function bound(query, args) {
+  const parts = query.split('?');
+  if (parts.length - 1 !== args.length) {
+    throw new Error(`bind mismatch: ${parts.length - 1} placeholders, ${args.length} args`);
+  }
+  let frag = sql.raw(parts[0]);
+  for (let i = 0; i < args.length; i++) {
+    frag = sql`${frag}${args[i]}${sql.raw(parts[i + 1])}`;
+  }
+  return frag;
+}
 
-const claimRes = await sql`
-  SELECT honker_claim_batch(${'emails'}, ${'w1'}, ${8}, ${300}) AS jobs
-`.execute(db);
-const claimed = JSON.parse(claimRes.rows[0].jobs);
-assert.equal(claimed.length, 1);
-assert.equal(claimed[0].id, id);
+await run(async (query, args) => {
+  const { rows } = await bound(query, args).execute(db);
+  return rows[0] ? Object.values(rows[0])[0] : null;
+}, 'ky');
 
-const ackRes = await sql`SELECT honker_ack(${id}, ${'w1'}) AS ok`.execute(db);
-assert.equal(ackRes.rows[0].ok, 1);
+await sql`CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)`.execute(db);
+
+const committed = await db.transaction().execute(async (tx) => {
+  await sql`INSERT INTO orders (id, user_id) VALUES (${42}, ${1})`.execute(tx);
+  const { rows } = await sql`
+    SELECT honker_enqueue(${'ky_atomic'}, ${JSON.stringify({ order_id: 42 })}, NULL, ${null}, ${0}, ${3}, NULL) AS id
+  `.execute(tx);
+  return rows[0].id;
+});
+const committedCount = await sql`SELECT COUNT(*) AS n FROM orders WHERE id = ${42}`.execute(db);
+assert.equal(committedCount.rows[0].n, 1);
+const committedJob = await sql`SELECT honker_get_job(${committed}) AS job`.execute(db);
+assert.match(String(committedJob.rows[0].job), /order_id/);
+
+let rolled;
+try {
+  await db.transaction().execute(async (tx) => {
+    await sql`INSERT INTO orders (id, user_id) VALUES (${43}, ${1})`.execute(tx);
+    const { rows } = await sql`
+      SELECT honker_enqueue(${'ky_atomic'}, ${JSON.stringify({ order_id: 43 })}, NULL, ${null}, ${0}, ${3}, NULL) AS id
+    `.execute(tx);
+    rolled = rows[0].id;
+    throw new Error('rollback');
+  });
+} catch (err) {
+  if (err.message !== 'rollback') throw err;
+}
+const rolledCount = await sql`SELECT COUNT(*) AS n FROM orders WHERE id = ${43}`.execute(db);
+assert.equal(rolledCount.rows[0].n, 0);
+const rolledJob = await sql`SELECT honker_get_job(${rolled}) AS job`.execute(db);
+assert.equal(rolledJob.rows[0].job, '');
+
 await db.destroy();
 console.log('PASS kysely');

--- a/scripts/proof/orm/js/surface.mjs
+++ b/scripts/proof/orm/js/surface.mjs
@@ -1,0 +1,120 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function catalogPath() {
+  if (process.env.HONKER_ORM_SURFACE) {
+    if (!fs.existsSync(process.env.HONKER_ORM_SURFACE)) {
+      throw new Error(`HONKER_ORM_SURFACE=${process.env.HONKER_ORM_SURFACE} is not a file`);
+    }
+    return process.env.HONKER_ORM_SURFACE;
+  }
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  for (const candidate of [
+    path.join(here, 'surface.json'),
+    path.join(here, '..', 'surface.json'),
+  ]) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error('surface.json not found; set HONKER_ORM_SURFACE');
+}
+
+function asInt(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) throw new Error(`expected number, got ${value}`);
+  return n;
+}
+
+function asText(value) {
+  if (value == null) return '';
+  if (Buffer.isBuffer(value)) return value.toString('utf8');
+  return String(value);
+}
+
+function resolve(token, prefix, variables) {
+  if (typeof token !== 'string') return token;
+  if (token.startsWith('$ns:')) return `${prefix}_${token.slice(4)}`;
+  if (token.startsWith('$json:')) {
+    const keys = token.slice(6).split(',');
+    return JSON.stringify(keys.map((k) => asInt(variables[k])));
+  }
+  if (token.startsWith('$')) return variables[token.slice(1)];
+  return token;
+}
+
+function resolveText(text, prefix, variables) {
+  let out = text;
+  for (const [key, value] of Object.entries(variables)) {
+    out = out.replaceAll(`$${key}`, asText(value));
+  }
+  return out.replaceAll('$ns:', `${prefix}_`);
+}
+
+function check(expect, result, prefix, variables) {
+  switch (expect.kind) {
+    case 'int_gt':
+      if (!(asInt(result) > expect.n)) throw new Error(`got ${result}`);
+      break;
+    case 'int_eq':
+      if (asInt(result) !== expect.n) throw new Error(`got ${result}`);
+      break;
+    case 'int_ge':
+      if (!(asInt(result) >= expect.n)) throw new Error(`got ${result}`);
+      break;
+    case 'int_gt_ref':
+      if (!(asInt(result) > asInt(variables[expect.ref]))) throw new Error(`got ${result}`);
+      break;
+    case 'eq_ref':
+      if (asInt(result) !== asInt(variables[expect.ref])) throw new Error(`got ${result}`);
+      break;
+    case 'json_len': {
+      const parsed = JSON.parse(asText(result));
+      if (parsed.length !== expect.n) throw new Error(`got ${result}`);
+      break;
+    }
+    case 'json_id_eq_ref': {
+      const parsed = JSON.parse(asText(result));
+      if (parsed.length !== 1 || asInt(parsed[0].id) !== asInt(variables[expect.ref])) {
+        throw new Error(`got ${result}`);
+      }
+      break;
+    }
+    case 'contains': {
+      const needle = resolveText(expect.s, prefix, variables);
+      if (!asText(result).includes(needle)) throw new Error(`${needle} not in ${result}`);
+      break;
+    }
+    case 'empty_string': {
+      const text = result == null ? '' : asText(result);
+      if (text !== '') throw new Error(`expected empty string, got ${result}`);
+      break;
+    }
+    case 'is_null':
+      if (result !== null && result !== undefined) throw new Error(`expected NULL, got ${result}`);
+      break;
+    default:
+      throw new Error(`unknown expect kind ${expect.kind}`);
+  }
+}
+
+export async function run(scalar, prefix) {
+  const catalog = JSON.parse(fs.readFileSync(catalogPath(), 'utf8'));
+  const variables = {};
+  for (const step of catalog.steps) {
+    const args = step.args.map((arg) => resolve(arg, prefix, variables));
+    let result;
+    try {
+      result = await scalar(step.sql, args);
+    } catch (err) {
+      throw new Error(`${step.id} failed: ${err.message || err}`);
+    }
+    if (step.store) variables[step.store] = result;
+    if (step.expect) {
+      try {
+        check(step.expect, result, prefix, variables);
+      } catch (err) {
+        throw new Error(`${step.id}: ${err.message || err}`);
+      }
+    }
+  }
+}

--- a/scripts/proof/orm/jvm/pom.xml
+++ b/scripts/proof/orm/jvm/pom.xml
@@ -65,6 +65,11 @@
       <artifactId>exposed-jdbc</artifactId>
       <version>${exposed.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20250517</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/scripts/proof/orm/jvm/src/main/java/dev/honker/ormproof/OrmProof.java
+++ b/scripts/proof/orm/jvm/src/main/java/dev/honker/ormproof/OrmProof.java
@@ -1,5 +1,7 @@
 package dev.honker.ormproof;
 
+// docs:start example
+
 import dev.honker.HonkerExtension;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -284,3 +286,4 @@ public final class OrmProof {
         System.out.println("PASS jvm-jooq");
     }
 }
+// docs:end example

--- a/scripts/proof/orm/jvm/src/main/java/dev/honker/ormproof/OrmProof.java
+++ b/scripts/proof/orm/jvm/src/main/java/dev/honker/ormproof/OrmProof.java
@@ -1,18 +1,10 @@
 package dev.honker.ormproof;
 
-// The documented JVM recipes from guides/orm/jvm.mdx: raw JDBC, the
-// HonkerSql helper the page defines, Hibernate's doWork unwrap, and
-// jOOQ's transaction callback. Each runs an enqueue -> claim -> ack
-// round trip with bound parameters.
-
 import dev.honker.HonkerExtension;
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Properties;
-import org.hibernate.Session;
 import org.hibernate.cfg.Configuration;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
@@ -20,53 +12,6 @@ import org.sqlite.SQLiteConfig;
 
 public final class OrmProof {
 
-    // The helper exactly as the page defines it.
-    static long enqueue(Connection conn, String queue, String payloadJson) throws Exception {
-        try (var stmt = conn.prepareStatement(
-                "SELECT honker_enqueue(?, ?, NULL, NULL, 0, 3, NULL) AS id")) {
-            stmt.setString(1, queue);
-            stmt.setString(2, payloadJson);
-            try (var rs = stmt.executeQuery()) {
-                rs.next();
-                return rs.getLong("id");
-            }
-        }
-    }
-
-    static void claimAndAck(Connection conn, String queue, long id) throws Exception {
-        String claimed;
-        try (PreparedStatement stmt = conn.prepareStatement(
-                "SELECT honker_claim_batch(?, ?, ?, ?)")) {
-            stmt.setString(1, queue);
-            stmt.setString(2, "w1");
-            stmt.setInt(3, 8);
-            stmt.setInt(4, 300);
-            try (ResultSet rs = stmt.executeQuery()) {
-                rs.next();
-                claimed = rs.getString(1);
-            }
-        }
-        if (!claimed.contains("\"id\":" + id)) {
-            throw new IllegalStateException("claimed the wrong job: " + claimed);
-        }
-        try (PreparedStatement stmt = conn.prepareStatement("SELECT honker_ack(?, ?)")) {
-            stmt.setLong(1, id);
-            stmt.setString(2, "w1");
-            try (ResultSet rs = stmt.executeQuery()) {
-                rs.next();
-                if (rs.getInt(1) != 1) {
-                    throw new IllegalStateException("ack must match the claim");
-                }
-            }
-        }
-    }
-
-    static String jdbcUrl(String dbPath) {
-        return "jdbc:sqlite:" + dbPath;
-    }
-
-    // The page's wiring: enable extension loading before the connection
-    // opens, then load with an explicit entry point.
     static Properties extensionProps() {
         var config = new SQLiteConfig();
         config.enableLoadExtension(true);
@@ -79,25 +24,109 @@ public final class OrmProof {
         stmt.execute("SELECT honker_bootstrap()");
     }
 
+    static String jdbcUrl(String dbPath) {
+        return "jdbc:sqlite:" + dbPath;
+    }
+
+    static void proveAtomicity(Connection conn, String queue, int commitId, int rollbackId) throws Exception {
+        try (var stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE IF NOT EXISTS orders (id INTEGER PRIMARY KEY, user_id INTEGER)");
+        }
+        conn.setAutoCommit(false);
+        try (var ins = conn.prepareStatement("INSERT INTO orders (id, user_id) VALUES (?, ?)")) {
+            ins.setInt(1, commitId);
+            ins.setInt(2, 1);
+            ins.executeUpdate();
+        }
+        long jobId;
+        try (var enq = conn.prepareStatement(
+                "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)")) {
+            enq.setString(1, queue);
+            enq.setString(2, "{\"order_id\":" + commitId + "}");
+            enq.setInt(3, 0);
+            enq.setInt(4, 3);
+            try (var rs = enq.executeQuery()) {
+                rs.next();
+                jobId = rs.getLong(1);
+            }
+        }
+        conn.commit();
+        conn.setAutoCommit(true);
+
+        try (var check = conn.prepareStatement("SELECT COUNT(*) FROM orders WHERE id = ?")) {
+            check.setInt(1, commitId);
+            try (var rs = check.executeQuery()) {
+                rs.next();
+                if (rs.getInt(1) != 1) {
+                    throw new IllegalStateException("missing committed order");
+                }
+            }
+        }
+        try (var job = conn.prepareStatement("SELECT honker_get_job(?)")) {
+            job.setLong(1, jobId);
+            try (var rs = job.executeQuery()) {
+                rs.next();
+                if (!rs.getString(1).contains("order_id")) {
+                    throw new IllegalStateException("missing committed job");
+                }
+            }
+        }
+
+        conn.setAutoCommit(false);
+        try (var ins = conn.prepareStatement("INSERT INTO orders (id, user_id) VALUES (?, ?)")) {
+            ins.setInt(1, rollbackId);
+            ins.setInt(2, 1);
+            ins.executeUpdate();
+        }
+        long rolled;
+        try (var enq = conn.prepareStatement(
+                "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)")) {
+            enq.setString(1, queue);
+            enq.setString(2, "{\"order_id\":" + rollbackId + "}");
+            enq.setInt(3, 0);
+            enq.setInt(4, 3);
+            try (var rs = enq.executeQuery()) {
+                rs.next();
+                rolled = rs.getLong(1);
+            }
+        }
+        conn.rollback();
+        conn.setAutoCommit(true);
+
+        try (var check = conn.prepareStatement("SELECT COUNT(*) FROM orders WHERE id = ?")) {
+            check.setInt(1, rollbackId);
+            try (var rs = check.executeQuery()) {
+                rs.next();
+                if (rs.getInt(1) != 0) {
+                    throw new IllegalStateException("rollback left an order");
+                }
+            }
+        }
+        try (var job = conn.prepareStatement("SELECT honker_get_job(?)")) {
+            job.setLong(1, rolled);
+            try (var rs = job.executeQuery()) {
+                rs.next();
+                if (!rs.getString(1).isEmpty()) {
+                    throw new IllegalStateException("rollback left a job");
+                }
+            }
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         String dbPath = System.getenv("HONKER_TEST_DB");
         if (dbPath == null || dbPath.isBlank()) {
             throw new IllegalStateException("HONKER_TEST_DB is required");
         }
 
-        // ---- raw JDBC -------------------------------------------------
         try (var conn = DriverManager.getConnection(jdbcUrl(dbPath), extensionProps());
                 var stmt = conn.createStatement()) {
             loadHonker(stmt);
-            long id = enqueue(conn, "emails_jdbc", "{\"to\":\"alice@example.com\"}");
-            if (id <= 0) {
-                throw new IllegalStateException("expected a job id, got " + id);
-            }
-            claimAndAck(conn, "emails_jdbc", id);
+            Surface.run(conn, "jdbc");
+            proveAtomicity(conn, "jdbc_atomic", 42, 43);
         }
         System.out.println("PASS jvm-jdbc");
 
-        // ---- Hibernate / JPA -----------------------------------------
         var cfg = new Configuration()
                 .setProperty("hibernate.connection.driver_class", "org.sqlite.JDBC")
                 .setProperty("hibernate.connection.url", jdbcUrl(dbPath))
@@ -106,16 +135,91 @@ public final class OrmProof {
                 .setProperty("hibernate.hbm2ddl.auto", "none");
         try (var sf = cfg.buildSessionFactory(); var session = sf.openSession()) {
             session.beginTransaction();
-            // The documented shape: unwrap the JDBC connection inside the
-            // ORM's own transaction so the enqueue shares it.
             session.doWork(conn -> {
                 try (var stmt = conn.createStatement()) {
                     loadHonker(stmt);
-                    long id = enqueue(conn, "emails_hib", "{\"to\":\"alice@example.com\"}");
-                    if (id <= 0) {
-                        throw new IllegalStateException("expected a job id, got " + id);
+                    Surface.run(conn, "hib");
+                    stmt.execute("CREATE TABLE IF NOT EXISTS orders (id INTEGER PRIMARY KEY, user_id INTEGER)");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            session.getTransaction().commit();
+
+            session.beginTransaction();
+            final long[] committed = new long[1];
+            session.doWork(conn -> {
+                try (var ins = conn.prepareStatement("INSERT INTO orders (id, user_id) VALUES (?, ?)")) {
+                    ins.setInt(1, 52);
+                    ins.setInt(2, 1);
+                    ins.executeUpdate();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                try (var enq = conn.prepareStatement(
+                        "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)")) {
+                    enq.setString(1, "hib_atomic");
+                    enq.setString(2, "{\"order_id\":52}");
+                    enq.setInt(3, 0);
+                    enq.setInt(4, 3);
+                    try (var rs = enq.executeQuery()) {
+                        rs.next();
+                        committed[0] = rs.getLong(1);
                     }
-                    claimAndAck(conn, "emails_hib", id);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            session.getTransaction().commit();
+
+            session.beginTransaction();
+            session.doWork(conn -> {
+                try (var check = conn.prepareStatement("SELECT COUNT(*) FROM orders WHERE id = 52")) {
+                    try (var rs = check.executeQuery()) {
+                        rs.next();
+                        if (rs.getInt(1) != 1) {
+                            throw new IllegalStateException("missing committed order");
+                        }
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            session.getTransaction().commit();
+
+            session.beginTransaction();
+            session.doWork(conn -> {
+                try (var ins = conn.prepareStatement("INSERT INTO orders (id, user_id) VALUES (?, ?)")) {
+                    ins.setInt(1, 53);
+                    ins.setInt(2, 1);
+                    ins.executeUpdate();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                try (var enq = conn.prepareStatement(
+                        "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)")) {
+                    enq.setString(1, "hib_atomic");
+                    enq.setString(2, "{\"order_id\":53}");
+                    enq.setInt(3, 0);
+                    enq.setInt(4, 3);
+                    try (var rs = enq.executeQuery()) {
+                        rs.next();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            session.getTransaction().rollback();
+
+            session.beginTransaction();
+            session.doWork(conn -> {
+                try (var check = conn.prepareStatement("SELECT COUNT(*) FROM orders WHERE id = 53")) {
+                    try (var rs = check.executeQuery()) {
+                        rs.next();
+                        if (rs.getInt(1) != 0) {
+                            throw new IllegalStateException("rollback left an order");
+                        }
+                    }
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -124,23 +228,58 @@ public final class OrmProof {
         }
         System.out.println("PASS jvm-hibernate");
 
-        // ---- jOOQ -----------------------------------------------------
         try (var conn = DriverManager.getConnection(jdbcUrl(dbPath), extensionProps());
                 var stmt = conn.createStatement()) {
             loadHonker(stmt);
             var ctx = DSL.using(conn, SQLDialect.SQLITE);
+            Surface.run(conn, "jooq");
             ctx.transaction(configuration -> {
                 var tx = DSL.using(configuration);
+                tx.execute("CREATE TABLE IF NOT EXISTS orders (id INTEGER PRIMARY KEY, user_id INTEGER)");
+                tx.execute("INSERT INTO orders (id, user_id) VALUES (?, ?)", 62, 1);
                 Object raw = tx.fetchValue(
-                        "SELECT honker_enqueue(?, ?, NULL, NULL, 0, 3, NULL)",
-                        "emails_jooq",
-                        "{\"to\":\"alice@example.com\"}");
-                Long id = raw == null ? null : ((Number) raw).longValue();
-                if (id == null || id <= 0) {
-                    throw new IllegalStateException("expected a job id, got " + id);
+                        "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+                        "jooq_atomic",
+                        "{\"order_id\":62}",
+                        0,
+                        3);
+                Long id = ((Number) raw).longValue();
+                if (id <= 0) {
+                    throw new IllegalStateException("expected a job id");
                 }
-                claimAndAck(conn, "emails_jooq", id);
             });
+            try {
+                ctx.transaction(configuration -> {
+                    var tx = DSL.using(configuration);
+                    tx.execute("INSERT INTO orders (id, user_id) VALUES (?, ?)", 63, 1);
+                    tx.fetchValue(
+                            "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+                            "jooq_atomic",
+                            "{\"order_id\":63}",
+                            0,
+                            3);
+                    throw new RuntimeException("rollback");
+                });
+            } catch (RuntimeException e) {
+                boolean rollback = false;
+                for (Throwable t = e; t != null; t = t.getCause()) {
+                    if ("rollback".equals(t.getMessage())) {
+                        rollback = true;
+                        break;
+                    }
+                }
+                if (!rollback) {
+                    throw e;
+                }
+            }
+            try (var check = conn.prepareStatement("SELECT COUNT(*) FROM orders WHERE id = 63")) {
+                try (var rs = check.executeQuery()) {
+                    rs.next();
+                    if (rs.getInt(1) != 0) {
+                        throw new IllegalStateException("rollback left an order");
+                    }
+                }
+            }
         }
         System.out.println("PASS jvm-jooq");
     }

--- a/scripts/proof/orm/jvm/src/main/java/dev/honker/ormproof/Surface.java
+++ b/scripts/proof/orm/jvm/src/main/java/dev/honker/ormproof/Surface.java
@@ -1,0 +1,204 @@
+package dev.honker.ormproof;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+final class Surface {
+    private Surface() {}
+
+    static Path catalogPath() {
+        String env = System.getenv("HONKER_ORM_SURFACE");
+        if (env != null && !env.isBlank()) {
+            Path p = Path.of(env);
+            if (!Files.isRegularFile(p)) {
+                throw new IllegalStateException("HONKER_ORM_SURFACE=" + env + " is not a file");
+            }
+            return p;
+        }
+        Path cwd = Path.of("").toAbsolutePath();
+        Path[] candidates = new Path[] {
+            cwd.resolve("surface.json"),
+            cwd.resolve("../surface.json"),
+            cwd.resolve("scripts/proof/orm/surface.json"),
+        };
+        for (Path p : candidates) {
+            if (Files.isRegularFile(p)) {
+                return p;
+            }
+        }
+        throw new IllegalStateException("surface.json not found; set HONKER_ORM_SURFACE");
+    }
+
+    static long asInt(Object value) {
+        if (value instanceof Number n) {
+            return n.longValue();
+        }
+        if (value instanceof String s) {
+            return Long.parseLong(s);
+        }
+        throw new IllegalStateException("expected int, got " + value);
+    }
+
+    static String asText(Object value) {
+        return value == null ? "" : String.valueOf(value);
+    }
+
+    static Object resolve(Object token, String prefix, Map<String, Object> vars) {
+        if (!(token instanceof String s)) {
+            if (token == JSONObject.NULL) {
+                return null;
+            }
+            return token;
+        }
+        if (s.startsWith("$ns:")) {
+            return prefix + "_" + s.substring(4);
+        }
+        if (s.startsWith("$json:")) {
+            JSONArray ids = new JSONArray();
+            for (String key : s.substring(6).split(",")) {
+                ids.put(asInt(vars.get(key)));
+            }
+            return ids.toString();
+        }
+        if (s.startsWith("$")) {
+            return vars.get(s.substring(1));
+        }
+        return s;
+    }
+
+    static String resolveText(String text, String prefix, Map<String, Object> vars) {
+        String out = text;
+        for (Map.Entry<String, Object> e : vars.entrySet()) {
+            out = out.replace("$" + e.getKey(), asText(e.getValue()));
+        }
+        return out.replace("$ns:", prefix + "_");
+    }
+
+    static Object scalar(Connection conn, String sql, List<Object> args) throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+            for (int i = 0; i < args.size(); i++) {
+                Object arg = args.get(i);
+                if (arg == null) {
+                    stmt.setNull(i + 1, Types.NULL);
+                } else if (arg instanceof Integer n) {
+                    stmt.setInt(i + 1, n);
+                } else if (arg instanceof Long n) {
+                    stmt.setLong(i + 1, n);
+                } else if (arg instanceof Number n) {
+                    stmt.setLong(i + 1, n.longValue());
+                } else {
+                    stmt.setString(i + 1, String.valueOf(arg));
+                }
+            }
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    return null;
+                }
+                Object value = rs.getObject(1);
+                return rs.wasNull() ? null : value;
+            }
+        }
+    }
+
+    static void check(JSONObject expect, Object result, String prefix, Map<String, Object> vars) {
+        String kind = expect.getString("kind");
+        switch (kind) {
+            case "int_gt" -> {
+                if (!(asInt(result) > expect.getLong("n"))) {
+                    throw new IllegalStateException("got " + result);
+                }
+            }
+            case "int_eq" -> {
+                if (asInt(result) != expect.getLong("n")) {
+                    throw new IllegalStateException("got " + result);
+                }
+            }
+            case "int_ge" -> {
+                if (asInt(result) < expect.getLong("n")) {
+                    throw new IllegalStateException("got " + result);
+                }
+            }
+            case "int_gt_ref" -> {
+                if (!(asInt(result) > asInt(vars.get(expect.getString("ref"))))) {
+                    throw new IllegalStateException("got " + result);
+                }
+            }
+            case "eq_ref" -> {
+                if (asInt(result) != asInt(vars.get(expect.getString("ref")))) {
+                    throw new IllegalStateException("got " + result);
+                }
+            }
+            case "json_len" -> {
+                if (new JSONArray(asText(result)).length() != expect.getInt("n")) {
+                    throw new IllegalStateException("got " + result);
+                }
+            }
+            case "json_id_eq_ref" -> {
+                JSONArray parsed = new JSONArray(asText(result));
+                if (parsed.length() != 1
+                        || asInt(parsed.getJSONObject(0).get("id")) != asInt(vars.get(expect.getString("ref")))) {
+                    throw new IllegalStateException("got " + result);
+                }
+            }
+            case "contains" -> {
+                String needle = resolveText(expect.getString("s"), prefix, vars);
+                if (!asText(result).contains(needle)) {
+                    throw new IllegalStateException(needle + " not in " + result);
+                }
+            }
+            case "empty_string" -> {
+                if (!asText(result).isEmpty()) {
+                    throw new IllegalStateException("expected empty string, got " + result);
+                }
+            }
+            case "is_null" -> {
+                if (result != null) {
+                    throw new IllegalStateException("expected NULL, got " + result);
+                }
+            }
+            default -> throw new IllegalStateException("unknown expect kind " + kind);
+        }
+    }
+
+    static void run(Connection conn, String prefix) throws Exception {
+        JSONObject catalog = new JSONObject(Files.readString(catalogPath()));
+        Map<String, Object> vars = new HashMap<>();
+        JSONArray steps = catalog.getJSONArray("steps");
+        for (int i = 0; i < steps.length(); i++) {
+            JSONObject step = steps.getJSONObject(i);
+            String id = step.getString("id");
+            JSONArray rawArgs = step.getJSONArray("args");
+            List<Object> args = new ArrayList<>();
+            for (int a = 0; a < rawArgs.length(); a++) {
+                args.add(resolve(rawArgs.get(a), prefix, vars));
+            }
+            Object result;
+            try {
+                result = scalar(conn, step.getString("sql"), args);
+            } catch (Exception e) {
+                throw new IllegalStateException(id + " failed: " + e.getMessage(), e);
+            }
+            if (step.has("store") && !step.isNull("store")) {
+                vars.put(step.getString("store"), result);
+            }
+            if (step.has("expect")) {
+                try {
+                    check(step.getJSONObject("expect"), result, prefix, vars);
+                } catch (Exception e) {
+                    throw new IllegalStateException(id + ": " + e.getMessage(), e);
+                }
+            }
+        }
+    }
+}

--- a/scripts/proof/orm/jvm/src/main/kotlin/dev/honker/ormproof/ExposedProof.kt
+++ b/scripts/proof/orm/jvm/src/main/kotlin/dev/honker/ormproof/ExposedProof.kt
@@ -1,13 +1,9 @@
 package dev.honker.ormproof
 
-// Kotlin Exposed, as guides/orm/jvm.mdx shows it: raw SQL inside
-// transaction { }. The page's snippet inlines its values; this binds
-// them, because that is what an app with real data would do and it is
-// the path where driver type handling actually shows up.
-
 import dev.honker.HonkerExtension
 import java.sql.DriverManager
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.sqlite.SQLiteConfig
 
@@ -17,11 +13,6 @@ object ExposedProof {
         val dbPath = System.getenv("HONKER_TEST_DB")
             ?: error("HONKER_TEST_DB is required")
 
-        // Extension loading has to be enabled before the connection
-        // opens, which means Exposed's url+driver overload is not
-        // enough — it never sees the SQLiteConfig properties and
-        // load_extension comes back "not authorized". Hand Exposed a
-        // connection factory instead.
         val props = SQLiteConfig().apply { enableLoadExtension(true) }.toProperties()
         Database.connect({
             DriverManager.getConnection("jdbc:sqlite:$dbPath", props).also { conn ->
@@ -36,36 +27,69 @@ object ExposedProof {
         })
 
         transaction {
-            val conn = (this.connection.connection as java.sql.Connection)
+            val conn = TransactionManager.current().connection.connection as java.sql.Connection
+            Surface.run(conn, "exp")
+        }
 
-            val id = conn.prepareStatement(
-                "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL) AS id"
-            ).use { stmt ->
-                stmt.setString(1, "emails_exposed")
-                stmt.setString(2, """{"to":"alice@example.com"}""")
-                stmt.setInt(3, 0)
-                stmt.setInt(4, 3)
-                stmt.executeQuery().use { rs -> rs.next(); rs.getLong("id") }
-            }
-            check(id > 0) { "expected a job id, got $id" }
+        transaction {
+            exec("CREATE TABLE IF NOT EXISTS orders (id INTEGER PRIMARY KEY, user_id INTEGER)")
+            exec("INSERT INTO orders (id, user_id) VALUES (72, 1)")
+            exec(
+                """
+                SELECT honker_enqueue(
+                  'exp_atomic',
+                  '{"order_id":72}',
+                  NULL, NULL, 0, 3, NULL
+                )
+                """.trimIndent()
+            )
+        }
 
-            val claimed = conn.prepareStatement(
-                "SELECT honker_claim_batch(?, ?, ?, ?)"
-            ).use { stmt ->
-                stmt.setString(1, "emails_exposed")
-                stmt.setString(2, "w1")
-                stmt.setInt(3, 8)
-                stmt.setInt(4, 300)
-                stmt.executeQuery().use { rs -> rs.next(); rs.getString(1) }
+        transaction {
+            val conn = TransactionManager.current().connection.connection as java.sql.Connection
+            conn.prepareStatement("SELECT COUNT(*) FROM orders WHERE id = 72").use { stmt ->
+                stmt.executeQuery().use { rs ->
+                    rs.next()
+                    check(rs.getInt(1) == 1) { "missing committed order" }
+                }
             }
-            check(claimed.contains("\"id\":$id")) { "claimed the wrong job: $claimed" }
+        }
 
-            val acked = conn.prepareStatement("SELECT honker_ack(?, ?)").use { stmt ->
-                stmt.setLong(1, id)
-                stmt.setString(2, "w1")
-                stmt.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        try {
+            transaction {
+                exec("INSERT INTO orders (id, user_id) VALUES (73, 1)")
+                exec(
+                    """
+                    SELECT honker_enqueue(
+                      'exp_atomic',
+                      '{"order_id":73}',
+                      NULL, NULL, 0, 3, NULL
+                    )
+                    """.trimIndent()
+                )
+                error("rollback")
             }
-            check(acked == 1) { "ack must match the claim" }
+        } catch (e: Throwable) {
+            var t: Throwable? = e
+            var isRollback = false
+            while (t != null) {
+                if (t.message == "rollback") {
+                    isRollback = true
+                    break
+                }
+                t = t.cause
+            }
+            if (!isRollback) throw e
+        }
+
+        transaction {
+            val conn = TransactionManager.current().connection.connection as java.sql.Connection
+            conn.prepareStatement("SELECT COUNT(*) FROM orders WHERE id = 73").use { stmt ->
+                stmt.executeQuery().use { rs ->
+                    rs.next()
+                    check(rs.getInt(1) == 0) { "rollback left an order" }
+                }
+            }
         }
 
         println("PASS jvm-kotlin-exposed")

--- a/scripts/proof/orm/jvm/src/main/kotlin/dev/honker/ormproof/ExposedProof.kt
+++ b/scripts/proof/orm/jvm/src/main/kotlin/dev/honker/ormproof/ExposedProof.kt
@@ -1,5 +1,7 @@
 package dev.honker.ormproof
 
+// docs:start example
+
 import dev.honker.HonkerExtension
 import java.sql.DriverManager
 import org.jetbrains.exposed.sql.Database
@@ -95,3 +97,4 @@ object ExposedProof {
         println("PASS jvm-kotlin-exposed")
     }
 }
+// docs:end example

--- a/scripts/proof/orm/python/django_orm.py
+++ b/scripts/proof/orm/python/django_orm.py
@@ -1,5 +1,7 @@
 """Django, as guides/orm/python.mdx shows it."""
 
+# docs:start example
+
 import json
 import os
 
@@ -86,3 +88,4 @@ def prove_atomicity():
 
 prove_atomicity()
 print("PASS django")
+# docs:end example

--- a/scripts/proof/orm/python/django_orm.py
+++ b/scripts/proof/orm/python/django_orm.py
@@ -1,8 +1,4 @@
-"""Django, as guides/orm/python.mdx shows it.
-
-Drives the real connection_created signal rather than loading the
-extension by hand, so the documented receiver is what gets exercised.
-"""
+"""Django, as guides/orm/python.mdx shows it."""
 
 import json
 import os
@@ -21,37 +17,72 @@ settings.configure(
 )
 django.setup()
 
-import honker  # noqa: E402  (must follow django.setup())
-from django.db import connection  # noqa: E402
+import honker  # noqa: E402
+from django.db import connection, transaction  # noqa: E402
 from django.db.backends.signals import connection_created  # noqa: E402
 from django.dispatch import receiver  # noqa: E402
+
+from surface import run  # noqa: E402
 
 
 @receiver(connection_created)
 def _load_honker(sender, connection, **kwargs):
     if connection.vendor != "sqlite":
         return
-    raw = connection.connection  # underlying sqlite3.Connection
+    raw = connection.connection
     honker.load_extension(raw)
     raw.execute("SELECT honker_bootstrap()")
 
 
-with connection.cursor() as cur:
-    payload = json.dumps({"to": "alice@example.com"})
-    # Django's placeholder style, with every value bound.
-    cur.execute(
-        "SELECT honker_enqueue(%s, %s, NULL, NULL, %s, %s, NULL)",
-        ["emails", payload, 0, 3],
-    )
-    job_id = cur.fetchone()[0]
-    assert job_id > 0, f"expected a job id, got {job_id}"
+def scalar(sql, args):
+    with connection.cursor() as cur:
+        cur.execute(sql.replace("?", "%s"), args)
+        row = cur.fetchone()
+        return None if row is None else row[0]
 
-    cur.execute("SELECT honker_claim_batch(%s, %s, %s, %s)", ["emails", "w1", 8, 300])
-    claimed = json.loads(cur.fetchone()[0])
-    assert len(claimed) == 1, f"expected one claimed job, got {claimed}"
-    assert claimed[0]["id"] == job_id
 
-    cur.execute("SELECT honker_ack(%s, %s)", [job_id, "w1"])
-    assert cur.fetchone()[0] == 1, "ack must match the claim"
+run(scalar, "dj")
 
+
+def prove_atomicity():
+    with connection.cursor() as cur:
+        cur.execute("CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)")
+
+    with transaction.atomic():
+        with connection.cursor() as cur:
+            cur.execute("INSERT INTO orders (id, user_id) VALUES (%s, %s)", [42, 1])
+            cur.execute(
+                "SELECT honker_enqueue(%s, %s, NULL, NULL, %s, %s, NULL)",
+                ["dj_atomic", json.dumps({"order_id": 42}), 0, 3],
+            )
+            job_id = cur.fetchone()[0]
+
+    with connection.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM orders WHERE id = %s", [42])
+        assert cur.fetchone()[0] == 1
+        cur.execute("SELECT honker_get_job(%s)", [job_id])
+        assert "order_id" in (cur.fetchone()[0] or "")
+
+    try:
+        with transaction.atomic():
+            with connection.cursor() as cur:
+                cur.execute("INSERT INTO orders (id, user_id) VALUES (%s, %s)", [43, 1])
+                cur.execute(
+                    "SELECT honker_enqueue(%s, %s, NULL, NULL, %s, %s, NULL)",
+                    ["dj_atomic", json.dumps({"order_id": 43}), 0, 3],
+                )
+                rolled = cur.fetchone()[0]
+            raise RuntimeError("rollback")
+    except RuntimeError as exc:
+        if str(exc) != "rollback":
+            raise
+
+    with connection.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM orders WHERE id = %s", [43])
+        assert cur.fetchone()[0] == 0
+        cur.execute("SELECT honker_get_job(%s)", [rolled])
+        assert not cur.fetchone()[0]
+
+
+prove_atomicity()
 print("PASS django")

--- a/scripts/proof/orm/python/sqlalchemy_orm.py
+++ b/scripts/proof/orm/python/sqlalchemy_orm.py
@@ -1,16 +1,12 @@
-"""SQLAlchemy / SQLModel, as guides/orm/python.mdx shows it.
-
-Both share this wiring: the connect event loads the extension onto the
-raw DB-API connection. SQLModel's Session subclasses SQLAlchemy's, so
-the extension path is identical and only the wrapper on top differs.
-"""
+"""SQLAlchemy, as guides/orm/python.mdx shows it."""
 
 import json
 import os
-import sys
 
 import honker
 from sqlalchemy import create_engine, event, text
+
+from surface import qmark_to_named, run
 
 DB = os.environ["HONKER_TEST_DB"]
 engine = create_engine(f"sqlite:///{DB}")
@@ -22,33 +18,48 @@ def _load_honker(conn, _):
     conn.execute("SELECT honker_bootstrap()")
 
 
-with engine.connect() as conn:
-    # Bound parameters, not literals: SQLAlchemy's own binding layer is
-    # the thing under test, the same way better-sqlite3's REAL binding
-    # was for Node.
-    payload = json.dumps({"to": "alice@example.com"})
-    job_id = conn.execute(
-        text(
-            "SELECT honker_enqueue(:q, :p, NULL, NULL, :prio, :max, NULL) AS id"
-        ),
-        {"q": "emails", "p": payload, "prio": 0, "max": 3},
-    ).scalar_one()
-    assert job_id > 0, f"expected a job id, got {job_id}"
+def scalar(sql, args):
+    named, names = qmark_to_named(sql)
+    params = dict(zip(names, args))
+    with engine.connect() as conn:
+        result = conn.execute(text(named), params).scalar()
+        conn.commit()
+        return result
 
-    claimed = json.loads(
-        conn.execute(
-            text("SELECT honker_claim_batch(:q, :w, :n, :t) AS jobs"),
-            {"q": "emails", "w": "w1", "n": 8, "t": 300},
+
+run(scalar, "sa")
+
+
+def prove_atomicity():
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)"))
+
+    with engine.begin() as conn:
+        conn.execute(text("INSERT INTO orders (id, user_id) VALUES (:id, :uid)"), {"id": 42, "uid": 1})
+        job_id = conn.execute(
+            text("SELECT honker_enqueue(:q, :p, NULL, NULL, :prio, :max, NULL)"),
+            {"q": "sa_atomic", "p": json.dumps({"order_id": 42}), "prio": 0, "max": 3},
         ).scalar_one()
-    )
-    assert len(claimed) == 1, f"expected one claimed job, got {claimed}"
-    assert claimed[0]["id"] == job_id
-    assert json.loads(claimed[0]["payload"])["to"] == "alice@example.com"
 
-    acked = conn.execute(
-        text("SELECT honker_ack(:id, :w) AS ok"), {"id": job_id, "w": "w1"}
-    ).scalar_one()
-    assert acked == 1, "ack must match the claim"
+    with engine.connect() as conn:
+        assert conn.execute(text("SELECT COUNT(*) FROM orders WHERE id = 42")).scalar_one() == 1
+        job = conn.execute(text("SELECT honker_get_job(:id)"), {"id": job_id}).scalar()
+        assert job and "order_id" in job
 
-print("PASS sqlalchemy", file=sys.stderr)
+    with engine.connect() as conn:
+        trans = conn.begin()
+        conn.execute(text("INSERT INTO orders (id, user_id) VALUES (:id, :uid)"), {"id": 43, "uid": 1})
+        rolled = conn.execute(
+            text("SELECT honker_enqueue(:q, :p, NULL, NULL, :prio, :max, NULL)"),
+            {"q": "sa_atomic", "p": json.dumps({"order_id": 43}), "prio": 0, "max": 3},
+        ).scalar_one()
+        trans.rollback()
+
+    with engine.connect() as conn:
+        assert conn.execute(text("SELECT COUNT(*) FROM orders WHERE id = 43")).scalar_one() == 0
+        job = conn.execute(text("SELECT honker_get_job(:id)"), {"id": rolled}).scalar()
+        assert not job
+
+
+prove_atomicity()
 print("PASS sqlalchemy")

--- a/scripts/proof/orm/python/sqlalchemy_orm.py
+++ b/scripts/proof/orm/python/sqlalchemy_orm.py
@@ -1,5 +1,7 @@
 """SQLAlchemy, as guides/orm/python.mdx shows it."""
 
+# docs:start example
+
 import json
 import os
 
@@ -63,3 +65,4 @@ def prove_atomicity():
 
 prove_atomicity()
 print("PASS sqlalchemy")
+# docs:end example

--- a/scripts/proof/orm/python/sqlmodel_orm.py
+++ b/scripts/proof/orm/python/sqlmodel_orm.py
@@ -1,5 +1,7 @@
 """SQLModel, as guides/orm/python.mdx shows it."""
 
+# docs:start example
+
 import json
 import os
 
@@ -71,3 +73,4 @@ def prove_atomicity():
 
 prove_atomicity()
 print("PASS sqlmodel")
+# docs:end example

--- a/scripts/proof/orm/python/sqlmodel_orm.py
+++ b/scripts/proof/orm/python/sqlmodel_orm.py
@@ -1,9 +1,4 @@
-"""SQLModel, as guides/orm/python.mdx shows it.
-
-SQLModel's Session inherits from SQLAlchemy's, so this proves the
-documented SQLModel entry point reaches the same working extension
-rather than assuming the SQLAlchemy scenario covers it.
-"""
+"""SQLModel, as guides/orm/python.mdx shows it."""
 
 import json
 import os
@@ -11,6 +6,8 @@ import os
 import honker
 from sqlalchemy import event
 from sqlmodel import Session, create_engine, text
+
+from surface import qmark_to_named, run
 
 DB = os.environ["HONKER_TEST_DB"]
 engine = create_engine(f"sqlite:///{DB}")
@@ -22,26 +19,55 @@ def _load_honker(conn, _):
     conn.execute("SELECT honker_bootstrap()")
 
 
-with Session(engine) as session:
-    payload = json.dumps({"to": "alice@example.com"})
-    job_id = session.exec(
-        text("SELECT honker_enqueue(:q, :p, NULL, NULL, :prio, :max, NULL) AS id"),
-        params={"q": "emails", "p": payload, "prio": 0, "max": 3},
-    ).scalar_one()
-    assert job_id > 0, f"expected a job id, got {job_id}"
+def scalar(sql, args):
+    named, names = qmark_to_named(sql)
+    params = dict(zip(names, args))
+    with Session(engine) as session:
+        result = session.exec(text(named), params=params).scalar_one()
+        session.commit()
+        return result
 
-    claimed = json.loads(
-        session.exec(
-            text("SELECT honker_claim_batch(:q, :w, :n, :t) AS jobs"),
-            params={"q": "emails", "w": "w1", "n": 8, "t": 300},
+
+run(scalar, "sm")
+
+
+def prove_atomicity():
+    with Session(engine) as session:
+        session.execute(text("CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)"))
+        session.commit()
+
+    with Session(engine) as session:
+        session.execute(
+            text("INSERT INTO orders (id, user_id) VALUES (:id, :uid)"),
+            {"id": 42, "uid": 1},
+        )
+        job_id = session.exec(
+            text("SELECT honker_enqueue(:q, :p, NULL, NULL, :prio, :max, NULL)"),
+            params={"q": "sm_atomic", "p": json.dumps({"order_id": 42}), "prio": 0, "max": 3},
         ).scalar_one()
-    )
-    assert len(claimed) == 1
-    assert claimed[0]["id"] == job_id
+        session.commit()
 
-    acked = session.exec(
-        text("SELECT honker_ack(:id, :w) AS ok"), params={"id": job_id, "w": "w1"}
-    ).scalar_one()
-    assert acked == 1
+    with Session(engine) as session:
+        assert session.exec(text("SELECT COUNT(*) FROM orders WHERE id = 42")).scalar_one() == 1
+        job = session.exec(text("SELECT honker_get_job(:id)"), params={"id": job_id}).scalar_one()
+        assert job and "order_id" in job
 
+    with Session(engine) as session:
+        session.execute(
+            text("INSERT INTO orders (id, user_id) VALUES (:id, :uid)"),
+            {"id": 43, "uid": 1},
+        )
+        rolled = session.exec(
+            text("SELECT honker_enqueue(:q, :p, NULL, NULL, :prio, :max, NULL)"),
+            params={"q": "sm_atomic", "p": json.dumps({"order_id": 43}), "prio": 0, "max": 3},
+        ).scalar_one()
+        session.rollback()
+
+    with Session(engine) as session:
+        assert session.exec(text("SELECT COUNT(*) FROM orders WHERE id = 43")).scalar_one() == 0
+        job = session.exec(text("SELECT honker_get_job(:id)"), params={"id": rolled}).scalar_one()
+        assert not job
+
+
+prove_atomicity()
 print("PASS sqlmodel")

--- a/scripts/proof/orm/python/surface.py
+++ b/scripts/proof/orm/python/surface.py
@@ -1,0 +1,123 @@
+"""Run the shared ORM SQL surface through a bound-parameter scalar()."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable
+
+
+def qmark_to_named(sql: str) -> tuple[str, list[str]]:
+    """Turn `?` placeholders into `:p0`, `:p1`, ... for SQLAlchemy."""
+    names: list[str] = []
+    out: list[str] = []
+    n = 0
+    for ch in sql:
+        if ch == "?":
+            name = f"p{n}"
+            names.append(name)
+            out.append(f":{name}")
+            n += 1
+        else:
+            out.append(ch)
+    return "".join(out), names
+
+
+def catalog_path() -> Path:
+    env = os.environ.get("HONKER_ORM_SURFACE")
+    if env:
+        p = Path(env)
+        if not p.is_file():
+            raise FileNotFoundError(f"HONKER_ORM_SURFACE={env} is not a file")
+        return p
+    here = Path(__file__).resolve().parent
+    for candidate in (here / "surface.json", here.parent / "surface.json"):
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError("surface.json not found; set HONKER_ORM_SURFACE")
+
+
+def load_catalog() -> dict:
+    return json.loads(catalog_path().read_text())
+
+
+def as_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        raise AssertionError(f"expected int, got {value!r}")
+    return int(value)
+
+
+def as_text(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+def resolve(token: Any, prefix: str, variables: dict[str, Any]) -> Any:
+    if not isinstance(token, str):
+        return token
+    if token.startswith("$ns:"):
+        return f"{prefix}_{token[4:]}"
+    if token.startswith("$json:"):
+        keys = token[6:].split(",")
+        return json.dumps([as_int(variables[k]) for k in keys])
+    if token.startswith("$"):
+        return variables[token[1:]]
+    return token
+
+
+def resolve_text(text: str, prefix: str, variables: dict[str, Any]) -> str:
+    out = text
+    for key, value in variables.items():
+        out = out.replace(f"${key}", as_text(value))
+    return out.replace("$ns:", f"{prefix}_")
+
+
+def check(expect: dict, result: Any, prefix: str, variables: dict[str, Any]) -> None:
+    kind = expect["kind"]
+    if kind == "int_gt":
+        assert as_int(result) > expect["n"], f"got {result!r}"
+    elif kind == "int_eq":
+        assert as_int(result) == expect["n"], f"got {result!r}"
+    elif kind == "int_ge":
+        assert as_int(result) >= expect["n"], f"got {result!r}"
+    elif kind == "int_gt_ref":
+        assert as_int(result) > as_int(variables[expect["ref"]]), f"got {result!r}"
+    elif kind == "eq_ref":
+        assert as_int(result) == as_int(variables[expect["ref"]]), f"got {result!r}"
+    elif kind == "json_len":
+        parsed = json.loads(as_text(result))
+        assert len(parsed) == expect["n"], f"got {result!r}"
+    elif kind == "json_id_eq_ref":
+        parsed = json.loads(as_text(result))
+        assert len(parsed) == 1, f"got {result!r}"
+        assert as_int(parsed[0]["id"]) == as_int(variables[expect["ref"]]), f"got {result!r}"
+    elif kind == "contains":
+        needle = resolve_text(expect["s"], prefix, variables)
+        assert needle in as_text(result), f"{needle!r} not in {result!r}"
+    elif kind == "empty_string":
+        text = "" if result is None else as_text(result)
+        assert text == "", f"expected empty string, got {result!r}"
+    elif kind == "is_null":
+        assert result is None, f"expected NULL, got {result!r}"
+    else:
+        raise AssertionError(f"unknown expect kind {kind}")
+
+
+def run(scalar: Callable[[str, list[Any]], Any], prefix: str) -> None:
+    catalog = load_catalog()
+    variables: dict[str, Any] = {}
+    for step in catalog["steps"]:
+        args = [resolve(arg, prefix, variables) for arg in step["args"]]
+        try:
+            result = scalar(step["sql"], args)
+        except Exception as exc:
+            raise AssertionError(f"{step['id']} failed: {exc}") from exc
+        if "store" in step:
+            variables[step["store"]] = result
+        if "expect" in step:
+            try:
+                check(step["expect"], result, prefix, variables)
+            except AssertionError as exc:
+                raise AssertionError(f"{step['id']}: {exc}") from exc

--- a/scripts/proof/orm/ruby/Gemfile
+++ b/scripts/proof/orm/ruby/Gemfile
@@ -4,3 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 8.0"
 gem "sqlite3", "~> 2.6"
+# Ruby 4 dropped fiddle from default gems. The honker gem uses it to
+# resolve the bundled extension. CI's 3.4 still has it; this keeps the
+# proof runnable on 4.
+gem "fiddle"

--- a/scripts/proof/orm/ruby/Gemfile.lock
+++ b/scripts/proof/orm/ruby/Gemfile.lock
@@ -1,0 +1,101 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (8.1.3.1)
+      activesupport (= 8.1.3.1)
+    activerecord (8.1.3.1)
+      activemodel (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
+      timeout (>= 0.4.0)
+    activesupport (8.1.3.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    concurrent-ruby (1.3.8)
+    connection_pool (3.0.2)
+    drb (2.2.3)
+    fiddle (1.1.8)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    json (2.21.2)
+    logger (1.7.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    prism (1.9.0)
+    securerandom (0.4.1)
+    sqlite3 (2.9.6-aarch64-linux-gnu)
+    sqlite3 (2.9.6-aarch64-linux-musl)
+    sqlite3 (2.9.6-arm-linux-gnu)
+    sqlite3 (2.9.6-arm-linux-musl)
+    sqlite3 (2.9.6-arm64-darwin)
+    sqlite3 (2.9.6-x86-linux-gnu)
+    sqlite3 (2.9.6-x86-linux-musl)
+    sqlite3 (2.9.6-x86_64-darwin)
+    sqlite3 (2.9.6-x86_64-linux-gnu)
+    sqlite3 (2.9.6-x86_64-linux-musl)
+    timeout (0.6.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.1.1)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  activerecord (~> 8.0)
+  fiddle
+  sqlite3 (~> 2.6)
+
+CHECKSUMS
+  activemodel (8.1.3.1) sha256=99cc02ce2faec371d14440949d85787ebd23a907c9baef0a9d4bcd4d21888f88
+  activerecord (8.1.3.1) sha256=0a2fb6c28f4938f6b013a3a549bec0a7e37d535f3dc8990e804bcc3258c0403b
+  activesupport (8.1.3.1) sha256=85458765f25ea48b9019c46b6bb3fa5683197bf4280d9f06710a6e8d7a831376
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  fiddle (1.1.8) sha256=7fa8ee3627271497f3add5503acdbc3f40b32f610fc1cf49634f083ef3f32eee
+  i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  sqlite3 (2.9.6-aarch64-linux-gnu) sha256=d8b1f7d23efd7abac285775a9566562fc7debfef79d594e3a20354406fb7907c
+  sqlite3 (2.9.6-aarch64-linux-musl) sha256=3579e1c98cdc7ff5c3722847bb63ed4e1efb7ff675cb5e1e48ef2d4da5fb3bc9
+  sqlite3 (2.9.6-arm-linux-gnu) sha256=33541500e3615da02afe54a9cc38b17a6985d3cf9d8b76d6d0a83002f114e7ec
+  sqlite3 (2.9.6-arm-linux-musl) sha256=c5490af48bb228fefa54314e9541375c3907e70f8109f3881b5ff97e1c93ae33
+  sqlite3 (2.9.6-arm64-darwin) sha256=849b5d7f795e60fe25076d62c72dd722beb45b3850b516ad978d60ee848ec15b
+  sqlite3 (2.9.6-x86-linux-gnu) sha256=fbaa9f46f9708f57dd8a459b37fc269f9613e0cacf1547df01aa439cc45c20c0
+  sqlite3 (2.9.6-x86-linux-musl) sha256=6715026fbb5530e810b28ef43b9c4f84cd3c991f67b9d808a31fcc32b847abbd
+  sqlite3 (2.9.6-x86_64-darwin) sha256=b5842fea77781c14da03fa7bc0feb82db03a69e135affcb6f5399cbd2797a5f3
+  sqlite3 (2.9.6-x86_64-linux-gnu) sha256=613188ce02f614126ddbc38c5e217ccffd6306d0dcd9adca9764547aa890a634
+  sqlite3 (2.9.6-x86_64-linux-musl) sha256=d493b11818a3573387a1d56e1ee8fa00da23a683a7a1cc063e7a0feeed843abf
+  timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+
+BUNDLED WITH
+  4.0.11

--- a/scripts/proof/orm/ruby/active_record_proof.rb
+++ b/scripts/proof/orm/ruby/active_record_proof.rb
@@ -1,4 +1,5 @@
 # ActiveRecord, as guides/orm/ruby.mdx shows it.
+# docs:start example
 
 require "json"
 require "active_record"
@@ -117,3 +118,4 @@ job = conn.exec_query("SELECT honker_get_job(?)", "get", [rolled]).rows.first.fi
 raise "rollback left a job" unless job.to_s == ""
 
 puts "PASS ruby-activerecord"
+# docs:end example

--- a/scripts/proof/orm/ruby/active_record_proof.rb
+++ b/scripts/proof/orm/ruby/active_record_proof.rb
@@ -1,9 +1,4 @@
-# ActiveRecord, as guides/orm/ruby.mdx shows it: the sqlite3 adapter's
-# `extensions:` key fed from Honker.extension_path, then
-# honker_bootstrap once after connect.
-#
-# The doc shows this as database.yml; establish_connection takes the
-# same hash, so this is the same code path without a Rails app.
+# ActiveRecord, as guides/orm/ruby.mdx shows it.
 
 require "json"
 require "active_record"
@@ -21,29 +16,104 @@ ActiveRecord::Base.establish_connection(
 conn = ActiveRecord::Base.connection
 conn.execute("SELECT honker_bootstrap()")
 
-# Bound parameters throughout, so the adapter's own binding is what is
-# exercised rather than values interpolated into SQL text.
-payload = JSON.generate({ "to" => "alice@example.com" })
+catalog_path = ENV["HONKER_ORM_SURFACE"] || File.expand_path("../surface.json", __dir__)
+catalog = JSON.parse(File.read(catalog_path))
 
-id = conn.exec_query(
-  "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL) AS id",
-  "enqueue",
-  [ "emails", payload, 0, 3 ]
-).rows.first.first
-raise "expected a job id, got #{id.inspect}" unless id.is_a?(Integer) && id > 0
+def as_int(value)
+  Integer(value)
+end
 
-claimed_json = conn.exec_query(
-  "SELECT honker_claim_batch(?, ?, ?, ?) AS jobs",
-  "claim",
-  [ "emails", "w1", 8, 300 ]
-).rows.first.first
-claimed = JSON.parse(claimed_json)
-raise "expected one claimed job, got #{claimed_json}" unless claimed.length == 1
-raise "claimed the wrong job: #{claimed_json}" unless claimed.first["id"] == id
+def as_text(value)
+  value.nil? ? "" : value.to_s
+end
 
-acked = conn.exec_query(
-  "SELECT honker_ack(?, ?) AS ok", "ack", [ id, "w1" ]
-).rows.first.first
-raise "ack must match the claim, got #{acked.inspect}" unless acked == 1
+def resolve(token, prefix, vars)
+  return token unless token.is_a?(String)
+  return "#{prefix}_#{token[4..]}" if token.start_with?("$ns:")
+  if token.start_with?("$json:")
+    ids = token[6..].split(",").map { |k| as_int(vars.fetch(k)) }
+    return JSON.generate(ids)
+  end
+  return vars.fetch(token[1..]) if token.start_with?("$")
+  token
+end
+
+def resolve_text(text, prefix, vars)
+  out = text.dup
+  vars.each { |k, v| out = out.gsub("$#{k}", as_text(v)) }
+  out.gsub("$ns:", "#{prefix}_")
+end
+
+def check(expect, result, prefix, vars)
+  case expect["kind"]
+  when "int_gt" then raise "got #{result.inspect}" unless as_int(result) > expect["n"]
+  when "int_eq" then raise "got #{result.inspect}" unless as_int(result) == expect["n"]
+  when "int_ge" then raise "got #{result.inspect}" unless as_int(result) >= expect["n"]
+  when "int_gt_ref" then raise "got #{result.inspect}" unless as_int(result) > as_int(vars.fetch(expect["ref"]))
+  when "eq_ref" then raise "got #{result.inspect}" unless as_int(result) == as_int(vars.fetch(expect["ref"]))
+  when "json_len"
+    parsed = JSON.parse(as_text(result))
+    raise "got #{result.inspect}" unless parsed.length == expect["n"]
+  when "json_id_eq_ref"
+    parsed = JSON.parse(as_text(result))
+    raise "got #{result.inspect}" unless parsed.length == 1 && as_int(parsed[0]["id"]) == as_int(vars.fetch(expect["ref"]))
+  when "contains"
+    needle = resolve_text(expect["s"], prefix, vars)
+    raise "#{needle.inspect} not in #{result.inspect}" unless as_text(result).include?(needle)
+  when "empty_string"
+    raise "expected empty string, got #{result.inspect}" unless as_text(result) == ""
+  when "is_null"
+    raise "expected NULL, got #{result.inspect}" unless result.nil?
+  else
+    raise "unknown expect kind #{expect["kind"]}"
+  end
+end
+
+vars = {}
+catalog.fetch("steps").each do |step|
+  args = step.fetch("args").map { |a| resolve(a, "rb", vars) }
+  begin
+    result = conn.exec_query(step.fetch("sql"), step.fetch("id"), args).rows.first&.first
+  rescue StandardError => e
+    raise "#{step["id"]} failed: #{e}"
+  end
+  vars[step["store"]] = result if step["store"]
+  if step["expect"]
+    begin
+      check(step["expect"], result, "rb", vars)
+    rescue StandardError => e
+      raise "#{step["id"]}: #{e}"
+    end
+  end
+end
+
+conn.execute("CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)")
+
+job_id = nil
+ActiveRecord::Base.transaction do
+  conn.exec_query("INSERT INTO orders (id, user_id) VALUES (?, ?)", "ins", [42, 1])
+  job_id = conn.exec_query(
+    "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+    "enq",
+    ["rb_atomic", JSON.generate({ "order_id" => 42 }), 0, 3]
+  ).rows.first.first
+end
+raise "missing committed order" unless conn.select_value("SELECT COUNT(*) FROM orders WHERE id = 42") == 1
+job = conn.exec_query("SELECT honker_get_job(?)", "get", [job_id]).rows.first.first
+raise "missing committed job" unless job.to_s.include?("order_id")
+
+rolled = nil
+ActiveRecord::Base.transaction do
+  conn.exec_query("INSERT INTO orders (id, user_id) VALUES (?, ?)", "ins", [43, 1])
+  rolled = conn.exec_query(
+    "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+    "enq",
+    ["rb_atomic", JSON.generate({ "order_id" => 43 }), 0, 3]
+  ).rows.first.first
+  raise ActiveRecord::Rollback
+end
+raise "rollback left an order" unless conn.select_value("SELECT COUNT(*) FROM orders WHERE id = 43") == 0
+job = conn.exec_query("SELECT honker_get_job(?)", "get", [rolled]).rows.first.first
+raise "rollback left a job" unless job.to_s == ""
 
 puts "PASS ruby-activerecord"

--- a/scripts/proof/orm/rust/catalog.rs
+++ b/scripts/proof/orm/rust/catalog.rs
@@ -1,0 +1,149 @@
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+const CATALOG: &str = include_str!("../surface.json");
+
+fn as_int(value: &Value) -> Result<i64, String> {
+    match value {
+        Value::Number(n) => n
+            .as_i64()
+            .or_else(|| n.as_f64().map(|f| f as i64))
+            .ok_or_else(|| format!("expected int, got {value}")),
+        Value::String(s) => s.parse().map_err(|e| format!("{e}")),
+        _ => Err(format!("expected int, got {value}")),
+    }
+}
+
+fn as_text(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+fn resolve(token: &Value, prefix: &str, vars: &HashMap<String, Value>) -> Result<Value, String> {
+    let Some(s) = token.as_str() else {
+        return Ok(token.clone());
+    };
+    if let Some(name) = s.strip_prefix("$ns:") {
+        return Ok(Value::String(format!("{prefix}_{name}")));
+    }
+    if let Some(keys) = s.strip_prefix("$json:") {
+        let ids: Result<Vec<i64>, String> = keys
+            .split(',')
+            .map(|k| as_int(vars.get(k).ok_or_else(|| format!("missing {k}"))?))
+            .collect();
+        return Ok(Value::String(serde_json::to_string(&ids?).unwrap()));
+    }
+    if let Some(name) = s.strip_prefix('$') {
+        return vars
+            .get(name)
+            .cloned()
+            .ok_or_else(|| format!("missing {name}"));
+    }
+    Ok(Value::String(s.to_string()))
+}
+
+fn resolve_text(text: &str, prefix: &str, vars: &HashMap<String, Value>) -> String {
+    let mut out = text.to_string();
+    for (k, v) in vars {
+        out = out.replace(&format!("${k}"), &as_text(v));
+    }
+    out.replace("$ns:", &format!("{prefix}_"))
+}
+
+fn check(
+    expect: &Value,
+    result: &Value,
+    prefix: &str,
+    vars: &HashMap<String, Value>,
+) -> Result<(), String> {
+    let kind = expect["kind"].as_str().ok_or("missing kind")?;
+    match kind {
+        "int_gt" => {
+            if as_int(result)? <= expect["n"].as_i64().unwrap() {
+                return Err(format!("got {result}"));
+            }
+        }
+        "int_eq" => {
+            if as_int(result)? != expect["n"].as_i64().unwrap() {
+                return Err(format!("got {result}"));
+            }
+        }
+        "int_ge" => {
+            if as_int(result)? < expect["n"].as_i64().unwrap() {
+                return Err(format!("got {result}"));
+            }
+        }
+        "int_gt_ref" => {
+            let refn = as_int(&vars[expect["ref"].as_str().unwrap()])?;
+            if as_int(result)? <= refn {
+                return Err(format!("got {result}"));
+            }
+        }
+        "eq_ref" => {
+            let refn = as_int(&vars[expect["ref"].as_str().unwrap()])?;
+            if as_int(result)? != refn {
+                return Err(format!("got {result}"));
+            }
+        }
+        "json_len" => {
+            let parsed: Value = serde_json::from_str(&as_text(result)).map_err(|e| e.to_string())?;
+            if parsed.as_array().map(Vec::len) != Some(expect["n"].as_u64().unwrap() as usize) {
+                return Err(format!("got {result}"));
+            }
+        }
+        "json_id_eq_ref" => {
+            let parsed: Value = serde_json::from_str(&as_text(result)).map_err(|e| e.to_string())?;
+            let arr = parsed.as_array().ok_or_else(|| format!("got {result}"))?;
+            let refn = as_int(&vars[expect["ref"].as_str().unwrap()])?;
+            if arr.len() != 1 || as_int(&arr[0]["id"])? != refn {
+                return Err(format!("got {result}"));
+            }
+        }
+        "contains" => {
+            let needle = resolve_text(expect["s"].as_str().unwrap(), prefix, vars);
+            if !as_text(result).contains(&needle) {
+                return Err(format!("{needle} not in {result}"));
+            }
+        }
+        "empty_string" => {
+            if !as_text(result).is_empty() {
+                return Err(format!("expected empty string, got {result}"));
+            }
+        }
+        "is_null" => {
+            if !result.is_null() {
+                return Err(format!("expected NULL, got {result}"));
+            }
+        }
+        other => return Err(format!("unknown expect kind {other}")),
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn run_catalog(
+    prefix: &str,
+    mut scalar: impl FnMut(&str, Vec<Value>) -> Result<Value, String>,
+) -> Result<(), String> {
+    let catalog: Value = serde_json::from_str(CATALOG).map_err(|e| e.to_string())?;
+    let mut vars: HashMap<String, Value> = HashMap::new();
+    for step in catalog["steps"].as_array().unwrap() {
+        let sql = step["sql"].as_str().unwrap();
+        let mut args = Vec::new();
+        for arg in step["args"].as_array().unwrap() {
+            args.push(resolve(arg, prefix, &vars)?);
+        }
+        let id = step["id"].as_str().unwrap();
+        let result = scalar(sql, args).map_err(|e| format!("{id} failed: {e}"))?;
+        if let Some(store) = step["store"].as_str() {
+            vars.insert(store.to_string(), result.clone());
+        }
+        if !step["expect"].is_null() {
+            check(&step["expect"], &result, prefix, &vars).map_err(|e| format!("{id}: {e}"))?;
+        }
+    }
+    Ok(())
+}

--- a/scripts/proof/orm/rust/diesel/Cargo.toml
+++ b/scripts/proof/orm/rust/diesel/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "honker-orm-proof-diesel"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+diesel = { version = "2.3", features = ["sqlite", "returning_clauses_for_sqlite_3_35"] }
+libsqlite3-sys = "0.38"
+libloading = "0.9"
+serde_json = "1.0"

--- a/scripts/proof/orm/rust/diesel/src/main.rs
+++ b/scripts/proof/orm/rust/diesel/src/main.rs
@@ -1,4 +1,5 @@
 //! Diesel, as guides/orm/rust.mdx shows it.
+// docs:start example
 
 include!("../../catalog.rs");
 
@@ -158,3 +159,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("PASS rust-diesel");
     Ok(())
 }
+// docs:end example

--- a/scripts/proof/orm/rust/diesel/src/main.rs
+++ b/scripts/proof/orm/rust/diesel/src/main.rs
@@ -1,0 +1,155 @@
+//! Diesel, as guides/orm/rust.mdx shows it.
+
+include!("../../catalog.rs");
+
+use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Integer, Nullable, Text};
+use diesel::sqlite::{Sqlite, SqliteConnection};
+use libloading::Library;
+use std::os::raw::{c_char, c_int};
+
+#[derive(QueryableByName)]
+struct IdRow {
+    #[diesel(sql_type = BigInt)]
+    id: i64,
+}
+
+#[derive(QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    n: i64,
+}
+
+#[derive(QueryableByName)]
+struct JobRow {
+    #[diesel(sql_type = Text)]
+    job: String,
+}
+
+type ExtensionInit = unsafe extern "C" fn(
+    *mut libsqlite3_sys::sqlite3,
+    *mut *mut c_char,
+    *const libsqlite3_sys::sqlite3_api_routines,
+) -> c_int;
+
+fn open_honker(
+    database_url: &str,
+    extension_path: &str,
+) -> Result<(SqliteConnection, Library), Box<dyn std::error::Error>> {
+    let library = unsafe { Library::new(extension_path)? };
+    let init: ExtensionInit = unsafe { *library.get(b"sqlite3_honkerext_init")? };
+    let rc = unsafe { libsqlite3_sys::sqlite3_auto_extension(Some(init)) };
+    if rc != libsqlite3_sys::SQLITE_OK {
+        return Err(format!("sqlite3_auto_extension failed: {rc}").into());
+    }
+
+    let connection = SqliteConnection::establish(database_url);
+    unsafe { libsqlite3_sys::sqlite3_cancel_auto_extension(Some(init)) };
+    Ok((connection?, library))
+}
+
+#[derive(QueryableByName)]
+struct ScalarRow {
+    #[diesel(sql_type = Text)]
+    value: String,
+}
+
+fn diesel_scalar(
+    conn: &mut SqliteConnection,
+    sql: &str,
+    args: Vec<Value>,
+) -> Result<Value, String> {
+    let wrapped = format!(
+        "WITH scalar(value) AS ({sql}) \
+         SELECT json_object('type', typeof(value), 'value', value) AS value FROM scalar"
+    );
+    let mut query = sql_query(wrapped).into_boxed::<Sqlite>();
+    for arg in args {
+        query = match arg {
+            Value::Null => query.bind::<Nullable<Text>, _>(None::<String>),
+            Value::Number(n) => {
+                query.bind::<BigInt, _>(n.as_i64().ok_or_else(|| format!("bad number {n}"))?)
+            }
+            Value::String(s) => query.bind::<Text, _>(s),
+            other => return Err(format!("cannot bind {other}")),
+        };
+    }
+    let row: ScalarRow = query.get_result(conn).map_err(|e| e.to_string())?;
+    let envelope: Value = serde_json::from_str(&row.value).map_err(|e| e.to_string())?;
+    match envelope["type"].as_str() {
+        Some("null") => Ok(Value::Null),
+        Some("integer") => Ok(json!(envelope["value"].as_i64().unwrap())),
+        Some("real") => Ok(json!(envelope["value"].as_f64().unwrap() as i64)),
+        _ => Ok(envelope["value"].clone()),
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = std::env::var("HONKER_TEST_DB")?;
+    let ext = std::env::var("HONKER_EXTENSION_PATH")?;
+
+    let (mut conn, _honker_library) = open_honker(&db, &ext)?;
+    sql_query("SELECT honker_bootstrap()").execute(&mut conn)?;
+
+    run_catalog("di", |sql, args| diesel_scalar(&mut conn, sql, args))?;
+
+    sql_query("CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)")
+        .execute(&mut conn)?;
+
+    let committed = conn.transaction(|conn| {
+        sql_query("INSERT INTO orders (id, user_id) VALUES (?, ?)")
+            .bind::<Integer, _>(42)
+            .bind::<Integer, _>(1)
+            .execute(conn)?;
+        sql_query("SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL) AS id")
+            .bind::<Text, _>("di_atomic")
+            .bind::<Text, _>(r#"{"order_id":42}"#)
+            .bind::<BigInt, _>(0_i64)
+            .bind::<BigInt, _>(3_i64)
+            .get_result::<IdRow>(conn)
+            .map(|row| row.id)
+    })?;
+
+    let n: CountRow =
+        sql_query("SELECT COUNT(*) AS n FROM orders WHERE id = 42").get_result(&mut conn)?;
+    assert_eq!(n.n, 1, "missing committed order");
+    let job: JobRow = sql_query("SELECT honker_get_job(?) AS job")
+        .bind::<BigInt, _>(committed)
+        .get_result(&mut conn)?;
+    assert!(job.job.contains("order_id"), "{}", job.job);
+
+    let mut rolled = None;
+    let tx_res: Result<(), diesel::result::Error> = conn.transaction(|conn| {
+        sql_query("INSERT INTO orders (id, user_id) VALUES (?, ?)")
+            .bind::<Integer, _>(43)
+            .bind::<Integer, _>(1)
+            .execute(conn)?;
+        rolled = Some(
+            sql_query("SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL) AS id")
+                .bind::<Text, _>("di_atomic")
+                .bind::<Text, _>(r#"{"order_id":43}"#)
+                .bind::<BigInt, _>(0_i64)
+                .bind::<BigInt, _>(3_i64)
+                .get_result::<IdRow>(conn)?
+                .id,
+        );
+        Err(diesel::result::Error::RollbackTransaction)
+    });
+    assert!(
+        matches!(tx_res, Err(diesel::result::Error::RollbackTransaction)),
+        "expected rollback, got {tx_res:?}"
+    );
+    let rolled = rolled.expect("enqueue before rollback");
+
+    let n: CountRow =
+        sql_query("SELECT COUNT(*) AS n FROM orders WHERE id = 43").get_result(&mut conn)?;
+    assert_eq!(n.n, 0, "rollback left an order");
+    let job: JobRow = sql_query("SELECT honker_get_job(?) AS job")
+        .bind::<BigInt, _>(rolled)
+        .get_result(&mut conn)?;
+    assert_eq!(job.job, "", "rollback left a job");
+
+    println!("PASS rust-diesel");
+    Ok(())
+}

--- a/scripts/proof/orm/rust/diesel/src/main.rs
+++ b/scripts/proof/orm/rust/diesel/src/main.rs
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let db = std::env::var("HONKER_TEST_DB")?;
     let ext = std::env::var("HONKER_EXTENSION_PATH")?;
 
-    let (mut conn, _honker_library) = open_honker(&db, &ext)?;
+    let (mut conn, honker_library) = open_honker(&db, &ext)?;
     sql_query("SELECT honker_bootstrap()").execute(&mut conn)?;
 
     run_catalog("di", |sql, args| diesel_scalar(&mut conn, sql, args))?;
@@ -149,6 +149,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .bind::<BigInt, _>(rolled)
         .get_result(&mut conn)?;
     assert_eq!(job.job, "", "rollback left a job");
+
+    // The extension's callbacks remain registered on Diesel's SQLite handle.
+    // Close that handle before unloading the dynamic library that owns them.
+    drop(conn);
+    drop(honker_library);
 
     println!("PASS rust-diesel");
     Ok(())

--- a/scripts/proof/orm/rust/seaorm/Cargo.toml
+++ b/scripts/proof/orm/rust/seaorm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "honker-orm-proof-seaorm"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+sea-orm = { version = "2.0", features = ["sqlx-sqlite", "runtime-tokio"] }
+serde_json = "1.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/scripts/proof/orm/rust/seaorm/src/main.rs
+++ b/scripts/proof/orm/rust/seaorm/src/main.rs
@@ -1,0 +1,176 @@
+//! SeaORM, as guides/orm/rust.mdx shows it.
+
+include!("../../catalog.rs");
+
+use sea_orm::{
+    ConnectionTrait, Database, DbBackend, DbErr, QueryResult, Statement, TransactionTrait,
+    Value as SeaValue,
+};
+fn to_sea(value: &Value) -> SeaValue {
+    match value {
+        Value::Null => SeaValue::BigInt(None),
+        Value::Number(n) => SeaValue::BigInt(n.as_i64()),
+        Value::String(s) => SeaValue::String(Some(s.clone())),
+        other => SeaValue::String(Some(other.to_string())),
+    }
+}
+
+fn cell(row: &QueryResult) -> Value {
+    if let Ok(v) = row.try_get_by_index::<Option<i64>>(0) {
+        return match v {
+            Some(n) => json!(n),
+            None => Value::Null,
+        };
+    }
+    if let Ok(v) = row.try_get_by_index::<Option<String>>(0) {
+        return match v {
+            Some(s) => Value::String(s),
+            None => Value::Null,
+        };
+    }
+    Value::Null
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db_path = std::env::var("HONKER_TEST_DB")?;
+    let ext = std::env::var("HONKER_EXTENSION_PATH")?;
+
+    let mut opt = sea_orm::ConnectOptions::new(format!("sqlite://{db_path}?mode=rwc"));
+    let ext_clone = ext.clone();
+    opt.map_sqlx_sqlite_opts(move |opts| unsafe { opts.extension(ext_clone.clone()) });
+    let db = Database::connect(opt).await?;
+    db.execute_unprepared("SELECT honker_bootstrap()").await?;
+
+    let catalog: Value = serde_json::from_str(CATALOG)?;
+    let mut vars: HashMap<String, Value> = HashMap::new();
+    for step in catalog["steps"].as_array().unwrap() {
+        let sql = step["sql"].as_str().unwrap();
+        let args: Vec<SeaValue> = step["args"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|arg| resolve(arg, "so", &vars).map(|v| to_sea(&v)))
+            .collect::<Result<_, _>>()?;
+        let id = step["id"].as_str().unwrap();
+        let stmt = Statement::from_sql_and_values(DbBackend::Sqlite, sql, args);
+        let row = db
+            .query_one_raw(stmt)
+            .await
+            .map_err(|e| format!("{id} failed: {e}"))?
+            .ok_or_else(|| format!("{id} returned no row"))?;
+        let result = cell(&row);
+        if let Some(store) = step["store"].as_str() {
+            vars.insert(store.to_string(), result.clone());
+        }
+        if !step["expect"].is_null() {
+            check(&step["expect"], &result, "so", &vars).map_err(|e| format!("{id}: {e}"))?;
+        }
+    }
+
+    db.execute_unprepared("CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)")
+        .await?;
+
+    let committed = db
+        .transaction::<_, i64, DbErr>(|txn| {
+            Box::pin(async move {
+                txn.execute_raw(Statement::from_sql_and_values(
+                    DbBackend::Sqlite,
+                    "INSERT INTO orders (id, user_id) VALUES (?, ?)",
+                    [42i32.into(), 1i32.into()],
+                ))
+                .await?;
+                let row = txn
+                    .query_one_raw(Statement::from_sql_and_values(
+                        DbBackend::Sqlite,
+                        "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+                        [
+                            "so_atomic".into(),
+                            r#"{"order_id":42}"#.into(),
+                            0i64.into(),
+                            3i64.into(),
+                        ],
+                    ))
+                    .await?
+                    .ok_or_else(|| DbErr::Custom("missing enqueue row".into()))?;
+                row.try_get_by_index(0)
+            })
+        })
+        .await?;
+
+    let n = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT COUNT(*) FROM orders WHERE id = 42",
+            [],
+        ))
+        .await?
+        .ok_or("missing count")?;
+    assert_eq!(n.try_get_by_index::<i64>(0)?, 1, "missing committed order");
+    let job = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT honker_get_job(?)",
+            [committed.into()],
+        ))
+        .await?
+        .ok_or("missing job")?;
+    let job_s: String = job.try_get_by_index(0)?;
+    assert!(job_s.contains("order_id"), "{job_s}");
+
+    let rolled = std::sync::Arc::new(std::sync::Mutex::new(None::<i64>));
+    let rolled_slot = rolled.clone();
+    let tx_res = db
+        .transaction::<_, (), DbErr>(|txn| {
+            Box::pin(async move {
+                txn.execute_raw(Statement::from_sql_and_values(
+                    DbBackend::Sqlite,
+                    "INSERT INTO orders (id, user_id) VALUES (?, ?)",
+                    [43i32.into(), 1i32.into()],
+                ))
+                .await?;
+                let row = txn
+                    .query_one_raw(Statement::from_sql_and_values(
+                        DbBackend::Sqlite,
+                        "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+                        [
+                            "so_atomic".into(),
+                            r#"{"order_id":43}"#.into(),
+                            0i64.into(),
+                            3i64.into(),
+                        ],
+                    ))
+                    .await?
+                    .ok_or_else(|| DbErr::Custom("missing enqueue row".into()))?;
+                let id: i64 = row.try_get_by_index(0)?;
+                *rolled_slot.lock().unwrap() = Some(id);
+                Err(DbErr::Custom("rollback".into()))
+            })
+        })
+        .await;
+    assert!(tx_res.is_err(), "expected rollback, got {tx_res:?}");
+    let rolled = rolled.lock().unwrap().expect("enqueue before rollback");
+
+    let n = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT COUNT(*) FROM orders WHERE id = 43",
+            [],
+        ))
+        .await?
+        .ok_or("missing count")?;
+    assert_eq!(n.try_get_by_index::<i64>(0)?, 0, "rollback left an order");
+    let job = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT honker_get_job(?)",
+            [rolled.into()],
+        ))
+        .await?
+        .ok_or("missing job")?;
+    let job_s: String = job.try_get_by_index(0).unwrap_or_default();
+    assert_eq!(job_s, "", "rollback left a job");
+
+    println!("PASS rust-seaorm");
+    Ok(())
+}

--- a/scripts/proof/orm/rust/seaorm/src/main.rs
+++ b/scripts/proof/orm/rust/seaorm/src/main.rs
@@ -1,4 +1,5 @@
 //! SeaORM, as guides/orm/rust.mdx shows it.
+// docs:start example
 
 include!("../../catalog.rs");
 
@@ -174,3 +175,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("PASS rust-seaorm");
     Ok(())
 }
+// docs:end example

--- a/scripts/proof/orm/rust/src/main.rs
+++ b/scripts/proof/orm/rust/src/main.rs
@@ -1,9 +1,23 @@
-//! sqlx, as guides/orm/rust.mdx shows it: SqliteConnectOptions::extension
-//! with a path from HONKER_EXTENSION_PATH.
+//! sqlx, as guides/orm/rust.mdx shows it.
 
-use sqlx::sqlite::SqliteConnectOptions;
-use sqlx::{ConnectOptions, Executor, Row};
+include!("../catalog.rs");
+
+use sqlx::sqlite::{SqliteConnectOptions, SqliteRow};
+use sqlx::{ConnectOptions, Connection, Executor, Row};
 use std::str::FromStr;
+
+fn cell(row: &SqliteRow) -> Value {
+    if let Ok(v) = row.try_get::<Option<i64>, _>(0) {
+        return v.map_or(Value::Null, |n| json!(n));
+    }
+    if let Ok(v) = row.try_get::<Option<f64>, _>(0) {
+        return v.map_or(Value::Null, |n| json!(n as i64));
+    }
+    if let Ok(v) = row.try_get::<Option<String>, _>(0) {
+        return v.map_or(Value::Null, Value::String);
+    }
+    Value::Null
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,37 +30,91 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = opts.connect().await?;
     conn.execute("SELECT honker_bootstrap()").await?;
 
-    // Bound parameters, so sqlx's own binding is what is exercised.
-    let payload = serde_json::json!({ "to": "alice@example.com" }).to_string();
-    let id: i64 = sqlx::query("SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL) AS id")
-        .bind("emails")
-        .bind(&payload)
+    let catalog: Value = serde_json::from_str(CATALOG)?;
+    let mut vars: HashMap<String, Value> = HashMap::new();
+    for step in catalog["steps"].as_array().unwrap() {
+        let sql = step["sql"].as_str().unwrap();
+        let mut query = sqlx::query(sql);
+        for arg in step["args"].as_array().unwrap() {
+            let resolved = resolve(arg, "rs", &vars)?;
+            query = match resolved {
+                Value::Null => query.bind(None::<String>),
+                Value::Number(n) => query.bind(n.as_i64().unwrap()),
+                Value::String(s) => query.bind(s),
+                other => return Err(format!("cannot bind {other}").into()),
+            };
+        }
+        let id = step["id"].as_str().unwrap();
+        let row = query
+            .fetch_one(&mut conn)
+            .await
+            .map_err(|e| format!("{id} failed: {e}"))?;
+        let result = cell(&row);
+        if let Some(store) = step["store"].as_str() {
+            vars.insert(store.to_string(), result.clone());
+        }
+        if !step["expect"].is_null() {
+            check(&step["expect"], &result, "rs", &vars).map_err(|e| format!("{id}: {e}"))?;
+        }
+    }
+
+    conn.execute("CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)")
+        .await?;
+    let mut tx = conn.begin().await?;
+    sqlx::query("INSERT INTO orders (id, user_id) VALUES (?, ?)")
+        .bind(42_i64)
+        .bind(1_i64)
+        .execute(&mut *tx)
+        .await?;
+    let committed: i64 = sqlx::query("SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)")
+        .bind("rs_atomic")
+        .bind(r#"{"order_id":42}"#)
         .bind(0_i64)
         .bind(3_i64)
-        .fetch_one(&mut conn)
+        .fetch_one(&mut *tx)
         .await?
         .get(0);
-    assert!(id > 0, "expected a job id, got {id}");
+    tx.commit().await?;
 
-    let claimed_json: String = sqlx::query("SELECT honker_claim_batch(?, ?, ?, ?) AS jobs")
-        .bind("emails")
-        .bind("w1")
-        .bind(8_i64)
-        .bind(300_i64)
+    let n: i64 = sqlx::query("SELECT COUNT(*) FROM orders WHERE id = 42")
         .fetch_one(&mut conn)
         .await?
         .get(0);
-    let claimed: serde_json::Value = serde_json::from_str(&claimed_json)?;
-    assert_eq!(claimed.as_array().map(Vec::len), Some(1), "got {claimed_json}");
-    assert_eq!(claimed[0]["id"].as_i64(), Some(id));
+    assert_eq!(n, 1);
+    let job: String = sqlx::query("SELECT honker_get_job(?)")
+        .bind(committed)
+        .fetch_one(&mut conn)
+        .await?
+        .get(0);
+    assert!(job.contains("order_id"), "{job}");
 
-    let acked: i64 = sqlx::query("SELECT honker_ack(?, ?) AS ok")
-        .bind(id)
-        .bind("w1")
+    let mut tx = conn.begin().await?;
+    sqlx::query("INSERT INTO orders (id, user_id) VALUES (?, ?)")
+        .bind(43_i64)
+        .bind(1_i64)
+        .execute(&mut *tx)
+        .await?;
+    let rolled: i64 = sqlx::query("SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)")
+        .bind("rs_atomic")
+        .bind(r#"{"order_id":43}"#)
+        .bind(0_i64)
+        .bind(3_i64)
+        .fetch_one(&mut *tx)
+        .await?
+        .get(0);
+    tx.rollback().await?;
+
+    let n: i64 = sqlx::query("SELECT COUNT(*) FROM orders WHERE id = 43")
         .fetch_one(&mut conn)
         .await?
         .get(0);
-    assert_eq!(acked, 1, "ack must match the claim");
+    assert_eq!(n, 0, "rollback left an order");
+    let job: String = sqlx::query("SELECT honker_get_job(?)")
+        .bind(rolled)
+        .fetch_one(&mut conn)
+        .await?
+        .get(0);
+    assert_eq!(job, "", "rollback left a job");
 
     println!("PASS rust-sqlx");
     Ok(())

--- a/scripts/proof/orm/rust/src/main.rs
+++ b/scripts/proof/orm/rust/src/main.rs
@@ -1,4 +1,5 @@
 //! sqlx, as guides/orm/rust.mdx shows it.
+// docs:start example
 
 include!("../catalog.rs");
 
@@ -119,3 +120,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("PASS rust-sqlx");
     Ok(())
 }
+// docs:end example

--- a/scripts/proof/orm/surface.json
+++ b/scripts/proof/orm/surface.json
@@ -1,0 +1,391 @@
+{
+  "functions": [
+    "honker_enqueue",
+    "honker_claim_batch",
+    "honker_ack",
+    "honker_ack_batch",
+    "honker_retry",
+    "honker_fail",
+    "honker_heartbeat",
+    "honker_sweep_expired",
+    "honker_queue_next_claim_at",
+    "honker_cancel",
+    "honker_get_job",
+    "honker_stream_publish",
+    "honker_stream_read_since",
+    "honker_stream_save_offset",
+    "honker_stream_get_offset",
+    "notify",
+    "honker_scheduler_register",
+    "honker_scheduler_unregister",
+    "honker_scheduler_tick",
+    "honker_scheduler_soonest",
+    "honker_scheduler_pause",
+    "honker_scheduler_resume",
+    "honker_scheduler_list",
+    "honker_scheduler_update",
+    "honker_cron_next_after",
+    "honker_lock_acquire",
+    "honker_lock_release",
+    "honker_lock_renew",
+    "honker_rate_limit_try",
+    "honker_rate_limit_sweep",
+    "honker_result_save",
+    "honker_result_get",
+    "honker_result_sweep"
+  ],
+  "steps": [
+    {
+      "id": "enqueue",
+      "sql": "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+      "args": ["$ns:q", "{\"to\":\"alice@example.com\"}", 0, 3],
+      "store": "job_id",
+      "expect": {"kind": "int_gt", "n": 0}
+    },
+    {
+      "id": "get_job",
+      "sql": "SELECT honker_get_job(?)",
+      "args": ["$job_id"],
+      "expect": {"kind": "contains", "s": "alice@example.com"}
+    },
+    {
+      "id": "claim",
+      "sql": "SELECT honker_claim_batch(?, ?, ?, ?)",
+      "args": ["$ns:q", "w1", 8, 300],
+      "expect": {"kind": "json_id_eq_ref", "ref": "job_id"}
+    },
+    {
+      "id": "heartbeat",
+      "sql": "SELECT honker_heartbeat(?, ?, ?)",
+      "args": ["$job_id", "w1", 60],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "ack",
+      "sql": "SELECT honker_ack(?, ?)",
+      "args": ["$job_id", "w1"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "get_job_after_ack",
+      "sql": "SELECT honker_get_job(?)",
+      "args": ["$job_id"],
+      "expect": {"kind": "empty_string"}
+    },
+    {
+      "id": "enqueue_opts",
+      "sql": "SELECT honker_enqueue(?, ?, NULL, ?, ?, ?, ?)",
+      "args": ["$ns:q", "{\"to\":\"bob@example.com\"}", 0, 10, 3, 3600],
+      "store": "job_opt",
+      "expect": {"kind": "int_gt", "n": 0}
+    },
+    {
+      "id": "claim_opts",
+      "sql": "SELECT honker_claim_batch(?, ?, ?, ?)",
+      "args": ["$ns:q", "w1", 8, 300],
+      "expect": {"kind": "json_id_eq_ref", "ref": "job_opt"}
+    },
+    {
+      "id": "ack_opts",
+      "sql": "SELECT honker_ack(?, ?)",
+      "args": ["$job_opt", "w1"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "enqueue_retry",
+      "sql": "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+      "args": ["$ns:qr", "{\"n\":1}", 0, 2],
+      "store": "job_r",
+      "expect": {"kind": "int_gt", "n": 0}
+    },
+    {
+      "id": "claim_retry",
+      "sql": "SELECT honker_claim_batch(?, ?, ?, ?)",
+      "args": ["$ns:qr", "w1", 8, 300],
+      "expect": {"kind": "json_id_eq_ref", "ref": "job_r"}
+    },
+    {
+      "id": "retry",
+      "sql": "SELECT honker_retry(?, ?, ?, ?)",
+      "args": ["$job_r", "w1", 0, "transient"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "reclaim",
+      "sql": "SELECT honker_claim_batch(?, ?, ?, ?)",
+      "args": ["$ns:qr", "w1", 8, 300],
+      "expect": {"kind": "json_id_eq_ref", "ref": "job_r"}
+    },
+    {
+      "id": "fail",
+      "sql": "SELECT honker_fail(?, ?, ?)",
+      "args": ["$job_r", "w1", "permanent"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "enqueue_cancel",
+      "sql": "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+      "args": ["$ns:qc", "{\"n\":1}", 0, 3],
+      "store": "job_c",
+      "expect": {"kind": "int_gt", "n": 0}
+    },
+    {
+      "id": "cancel",
+      "sql": "SELECT honker_cancel(?)",
+      "args": ["$job_c"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "cancel_idempotent",
+      "sql": "SELECT honker_cancel(?)",
+      "args": ["$job_c"],
+      "expect": {"kind": "int_eq", "n": 0}
+    },
+    {
+      "id": "get_cancelled",
+      "sql": "SELECT honker_get_job(?)",
+      "args": ["$job_c"],
+      "expect": {"kind": "empty_string"}
+    },
+    {
+      "id": "claim_cancelled",
+      "sql": "SELECT honker_claim_batch(?, ?, ?, ?)",
+      "args": ["$ns:qc", "w1", 8, 300],
+      "expect": {"kind": "json_len", "n": 0}
+    },
+    {
+      "id": "enqueue_b1",
+      "sql": "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+      "args": ["$ns:qb", "{\"i\":1}", 0, 3],
+      "store": "b1",
+      "expect": {"kind": "int_gt", "n": 0}
+    },
+    {
+      "id": "enqueue_b2",
+      "sql": "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+      "args": ["$ns:qb", "{\"i\":2}", 0, 3],
+      "store": "b2",
+      "expect": {"kind": "int_gt", "n": 0}
+    },
+    {
+      "id": "claim_batch",
+      "sql": "SELECT honker_claim_batch(?, ?, ?, ?)",
+      "args": ["$ns:qb", "w1", 8, 300],
+      "expect": {"kind": "json_len", "n": 2}
+    },
+    {
+      "id": "ack_batch",
+      "sql": "SELECT honker_ack_batch(?, ?)",
+      "args": ["$json:b1,b2", "w1"],
+      "expect": {"kind": "int_eq", "n": 2}
+    },
+    {
+      "id": "enqueue_expired",
+      "sql": "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, ?)",
+      "args": ["$ns:qe", "{\"i\":1}", 0, 3, -1],
+      "store": "job_e",
+      "expect": {"kind": "int_gt", "n": 0}
+    },
+    {
+      "id": "sweep_expired",
+      "sql": "SELECT honker_sweep_expired(?)",
+      "args": ["$ns:qe"],
+      "expect": {"kind": "int_ge", "n": 1}
+    },
+    {
+      "id": "next_claim_at",
+      "sql": "SELECT honker_queue_next_claim_at(?)",
+      "args": ["$ns:qe"],
+      "expect": {"kind": "int_ge", "n": 0}
+    },
+    {
+      "id": "notify",
+      "sql": "SELECT notify(?, ?)",
+      "args": ["$ns:ch", "{\"id\":42}"],
+      "expect": {"kind": "int_gt", "n": 0}
+    },
+    {
+      "id": "stream_publish",
+      "sql": "SELECT honker_stream_publish(?, ?, ?)",
+      "args": ["$ns:topic", null, "{\"e\":1}"],
+      "store": "off1",
+      "expect": {"kind": "int_gt", "n": 0}
+    },
+    {
+      "id": "stream_publish_key",
+      "sql": "SELECT honker_stream_publish(?, ?, ?)",
+      "args": ["$ns:topic", "k1", "{\"e\":2}"],
+      "store": "off2",
+      "expect": {"kind": "int_gt_ref", "ref": "off1"}
+    },
+    {
+      "id": "stream_read",
+      "sql": "SELECT honker_stream_read_since(?, ?, ?)",
+      "args": ["$ns:topic", 0, 10],
+      "expect": {"kind": "json_len", "n": 2}
+    },
+    {
+      "id": "stream_save_offset",
+      "sql": "SELECT honker_stream_save_offset(?, ?, ?)",
+      "args": ["$ns:cons", "$ns:topic", "$off1"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "stream_get_offset",
+      "sql": "SELECT honker_stream_get_offset(?, ?)",
+      "args": ["$ns:cons", "$ns:topic"],
+      "expect": {"kind": "eq_ref", "ref": "off1"}
+    },
+    {
+      "id": "cron_next",
+      "sql": "SELECT honker_cron_next_after(?, ?)",
+      "args": ["@every 1s", 1000],
+      "expect": {"kind": "int_gt", "n": 1000}
+    },
+    {
+      "id": "sched_register",
+      "sql": "SELECT honker_scheduler_register(?, ?, ?, ?, ?, ?, ?)",
+      "args": ["$ns:sched", "$ns:sq", "@every 60s", "{\"ok\":true}", 0, null, 3],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "sched_soonest",
+      "sql": "SELECT honker_scheduler_soonest()",
+      "args": [],
+      "store": "boundary",
+      "expect": {"kind": "int_gt", "n": 0}
+    },
+    {
+      "id": "sched_tick",
+      "sql": "SELECT honker_scheduler_tick(?)",
+      "args": ["$boundary"],
+      "expect": {"kind": "contains", "s": "$ns:sched"}
+    },
+    {
+      "id": "sched_list",
+      "sql": "SELECT honker_scheduler_list()",
+      "args": [],
+      "expect": {"kind": "contains", "s": "$ns:sched"}
+    },
+    {
+      "id": "sched_pause",
+      "sql": "SELECT honker_scheduler_pause(?)",
+      "args": ["$ns:sched"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "sched_resume",
+      "sql": "SELECT honker_scheduler_resume(?)",
+      "args": ["$ns:sched"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "sched_update",
+      "sql": "SELECT honker_scheduler_update(?, ?, ?, ?, ?, ?)",
+      "args": ["$ns:sched", "@every 30s", null, null, null, 0],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "sched_unregister",
+      "sql": "SELECT honker_scheduler_unregister(?)",
+      "args": ["$ns:sched"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "lock_acquire",
+      "sql": "SELECT honker_lock_acquire(?, ?, ?)",
+      "args": ["$ns:lock", "alice", 60],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "lock_held",
+      "sql": "SELECT honker_lock_acquire(?, ?, ?)",
+      "args": ["$ns:lock", "bob", 60],
+      "expect": {"kind": "int_eq", "n": 0}
+    },
+    {
+      "id": "lock_renew",
+      "sql": "SELECT honker_lock_renew(?, ?, ?)",
+      "args": ["$ns:lock", "alice", 60],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "lock_renew_other",
+      "sql": "SELECT honker_lock_renew(?, ?, ?)",
+      "args": ["$ns:lock", "bob", 60],
+      "expect": {"kind": "int_eq", "n": 0}
+    },
+    {
+      "id": "lock_release_other",
+      "sql": "SELECT honker_lock_release(?, ?)",
+      "args": ["$ns:lock", "bob"],
+      "expect": {"kind": "int_eq", "n": 0}
+    },
+    {
+      "id": "lock_release",
+      "sql": "SELECT honker_lock_release(?, ?)",
+      "args": ["$ns:lock", "alice"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "lock_reacquire",
+      "sql": "SELECT honker_lock_acquire(?, ?, ?)",
+      "args": ["$ns:lock", "bob", 60],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "lock_release_bob",
+      "sql": "SELECT honker_lock_release(?, ?)",
+      "args": ["$ns:lock", "bob"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "rate_ok_1",
+      "sql": "SELECT honker_rate_limit_try(?, ?, ?)",
+      "args": ["$ns:rl", 2, 60],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "rate_ok_2",
+      "sql": "SELECT honker_rate_limit_try(?, ?, ?)",
+      "args": ["$ns:rl", 2, 60],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "rate_blocked",
+      "sql": "SELECT honker_rate_limit_try(?, ?, ?)",
+      "args": ["$ns:rl", 2, 60],
+      "expect": {"kind": "int_eq", "n": 0}
+    },
+    {
+      "id": "rate_sweep",
+      "sql": "SELECT honker_rate_limit_sweep(?)",
+      "args": [1],
+      "expect": {"kind": "int_ge", "n": 0}
+    },
+    {
+      "id": "result_save",
+      "sql": "SELECT honker_result_save(?, ?, ?)",
+      "args": ["$job_id", "{\"ok\":true}", 0],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "result_get",
+      "sql": "SELECT honker_result_get(?)",
+      "args": ["$job_id"],
+      "expect": {"kind": "contains", "s": "ok"}
+    },
+    {
+      "id": "result_missing",
+      "sql": "SELECT honker_result_get(?)",
+      "args": [999999999],
+      "expect": {"kind": "is_null"}
+    },
+    {
+      "id": "result_sweep",
+      "sql": "SELECT honker_result_sweep()",
+      "args": [],
+      "expect": {"kind": "int_ge", "n": 0}
+    }
+  ]
+}

--- a/scripts/proof/orm/sync_docs.py
+++ b/scripts/proof/orm/sync_docs.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Keep ORM guide code blocks byte-for-byte equal to executable proofs.
+
+Proof sources delimit snippets with ``docs:start NAME`` and ``docs:end NAME``
+comments. Guide blocks name that source and region in an ``orm-proof`` HTML
+comment. This script replaces the fenced body from the source, or fails in
+``--check`` mode when a guide has drifted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[2]
+DOCS_ROOT = ROOT / "site/src/content/docs/guides/orm"
+
+BLOCK = re.compile(
+    r'(?P<header>\{/\* orm-proof source="(?P<source>[^"]+)" '
+    r'region="(?P<region>[^"]+)" \*/\}\n)'
+    r"```(?P<lang>[^\n]*)\n(?P<body>.*?)\n```\n"
+    r"(?P<footer>\{/\* /orm-proof \*/\})",
+    re.DOTALL,
+)
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def snippet(source: Path, region: str) -> str:
+    lines = source.read_text().splitlines()
+    start = [i for i, line in enumerate(lines) if f"docs:start {region}" in line]
+    end = [i for i, line in enumerate(lines) if f"docs:end {region}" in line]
+    if len(start) != 1 or len(end) != 1 or start[0] >= end[0]:
+        fail(
+            f"{source}: expected exactly one ordered docs:start/docs:end "
+            f"pair for {region!r}"
+        )
+    selected = lines[start[0] + 1 : end[0]]
+    while selected and not selected[0].strip():
+        selected.pop(0)
+    while selected and not selected[-1].strip():
+        selected.pop()
+    return "\n".join(selected)
+
+
+def render(path: Path) -> tuple[str, int]:
+    original = path.read_text()
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        source = (ROOT / match.group("source")).resolve()
+        if not source.is_relative_to(ROOT) or not source.is_file():
+            fail(f"{path}: invalid proof source {match.group('source')!r}")
+        body = snippet(source, match.group("region"))
+        count += 1
+        return (
+            f"{match.group('header')}```{match.group('lang')}\n{body}\n```\n"
+            f"{match.group('footer')}"
+        )
+
+    return BLOCK.sub(replace, original), count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    if not DOCS_ROOT.is_dir():
+        fail(
+            f"{DOCS_ROOT} is missing; initialize the site submodule before "
+            "checking executable documentation"
+        )
+
+    changed: list[Path] = []
+    blocks = 0
+    for path in sorted(DOCS_ROOT.glob("*.mdx")):
+        rendered, count = render(path)
+        blocks += count
+        if rendered != path.read_text():
+            changed.append(path)
+            if not args.check:
+                path.write_text(rendered)
+
+    if blocks == 0:
+        fail("no orm-proof blocks found")
+    if args.check and changed:
+        rel = ", ".join(str(path.relative_to(ROOT)) for path in changed)
+        fail(f"ORM guide snippets are stale: {rel}; run {Path(__file__).relative_to(ROOT)}")
+    verb = "checked" if args.check else "synced"
+    print(f"PASS orm-docs ({verb} {blocks} executable snippets)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add one shared 33-function ORM SQL surface catalog
- run that catalog through every documented integration that can load the extension
- prove ORM-owned commit and rollback atomicity with a business write plus honker_enqueue
- add sqlx, SeaORM, and Diesel executable consumer proofs
- wire every ORM proof into the existing pull_request CI workflow
- update the Node packaged-extension proof to cover better-sqlite3, Drizzle, and Kysely

## Automatic CI coverage
- Python matrix: SQLAlchemy, SQLModel, Django
- Node matrix: better-sqlite3, Drizzle, Kysely
- binding-smoke: database/sql, GORM, sqlx, SeaORM, Diesel, Microsoft.Data.Sqlite, Ecto, C++ sqlite3, ActiveRecord
- JVM job: JDBC, Hibernate, jOOQ, Exposed
- all jobs feed the required ci · all green aggregate

Prisma and Toasty remain documented as unable to load SQLite extensions. bun:sqlite uses the same documented connection API as better-sqlite3 and is not a separate CI job.

## Local verification
- PASS rust-sqlx
- PASS rust-seaorm
- PASS rust-diesel
- PASS orm-surface (33 functions, 16 atomicity proofs)
- cargo clippy --release for all three Rust proofs with -D warnings
- actionlint .github/workflows/ci.yml (existing SC1090 source warning ignored)
- docs: npm ci && npm run build

## Companion docs PR
- https://github.com/russellromney/honker-site/pull/7