### PR TITLE
Widen the kernel watcher shutdown bound to 300 ms

### DIFF
--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -3441,9 +3441,14 @@ while True:
         let _ = std::fs::remove_file(format!("{}-wal", tmp.display()));
         let _ = std::fs::remove_file(format!("{}-shm", tmp.display()));
 
+        // 300 ms = 6x RX_POLL_MS. The regression this guards is recv_timeout
+        // blocking on the safety-net interval, which lands at 500 ms or more,
+        // so this still catches it with room to spare. The old 150 ms bound
+        // was below CI scheduler jitter, not below the bug: it failed a
+        // Windows runner at 155 ms while the real failure is 3x further out.
         assert!(
-            elapsed < Duration::from_millis(150),
-            "kernel watcher shutdown took {elapsed:?}, expected < 150 ms \
+            elapsed < Duration::from_millis(300),
+            "kernel watcher shutdown took {elapsed:?}, expected < 300 ms \
              (RX_POLL_MS = 50 ms; if this exceeds 500 ms the recv_timeout \
              is blocking on the safety-net interval again)"
         );


### PR DESCRIPTION
`kernel_watcher_shutdown_is_responsive` failed a Windows runner at **155.8 ms** against a `< 150 ms` bound — on a PR that only moved a submodule pointer.

## Why the bound was wrong

The assertion message names the regression it exists to catch:

> if this exceeds 500 ms the recv_timeout is blocking on the safety-net interval again

So the fault shows at **500 ms or more**, but the bound fired at **150 ms**. That's not a tight guard on a real failure — it's inside CI scheduler jitter. It fires 3x before the thing it describes.

A timing bound that reddens `main` on unrelated changes trains people to hit re-run instead of reading it, which costs you the signal on the day it's real.

## The change

300 ms — 6x `RX_POLL_MS` (50 ms), still well under the 500 ms signature. The regression is caught with room to spare; runner jitter is not.

## Not touched

The JVM `crossProcessListenerWakeLatencyStaysBelowUserVisibleBounds` p90 bound also flaked this week (`[12, 12, 12, 12, 25, 30, 33, 47, 71, 96, 314, 372]` against `p90 < 250`). That one is different: p90 of 12 samples is effectively the second-worst of 12 process spawns, so it's an outlier by construction, and the number is a claim about user-visible latency. Worth deciding deliberately rather than folding into this.