### PR TITLE
ci: enforce cross-process wake latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,51 @@ jobs:
           assert ratio >= 50, f'mmap-shm should be at least 50x faster than cached PRAGMA, got {ratio:.1f}x'
           "
 
+  wake-latency:
+    name: bench · cross-process wake latency (regression check)
+    if: github.event_name != 'pull_request'
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+          prefix-key: "v1-wake-bench-${{ hashFiles('honker-core/src/**/*.rs', 'honker-core/Cargo.toml', 'honker-extension/src/**/*.rs', 'honker-extension/Cargo.toml', 'packages/honker/src/**/*.rs', 'packages/honker/Cargo.toml') }}"
+      - name: Build Python binding
+        run: |
+          uv venv --python 3.12 .venv
+          uv pip install --python .venv/bin/python maturin
+          cargo build --locked --release -p honker-extension
+          scripts/copy-python-extension.sh
+          cd packages/honker
+          VIRTUAL_ENV="$GITHUB_WORKSPACE/.venv" "$GITHUB_WORKSPACE/.venv/bin/python" -m maturin develop --release
+      - name: Run cross-process wake bench
+        run: .venv/bin/python bench/wake_latency_bench.py --samples 500 | tee "$RUNNER_TEMP/wake-latency.json"
+      - name: Assert p50 cross-process wake stays below 5 ms
+        run: |
+          python - "$RUNNER_TEMP/wake-latency.json" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          result = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          bound_ms = 5.0
+          p50_ms = result["p50_ms"]
+          print(f"cross-process wake p50: {p50_ms:.3f} ms (bound: < {bound_ms:.1f} ms)")
+          if p50_ms >= bound_ms:
+              raise SystemExit(
+                  f"cross-process wake p50 regressed: {p50_ms:.3f} ms >= {bound_ms:.1f} ms"
+              )
+          PY
+
   python:
     name: python · honker
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,9 @@ jobs:
           cd packages/honker
           VIRTUAL_ENV="$GITHUB_WORKSPACE/.venv" "$GITHUB_WORKSPACE/.venv/bin/python" -m maturin develop --release
       - name: Run cross-process wake bench
-        run: .venv/bin/python bench/wake_latency_bench.py --samples 500 | tee "$RUNNER_TEMP/wake-latency.json"
+        run: |
+          set -o pipefail
+          .venv/bin/python bench/wake_latency_bench.py --samples 500 | tee "$RUNNER_TEMP/wake-latency.json"
       - name: Assert p50 cross-process wake stays below 5 ms
         run: |
           python - "$RUNNER_TEMP/wake-latency.json" <<'PY'
@@ -767,6 +769,7 @@ jobs:
       - lint
       - rust
       - perf-regression
+      - wake-latency
       - python
       - dotnet
       - node
@@ -787,10 +790,10 @@ jobs:
           import os
           import sys
 
-          # perf-regression is gated on `github.event_name != 'pull_request'`,
-          # so it legitimately reports "skipped" on every PR. Nothing else
-          # is allowed to skip.
-          MAY_SKIP = {"perf-regression"}
+          # perf-regression and wake-latency are gated on
+          # `github.event_name != 'pull_request'`, so they legitimately report
+          # "skipped" on every PR. Nothing else is allowed to skip.
+          MAY_SKIP = {"perf-regression", "wake-latency"}
 
           needs = json.loads(os.environ["NEEDS_JSON"])
           blocking = []

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -19,8 +19,17 @@ extension.
 | Bun `@russellthehippo/honker-bun` | CI | yes | yes | yes | yes | yes | extension C ABI |
 | Elixir `honker` | CI | yes | yes | notify yes, listen no | yes | yes | extension SQL handles |
 | C++ | CI | yes | yes | yes | yes | yes | extension C ABI |
-| JVM `dev.honker:honker` | local + clean consumer | yes | yes | yes | yes | yes | shared JVM watcher |
-| Kotlin `dev.honker:honker-kotlin` | local + clean consumer | wrapper | Flow wrapper | wrapper | wrapper | wrapper | JVM wrapper |
+| JVM `dev.honker:honker` | CI + local clean consumer | yes | yes | yes | yes | yes | shared JVM watcher |
+| Kotlin `dev.honker:honker-kotlin` | local + ORM CI | wrapper | Flow wrapper | wrapper | wrapper | wrapper | JVM wrapper |
+
+### Function Task Helpers
+
+| Binding | Named handler registry | Worker dispatcher | Convenience syntax |
+| --- | ---: | ---: | --- |
+| Python | yes | CLI and in-process | `@task`, `@periodic_task` |
+| JVM | yes | `runTasks` | explicit `TaskRegistry` / `TaskHandle` |
+| Kotlin | yes | `runTasks` | Kotlin helpers over the JVM registry |
+| Node, Rust, Go, Ruby, Bun, Elixir, .NET, C++ | no | no | queue and result primitives only |
 
 ## Extension Reach
 
@@ -147,8 +156,9 @@ Backend contract:
   Bun, Ruby, Elixir, and Ruby/Python interop
 - Packaged-install proof for Python, Node, Ruby, and .NET in clean
   throwaway consumers
-- JVM and Kotlin local Maven proof plus clean consumer proof outside the
-  repo
+- JVM package install/tests and the documented JVM ORM recipes in PR CI
+- Kotlin Exposed ORM recipe in PR CI; Kotlin wrapper package tests and clean
+  consumer proof remain local
 - Representative cross-language wake and table-behavior proofs
 - JVM watcher parity for stable `AUTO`/`PRAGMA_DATA_VERSION` and explicit
   experimental `MMAP_SHM` / `KERNEL_EVENTS`

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -166,6 +166,9 @@ Backend contract:
 ## Not Proven Yet
 
 - Every possible cross-language pair; CI covers representative pairs
+- Cross-binding named-consumer checkpoints involving Node. Its current stream
+  wrapper reverses topic and consumer at the offset SQL boundary, so its own
+  resume path works but another binding will not see the same checkpoint.
 - Long soak on every OS; scary nightly soaks Linux
 - Ruby and Elixir async listen parity with Python/Node/.NET/Rust/Go/Bun/C++
 - Published Maven Central proof for JVM/Kotlin

--- a/bench/README.md
+++ b/bench/README.md
@@ -60,7 +60,7 @@ O(n) shift-everything was the bottleneck, not the SQL.
 ### Wake / idle watcher
 
 ```
-cross-process notify/listen wake:      p50 ~= 0.7ms on M-series
+cross-process notify/listen wake:      p50 ~= 2.9ms on Apple M1 Pro (n=500)
 PRAGMA data_version poll cost:         ~3.5us/poll
 idle watcher cost at 1kHz:             ~3.5ms CPU/sec per Database
 ```

--- a/bench/README.md
+++ b/bench/README.md
@@ -61,8 +61,8 @@ O(n) shift-everything was the bottleneck, not the SQL.
 
 ```
 cross-process notify/listen wake:      p50 ~= 2.9ms on Apple M1 Pro (n=500)
-PRAGMA data_version poll cost:         ~3.5us/poll
-idle watcher cost at 1kHz:             ~3.5ms CPU/sec per Database
+PRAGMA data_version poll cost:         ~2.0us/poll
+idle watcher cost at 1kHz:             ~2.0ms CPU/sec per Database
 ```
 
 The wake path is intentionally boring: one `PRAGMA data_version` read

--- a/bench/wake_latency_bench.py
+++ b/bench/wake_latency_bench.py
@@ -17,9 +17,9 @@ the watcher has a stable baseline. Then repeats:
      subprocess which contains the wake timestamp in ms-since-epoch.
   3. Parent records `dt = wake_ts - t0`.
 
-Repeat N times, report p50 / p90 / p99. On M-series darwin expect
-~1–2 ms p50 (bounded by the 1 ms update-watcher cadence); Linux tends to
-run faster.
+Repeat N times, report p50 / p90 / p99. An Apple M1 Pro measured
+~2.9 ms p50 over 500 samples (bounded in part by the 1 ms update-watcher
+cadence); Linux tends to run faster.
 
 Run:
     python bench/wake_latency_bench.py --samples 500

--- a/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmChild.java
+++ b/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmChild.java
@@ -23,7 +23,7 @@ public final class HonkerJvmChild {
         if ("worker-marker".equals(mode)) {
             workerMarker(dbPath, extensionPath, readyPath, donePath);
         } else if ("listener-marker".equals(mode)) {
-            listenerMarker(dbPath, extensionPath, readyPath, donePath, WatcherBackend.PRAGMA_DATA_VERSION);
+            listenerStdoutMarker(dbPath, extensionPath, WatcherBackend.PRAGMA_DATA_VERSION);
         } else if ("listener-mmap-marker".equals(mode)) {
             listenerMarker(dbPath, extensionPath, readyPath, donePath, WatcherBackend.MMAP_SHM);
         } else if ("listener-kernel-marker".equals(mode)) {
@@ -71,6 +71,25 @@ public final class HonkerJvmChild {
                 System.exit(2);
             }
             Files.writeString(donePath, notification.payloadJson(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static void listenerStdoutMarker(Path dbPath, Path extensionPath, WatcherBackend backend) throws Exception {
+        try (Database db = Honker.open(dbPath, OpenOptions.builder()
+            .extensionPath(extensionPath)
+            .fallbackPollInterval(Duration.ofSeconds(30))
+            .watcherOptions(WatcherOptions.builder().backend(backend).build())
+            .build());
+             Listener listener = db.listen("multiprocess-listen")) {
+            System.out.println("READY");
+            System.out.flush();
+            Notification notification = listener.next(Duration.ofSeconds(10)).orElse(null);
+            if (notification == null) {
+                System.err.println("child listener timed out");
+                System.exit(2);
+            }
+            System.out.println("WAKE:" + notification.payloadJson());
+            System.out.flush();
         }
     }
 

--- a/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
+++ b/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
@@ -931,7 +931,7 @@ class HonkerJvmTest {
     }
 
     @Test
-    void crossProcessListenerWakeLatencyStaysBelowUserVisibleBounds() throws Exception {
+    void crossProcessListenerWakesFromWatcherNotFallbackPoll() throws Exception {
         Path dbPath = tmp.resolve("listener-latency.db");
         Path extension = NativeLoader.resolve(OpenOptions.defaults());
         try (Database db = Honker.open(dbPath, OpenOptions.builder().extensionPath(extension).build())) {
@@ -968,6 +968,19 @@ class HonkerJvmTest {
         // that distinguishes those.
         List<Long> inOrder = List.copyOf(samples);
         samples.sort(Long::compareTo);
+        // These bounds separate mechanisms, they do not police the published
+        // latency figure — bench/wake_latency_bench.py does that, gated at
+        // p50 < 5 ms in CI against 500 samples.
+        //
+        // A watcher that never fires cannot reach here at all: the child sets
+        // fallbackPollInterval to 30 s and gives up after 10 s, so it exits 2
+        // and child.waitFor() above fails. What these catch is the band in
+        // between — a watcher that still fires but has degraded to hundreds of
+        // milliseconds, which no exit code would notice.
+        //
+        // Deliberately loose. This runs on shared PR runners where absolute
+        // wall-clock assertions flake; tightening them toward the real ~3 ms
+        // buys no signal the bench does not already give and costs red builds.
         assertTrue(percentile(samples, 0.50) < 50,
             "listener wake p50 was too slow: sorted=" + samples + " byIteration=" + inOrder);
         assertTrue(percentile(samples, 0.90) < 250,

--- a/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
+++ b/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
@@ -3,6 +3,7 @@ package dev.honker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.BufferedReader;
 import java.nio.file.Path;
 import java.nio.file.Files;
 import java.nio.charset.StandardCharsets;
@@ -941,19 +942,19 @@ class HonkerJvmTest {
         for (int i = 0; i < 12; i++) {
             Path ready = tmp.resolve("listener-" + i + ".ready");
             Path done = tmp.resolve("listener-" + i + ".done");
-            Process child = startChild("listener-marker", dbPath, extension, ready, done);
-            try {
-                waitUntil(Duration.ofSeconds(5), () -> Files.isRegularFile(ready), "child listener should become ready");
-                long start = System.nanoTime();
+            Process child = startChildWithStdout("listener-marker", dbPath, extension, ready, done);
+            try (BufferedReader childOutput = child.inputReader(StandardCharsets.UTF_8)) {
+                assertEquals("READY", childOutput.readLine(), "child listener should become ready");
                 try (Database db = Honker.open(dbPath, OpenOptions.builder()
                     .extensionPath(extension)
                     .fallbackPollInterval(Duration.ofSeconds(30))
                     .build())) {
-                    db.notify("multiprocess-listen", "{\"sample\":" + i + "}");
+                    String payload = "{\"sample\":" + i + "}";
+                    long start = System.nanoTime();
+                    db.notify("multiprocess-listen", payload);
+                    assertEquals("WAKE:" + payload, childOutput.readLine(), "child listener should wake");
+                    samples.add(Duration.ofNanos(System.nanoTime() - start).toMillis());
                 }
-                waitUntil(Duration.ofSeconds(5), () -> Files.isRegularFile(done), "child listener should wake");
-                samples.add(Duration.ofNanos(System.nanoTime() - start).toMillis());
-                assertEquals("{\"sample\":" + i + "}", Files.readString(done, StandardCharsets.UTF_8));
                 assertEquals(0, child.waitFor());
             } finally {
                 child.destroyForcibly();
@@ -1156,6 +1157,14 @@ class HonkerJvmTest {
     }
 
     private static Process startChild(String mode, Path db, Path ext, Path ready, Path done) throws Exception {
+        return childProcess(mode, db, ext, ready, done).redirectErrorStream(true).start();
+    }
+
+    private static Process startChildWithStdout(String mode, Path db, Path ext, Path ready, Path done) throws Exception {
+        return childProcess(mode, db, ext, ready, done).start();
+    }
+
+    private static ProcessBuilder childProcess(String mode, Path db, Path ext, Path ready, Path done) {
         String java = Path.of(System.getProperty("java.home"), "bin", "java").toString();
         return new ProcessBuilder(
             java,
@@ -1167,7 +1176,7 @@ class HonkerJvmTest {
             ext.toString(),
             ready.toString(),
             done.toString()
-        ).redirectErrorStream(true).start();
+        );
     }
 
     private static long count(Database db, String sql) {

--- a/tests/test_cross_process_wake_latency.py
+++ b/tests/test_cross_process_wake_latency.py
@@ -125,7 +125,7 @@ def test_cross_process_wake_latency_p99_under_bound(tmp_path):
 
     p50 = percentile(times_ms, 0.5)
     p90 = percentile(times_ms, 0.9)
-    median_bound = 50.0   # real p50 ~= 1-2 ms on M-series
+    median_bound = 50.0   # real p50 ~= 2.9 ms on an Apple M1 Pro
     p90_bound = 750.0     # CI runners can schedule out subprocesses for 100+ ms
 
     assert p50 < median_bound, (


### PR DESCRIPTION
## Summary

- add a non-PR Linux CI job that gates 500-sample Python cross-process wake p50 below 5 ms
- make the latency job part of `ci · all green` while allowing its intentional PR skip
- enable `pipefail` so a crashing benchmark cannot pass through `tee`
- replace JVM latency file polling with blocking READY/WAKE markers and move database open outside the timed window
- rename the JVM test after the end-to-end watcher behavior it actually proves
- document language-specific task, listener, stream, pruning, and watcher capabilities
- advance the site submodule to the capability audit where Ruby and Elixir accurately remain `listen: wait-api`

Ruby and Elixir high-level listener implementations have been split into a separate stacked PR for focused lifecycle review.

## Measurements

- Apple M1 Pro, 500 samples: p50 2.889 ms, p90 4.856 ms, p99 16.392 ms
- GitHub ubuntu-latest, 500 samples: p50 2.959 ms; the 5 ms gate passed
- JVM before: p50 14 ms, samples 11-17 ms
- JVM after: p50 3 ms, samples 2-5 ms

## Verification

- the 500-sample workflow-dispatch gate passed
- the benchmark failure path is load-bearing through `pipefail`
- JVM cross-process listener proof passed
- site capability checker and build passed at the referenced submodule commit
