### PR TITLE
Bump the .NET package to 0.5.1

### DIFF
--- a/packages/honker-dotnet/src/Honker/Honker.csproj
+++ b/packages/honker-dotnet/src/Honker/Honker.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Honker</RootNamespace>
     <IsPackable>true</IsPackable>
     <PackageId>Honker</PackageId>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <Authors>Russell Romney</Authors>
     <Description>SQLite queue, notify/listen, streams, scheduler, and outbox bindings for .NET via the Honker loadable extension.</Description>
     <PackageTags>sqlite;queue;pubsub;notify;listen;stream;outbox;scheduler</PackageTags>


### PR DESCRIPTION
NuGet 0.5.0 was published before #106 merged, so it has neither of that PR's transaction fixes.

## What 0.5.0 users have

`Database` shares one `SqliteConnection`. Before #106, `BeginTransaction` took the per-command lock only momentarily, so an unrelated command — a worker enqueue, a prune — could execute on that connection between `Begin` and `Commit` and get swept into a transaction it knew nothing about. It commits or rolls back with that transaction.

## Also included

The follow-up guard from my review of #106: a command that omits its transaction, issued from the thread that holds one, raises immediately instead of waiting forever on a gate only that thread can release. Regression test proved load-bearing — removing the guard fails it on a 5s timeout.

## Scope

.NET only. #106 touched no other published package.