### PR TITLE
Report JVM wake samples in iteration order on failure

### DIFF
--- a/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
+++ b/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
@@ -959,9 +959,18 @@ class HonkerJvmTest {
                 child.destroyForcibly();
             }
         }
+        // Keep iteration order for the failure message. Sorted samples say a
+        // tail exists but not where it came from: slow runs bunched at the
+        // start point at JIT or page-cache warmup, scattered ones at whatever
+        // else shares the runner. This has flaked on CI with a tail nobody
+        // could reproduce, and sorting threw away the half of the evidence
+        // that distinguishes those.
+        List<Long> inOrder = List.copyOf(samples);
         samples.sort(Long::compareTo);
-        assertTrue(percentile(samples, 0.50) < 50, "listener wake p50 was too slow: " + samples);
-        assertTrue(percentile(samples, 0.90) < 250, "listener wake p90 was too slow: " + samples);
+        assertTrue(percentile(samples, 0.50) < 50,
+            "listener wake p50 was too slow: sorted=" + samples + " byIteration=" + inOrder);
+        assertTrue(percentile(samples, 0.90) < 250,
+            "listener wake p90 was too slow: sorted=" + samples + " byIteration=" + inOrder);
     }
 
     @Test


### PR DESCRIPTION
`crossProcessListenerWakeLatencyStaysBelowUserVisibleBounds` flaked on a Linux runner:

```
listener wake p90 was too slow: [12, 12, 12, 12, 25, 30, 33, 47, 71, 96, 314, 372]
```

The message prints `samples` — but **after `sort()`**, so the only evidence a failure leaves behind can't distinguish the two likely causes. Slow runs bunched at the start mean JIT or page-cache warmup. Scattered ones mean contention from whatever else shares the runner. Those want different fixes, and sorting throws away the half of the data that tells them apart.

This reports both orders. Nothing about what's measured or asserted changes.

## What I ruled out

The obvious suspect: `System.nanoTime()` starts **before** `Honker.open(...)`, so every sample includes opening a connection — extension load, WAL setup — inside a number labelled "wake latency."

It doesn't hold up. That open measures **1 ms**, roughly 7% of a 14 ms sample, and the tail doesn't reproduce locally even with every core saturated:

```
idle          [12,12,12,13,13,14,14,14,14,14,14,15]
8 cpu hogs    [12,12,13,13,14,14,15,15,15,16,16,16]
```

Moving the open out of the timed window was the change I wrote first. It isn't justified: it chases 1 ms, and reusing a single long-lived publisher would quietly drop coverage of *a fresh connection's commit waking an existing listener* — a realistic short-lived-publisher pattern worth keeping.

So the threshold and the measurement both stay as they are until a failure names a cause. This PR just makes sure the next one can.