### PR TITLE
fix(node): migrate 0.4.6 stream checkpoints safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
             VENV_PY=.venv/bin/python
             ACTIVATE=.venv/bin/activate
           fi
-          uv pip install --python "$VENV_PY" maturin
+          uv pip install --python "$VENV_PY" maturin pytest pytest-xdist
           cd packages/honker
           . "../../$ACTIVATE"
           if [ "${{ runner.os }}" = "Windows" ]; then
@@ -378,6 +378,15 @@ jobs:
         run: |
           npm ci
           npx napi build --platform --release --features kernel-watcher,shm-fast-path
+      - name: Test Node ↔ Python stream checkpoint journeys
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            VENV_PY=.venv/Scripts/python.exe
+          else
+            VENV_PY=.venv/bin/python
+          fi
+          "$VENV_PY" -m pytest tests/test_node_python_interop.py -q --tb=short
       - name: Test (extension resolver — no addon load)
         working-directory: packages/honker-node
         shell: bash
@@ -458,9 +467,6 @@ jobs:
         with:
           use-cache: false
       - uses: oven-sh/setup-bun@v2
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "22"
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"
@@ -633,15 +639,6 @@ jobs:
         run: |
           . .venv/bin/activate
           python -m pytest tests/test_ruby_python_interop.py -q --tb=short
-      - name: Track Node ↔ Python stream-checkpoint defect
-        shell: bash
-        run: |
-          cd packages/honker-node
-          npm ci
-          npx napi build --platform --release --features kernel-watcher,shm-fast-path
-          cd ../..
-          . .venv/bin/activate
-          python -m pytest tests/test_node_python_interop.py -q --tb=short -rxX
 
   jvm:
     name: jvm · honker + documented ORM recipes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,9 @@ jobs:
           else
             maturin develop --release --features kernel-watcher,shm-fast-path
           fi
+      - name: Check Node package version alignment
+        shell: bash
+        run: python3 scripts/proof/check-node-version-alignment.py
       - name: Build .node binary
         working-directory: packages/honker-node
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,6 +458,9 @@ jobs:
         with:
           use-cache: false
       - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"
@@ -630,6 +633,15 @@ jobs:
         run: |
           . .venv/bin/activate
           python -m pytest tests/test_ruby_python_interop.py -q --tb=short
+      - name: Track Node ↔ Python stream-checkpoint defect
+        shell: bash
+        run: |
+          cd packages/honker-node
+          npm ci
+          npx napi build --platform --release --features kernel-watcher,shm-fast-path
+          cd ../..
+          . .venv/bin/activate
+          python -m pytest tests/test_node_python_interop.py -q --tb=short -rxX
 
   jvm:
     name: jvm · honker + documented ORM recipes

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -118,6 +118,7 @@ jobs:
         working-directory: packages/honker-node
         run: |
           npm ci
+          python3 ../../scripts/proof/check-node-version-alignment.py
           npm exec -- napi artifacts --output-dir . --npm-dir npm
           ../../scripts/copy-node-extension.sh
           ../../scripts/proof/check-node-native-artifacts.sh honker.*.node npm/*/*.node

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -159,3 +159,14 @@ Backend contract:
 - Long soak on every OS; scary nightly soaks Linux
 - Ruby and Elixir async listen parity with Python/Node/.NET/Rust/Go/Bun/C++
 - Published Maven Central proof for JVM/Kotlin
+
+## Known Defects
+
+- **Node stream checkpoints are not interoperable in
+  `@russellthehippo/honker-node@0.4.6`.** The wrapper passes `(topic,
+  consumer)` to SQL functions whose contract is `(consumer, topic)`. Node's
+  own save/resume path is self-consistent, but Python and other bindings read a
+  different `_honker_stream_consumers` row. Publishing and reading stream
+  events are unaffected. The strict expected-failure interop test in
+  `tests/test_node_python_interop.py` tracks this until the migration-safe fix
+  described in `ROADMAP.md` ships.

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -160,13 +160,16 @@ Backend contract:
 - Ruby and Elixir async listen parity with Python/Node/.NET/Rust/Go/Bun/C++
 - Published Maven Central proof for JVM/Kotlin
 
-## Known Defects
+## Compatibility Notes
 
-- **Node stream checkpoints are not interoperable in
-  `@russellthehippo/honker-node@0.4.6`.** The wrapper passes `(topic,
-  consumer)` to SQL functions whose contract is `(consumer, topic)`. Node's
-  own save/resume path is self-consistent, but Python and other bindings read a
-  different `_honker_stream_consumers` row. Publishing and reading stream
-  events are unaffected. The strict expected-failure interop test in
-  `tests/test_node_python_interop.py` tracks this until the migration-safe fix
-  described in `ROADMAP.md` ships.
+- **Node 0.4.6 stream checkpoints use transposed keys.** Its wrapper passes
+  `(topic, consumer)` to SQL functions whose contract is `(consumer, topic)`.
+  Publishing and explicit-offset reads are unaffected; named-consumer
+  `readFromConsumer()` and `subscribe()` cannot share 0.4.6 resume positions
+  with another binding.
+- Current Node source writes the canonical key. On first checkpoint access it
+  transactionally copies a legacy row only when that row's offset belongs to a
+  retained event in the requested stream. Canonical rows win, and unverifiable
+  alpha-era state fails loudly instead of guessing. Node/Python publish,
+  checkpoint, resume, subscription, legacy-upgrade, and transactional-save
+  journeys run in the Node CI matrix.

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -167,9 +167,10 @@ Backend contract:
   Publishing and explicit-offset reads are unaffected; named-consumer
   `readFromConsumer()` and `subscribe()` cannot share 0.4.6 resume positions
   with another binding.
-- Current Node source writes the canonical key. On first checkpoint access it
+- Node 0.5.0 writes the canonical key. On first checkpoint access it
   transactionally copies a legacy row only when that row's offset belongs to a
   retained event in the requested stream. Canonical rows win, and unverifiable
-  alpha-era state fails loudly instead of guessing. Node/Python publish,
-  checkpoint, resume, subscription, legacy-upgrade, and transactional-save
-  journeys run in the Node CI matrix.
+  alpha-era reads fail loudly instead of guessing. An explicit `saveOffset` or
+  `saveOffsetTx` establishes canonical progress and is the supported reset
+  path. Node/Python publish, checkpoint, resume, subscription, legacy-upgrade,
+  recovery, and transactional-save journeys run in the Node CI matrix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,16 @@
   stream. The migration is transactional, canonical state wins, and the old
   row remains available for rollback.
 - Unverifiable alpha-era checkpoint state fails with
-  `CheckpointMigrationError` instead of silently replaying or skipping events.
-  Concurrent use of Node 0.4.6 and a corrected release for the same consumer is
-  unsupported during upgrade.
+  `CheckpointMigrationError` on reads instead of silently replaying or skipping
+  events. An explicit `saveOffset` or `saveOffsetTx` establishes canonical
+  progress, so resetting to zero never requires raw SQL. Concurrent use of Node
+  0.4.6 and a corrected release for the same consumer is unsupported during
+  upgrade.
 - Cross-runtime tests publish real events and prove Python→Node and Node→Python
   named-consumer resume, Node subscription persistence, legacy 0.4.6 migration,
   and transactional commit/rollback.
+- The Node package and its platform-native packages advance to 0.5.0 for this
+  on-disk resume behavior change.
 
 ## Unreleased — extension reach for every binding (Phase Beavis)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## Unreleased — Node checkpoint interoperability (Phase Robinson)
+
+- Node stream checkpoint calls now use the shared SQL ABI's canonical
+  `(consumer, topic)` key order, so `saveOffset`, `saveOffsetTx`, `getOffset`,
+  `readFromConsumer`, and `subscribe` interoperate with every other binding.
+- Checkpoints written by Node 0.4.6 migrate automatically on first access when
+  their saved offset can be verified against a retained event in the requested
+  stream. The migration is transactional, canonical state wins, and the old
+  row remains available for rollback.
+- Unverifiable alpha-era checkpoint state fails with
+  `CheckpointMigrationError` instead of silently replaying or skipping events.
+  Concurrent use of Node 0.4.6 and a corrected release for the same consumer is
+  unsupported during upgrade.
+- Cross-runtime tests publish real events and prove Python→Node and Node→Python
+  named-consumer resume, Node subscription persistence, legacy 0.4.6 migration,
+  and transactional commit/rollback.
+
 ## Unreleased — extension reach for every binding (Phase Beavis)
 
 Closes issue #99. Every binding could `open()` a database; almost none

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,6 +50,51 @@ the watcher.
 - Do not make the kernel backend the default anywhere.
 - Do not weaken the test to make it pass.
 
+## Phase Robinson — Migrate Node Stream Checkpoint Keys
+
+> Known data-compatibility defect in `@russellthehippo/honker-node@0.4.6`
+
+Node 0.4.6 calls `honker_stream_save_offset` and
+`honker_stream_get_offset` with `(topic, consumer)` even though the SQL ABI and
+`_honker_stream_consumers(name, topic, offset)` use `(consumer, topic)`. Its
+own save/resume path works because both calls make the same mistake, but other
+bindings silently use a different checkpoint row.
+
+A direct argument swap is unsafe. Existing Node checkpoints would disappear
+from the corrected lookup, making upgraded consumers resume at offset zero and
+reprocess the full retained stream.
+
+### Migration-safe fix
+
+- Change new writes to the canonical `(consumer, topic)` key order.
+- On read/save, prefer an existing canonical row. Only when it is absent, read
+  the legacy `(topic, consumer)` row and copy its offset into the canonical row
+  transactionally before continuing.
+- Do not delete the legacy row automatically. It may also be a legitimate
+  canonical checkpoint for the reversed stream/consumer pair; automatic
+  deletion could corrupt that consumer.
+- Document the compatibility behavior and provide an explicit inspection or
+  cleanup recipe for users who know their stream/consumer names do not collide.
+- After a deprecation window, remove the fallback in a major release while
+  keeping the migration recipe available.
+
+If both key orders already exist, the canonical row wins. Taking the maximum
+would avoid some replay, but a legacy-looking row may belong to a real reversed
+pair; using it could skip unprocessed events, which is worse than replay.
+
+### Verification
+
+- Keep `tests/test_node_python_interop.py` as a strict expected failure until
+  the compatibility implementation lands; removing its marker is part of the
+  fix.
+- Add Node tests for canonical-only, legacy-only, both-rows, and identical
+  consumer/topic names, covering `saveOffset`, `saveOffsetTx`, `getOffset`, and
+  subscription resume.
+- Prove an on-disk checkpoint written by 0.4.6 survives upgrade without a
+  resume-from-zero replay, while new Node checkpoints are visible to Python.
+- Call out the migration in the Node release notes before publishing the fixed
+  package.
+
 ## Phase Ranger — Delegate Locks To Bouncer
 
 > Later architecture work

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,34 +64,30 @@ A direct argument swap is unsafe. Existing Node checkpoints would disappear
 from the corrected lookup, making upgraded consumers resume at offset zero and
 reprocess the full retained stream.
 
-### Migration-safe fix
+### Alpha compatibility fix
 
-- Change new writes to the canonical `(consumer, topic)` key order.
-- On read/save, prefer an existing canonical row. Only when it is absent, read
-  the legacy `(topic, consumer)` row and copy its offset into the canonical row
-  transactionally before continuing.
-- Do not delete the legacy row automatically. It may also be a legitimate
-  canonical checkpoint for the reversed stream/consumer pair; automatic
-  deletion could corrupt that consumer.
-- Document the compatibility behavior and provide an explicit inspection or
-  cleanup recipe for users who know their stream/consumer names do not collide.
-- After a deprecation window, remove the fallback in a major release while
-  keeping the migration recipe available.
-
-If both key orders already exist, the canonical row wins. Taking the maximum
-would avoid some replay, but a legacy-looking row may belong to a real reversed
-pair; using it could skip unprocessed events, which is worse than replay.
+- New writes use the canonical `(consumer, topic)` key order.
+- Reads and saves prefer an existing canonical row. When only the legacy
+  `(topic, consumer)` row exists, verify that its offset identifies a retained
+  event in the requested stream, then copy it to the canonical row in the same
+  transaction.
+- Offset zero is safe to copy. If a nonzero offset is missing or belongs to a
+  different stream, raise `CheckpointMigrationError` rather than guess.
+- Keep the legacy row for rollback. Canonical state wins once present.
+- Treat arbitrary/deleted offsets, reversed-name collisions, and mixed 0.4.6 +
+  corrected-version writers as unsupported alpha upgrade cases. There is no
+  migration CLI, configuration map, provenance table, or automatic cleanup.
 
 ### Verification
 
-- Keep `tests/test_node_python_interop.py` as a strict expected failure until
-  the compatibility implementation lands; removing its marker is part of the
-  fix.
-- Add Node tests for canonical-only, legacy-only, both-rows, and identical
-  consumer/topic names, covering `saveOffset`, `saveOffsetTx`, `getOffset`, and
+- Keep Node tests for canonical-only, legacy-only, canonical precedence, and
+  unverifiable rows, covering `saveOffset`, `saveOffsetTx`, `getOffset`, and
   subscription resume.
-- Prove an on-disk checkpoint written by 0.4.6 survives upgrade without a
-  resume-from-zero replay, while new Node checkpoints are visible to Python.
+- Prove an on-disk checkpoint written by 0.4.6 automatically migrates without
+  a resume-from-zero replay, while new Node checkpoints are visible to Python.
+- Run actual Python→Node and Node→Python publish/checkpoint/resume journeys,
+  including subscription persistence and transactional commit/rollback, in the
+  existing Node OS/version matrix.
 - Call out the migration in the Node release notes before publishing the fixed
   package.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,7 +72,9 @@ reprocess the full retained stream.
   event in the requested stream, then copy it to the canonical row in the same
   transaction.
 - Offset zero is safe to copy. If a nonzero offset is missing or belongs to a
-  different stream, raise `CheckpointMigrationError` rather than guess.
+  different stream, guarded reads raise `CheckpointMigrationError` rather than
+  guess. Explicit `saveOffset` / `saveOffsetTx` calls bypass that legacy row and
+  establish the caller-supplied canonical progress, including a zero reset.
 - Keep the legacy row for rollback. Canonical state wins once present.
 - Treat arbitrary/deleted offsets, reversed-name collisions, and mixed 0.4.6 +
   corrected-version writers as unsupported alpha upgrade cases. There is no
@@ -80,9 +82,9 @@ reprocess the full retained stream.
 
 ### Verification
 
-- Keep Node tests for canonical-only, legacy-only, canonical precedence, and
-  unverifiable rows, covering `saveOffset`, `saveOffsetTx`, `getOffset`, and
-  subscription resume.
+- Keep Node tests for canonical-only, legacy-only, canonical precedence,
+  unverifiable reads, explicit recovery, and identical/reversed names, covering
+  `saveOffset`, `saveOffsetTx`, `getOffset`, and subscription resume.
 - Prove an on-disk checkpoint written by 0.4.6 automatically migrates without
   a resume-from-zero replay, while new Node checkpoints are visible to Python.
 - Run actual Python→Node and Node→Python publish/checkpoint/resume journeys,

--- a/packages/honker-node/README.md
+++ b/packages/honker-node/README.md
@@ -81,4 +81,17 @@ Supported schedule forms:
 - `schedule` is the canonical recurring-schedule option.
 - `cron` still works as a compatibility alias.
 
+### Known issue in 0.4.6: cross-binding stream checkpoints
+
+`stream.saveOffset(consumer, offset)`, `stream.saveOffsetTx(...)`, and
+`stream.getOffset(consumer)` swap the stream topic and consumer name at the SQL
+boundary. Node-to-Node resume is self-consistent, but another binding does not
+see Node's checkpoint, and Node does not see checkpoints saved by Python or
+another binding. Stream publishing and reading are unaffected.
+
+Do not share named stream checkpoints between Node 0.4.6 and another binding.
+Correcting the argument order alone would make existing Node consumers resume
+from zero and replay old events, so the planned fix includes compatibility for
+the transposed rows already on disk.
+
 For streams, notify/listen, SQL functions, and full scheduler docs, see the main repo and docs site.

--- a/packages/honker-node/README.md
+++ b/packages/honker-node/README.md
@@ -96,11 +96,20 @@ saved. Migration is transactional, preserves the old row, and verifies that
 the saved offset belongs to a retained event in the requested stream. A
 canonical row always wins when both key orders exist.
 
-This alpha compatibility path deliberately rejects checkpoint state it cannot
+Node 0.5.0's alpha compatibility path deliberately rejects checkpoint state it cannot
 verify—for example, an arbitrary offset or one whose event was manually
 deleted—with `CheckpointMigrationError` and code
-`HONKER_CHECKPOINT_MIGRATION_UNVERIFIABLE`. Reset that checkpoint explicitly
-before continuing. Running 0.4.6 and a corrected version against the same
-consumer concurrently is unsupported during the upgrade.
+`HONKER_CHECKPOINT_MIGRATION_UNVERIFIABLE`. Guarded reads (`getOffset()`,
+`readFromConsumer()`, and `subscribe()`) throw because guessing could skip
+events. Recover by explicitly establishing canonical progress:
+
+```js
+stream.saveOffset("worker-c", 0);           // replay retained events
+stream.saveOffset("worker-c", knownOffset); // resume after a known event
+```
+
+`saveOffsetTx()` supports the same recovery inside a caller-owned transaction.
+Running 0.4.6 and a corrected version against the same consumer concurrently
+is unsupported during the upgrade.
 
 For streams, notify/listen, SQL functions, and full scheduler docs, see the main repo and docs site.

--- a/packages/honker-node/README.md
+++ b/packages/honker-node/README.md
@@ -81,17 +81,26 @@ Supported schedule forms:
 - `schedule` is the canonical recurring-schedule option.
 - `cron` still works as a compatibility alias.
 
-### Known issue in 0.4.6: cross-binding stream checkpoints
+### Upgrading stream checkpoints written by 0.4.6
 
+Node 0.4.6 swapped the stream topic and consumer name at the SQL boundary in
 `stream.saveOffset(consumer, offset)`, `stream.saveOffsetTx(...)`, and
-`stream.getOffset(consumer)` swap the stream topic and consumer name at the SQL
-boundary. Node-to-Node resume is self-consistent, but another binding does not
-see Node's checkpoint, and Node does not see checkpoints saved by Python or
-another binding. Stream publishing and reading are unaffected.
+`stream.getOffset(consumer)`. Publishing and explicit-offset `readSince()` were
+unaffected. Named-consumer `readFromConsumer()` and `subscribe()` were
+self-consistent within Node 0.4.6, but could not share resume positions with
+Python or another binding.
 
-Do not share named stream checkpoints between Node 0.4.6 and another binding.
-Correcting the argument order alone would make existing Node consumers resume
-from zero and replay old events, so the planned fix includes compatibility for
-the transposed rows already on disk.
+Later versions use the canonical `(consumer, topic)` key and automatically
+migrate a 0.4.6 checkpoint the first time that stream/consumer pair is read or
+saved. Migration is transactional, preserves the old row, and verifies that
+the saved offset belongs to a retained event in the requested stream. A
+canonical row always wins when both key orders exist.
+
+This alpha compatibility path deliberately rejects checkpoint state it cannot
+verify—for example, an arbitrary offset or one whose event was manually
+deleted—with `CheckpointMigrationError` and code
+`HONKER_CHECKPOINT_MIGRATION_UNVERIFIABLE`. Reset that checkpoint explicitly
+before continuing. Running 0.4.6 and a corrected version against the same
+consumer concurrently is unsupported during the upgrade.
 
 For streams, notify/listen, SQL functions, and full scheduler docs, see the main repo and docs site.

--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -86,6 +86,22 @@ function unwrapTx(tx) {
   return tx instanceof Transaction ? tx._tx : tx;
 }
 
+class CheckpointMigrationError extends Error {
+  constructor(stream, consumer, offset) {
+    super(
+      `Cannot automatically migrate the Node 0.4.6 checkpoint for stream ` +
+        `${JSON.stringify(stream)} and consumer ${JSON.stringify(consumer)}: ` +
+        `legacy offset ${offset} is not a retained event in that stream. ` +
+        `Reset or migrate this checkpoint explicitly before upgrading.`,
+    );
+    this.name = 'CheckpointMigrationError';
+    this.code = 'HONKER_CHECKPOINT_MIGRATION_UNVERIFIABLE';
+    this.stream = stream;
+    this.consumer = consumer;
+    this.offset = offset;
+  }
+}
+
 class Transaction {
   constructor(tx) {
     this._tx = tx;
@@ -612,22 +628,76 @@ class Stream {
     return this.readSince(this.getOffset(consumer), limit);
   }
 
-  saveOffset(consumer, offset) {
-    return (
-      this._db._callScalar('SELECT honker_stream_save_offset(?, ?, ?)', [
-        this.name,
-        consumer,
-        offset,
-      ]) === 1
+  // Node 0.4.6 persisted (stream, consumer) into the SQL ABI's
+  // (consumer, topic) key. Prefer the canonical row. When only the old
+  // row exists, its saved offset identifies which stream produced it:
+  // a normal checkpoint is the offset of an event in this stream. That
+  // lets the common upgrade path migrate automatically without guessing
+  // about a legitimate checkpoint for the reversed name pair.
+  _resolveCheckpointTx(tx, consumer) {
+    const canonicalOffset = scalar(
+      tx.query(
+        'SELECT offset FROM _honker_stream_consumers WHERE name = ? AND topic = ?',
+        [consumer, this.name],
+      ),
     );
+    if (canonicalOffset != null) return canonicalOffset;
+
+    const legacyOffset = scalar(
+      tx.query(
+        'SELECT offset FROM _honker_stream_consumers WHERE name = ? AND topic = ?',
+        [this.name, consumer],
+      ),
+    );
+    if (legacyOffset == null) return 0;
+
+    if (legacyOffset !== 0) {
+      const eventTopic = scalar(
+        tx.query('SELECT topic FROM _honker_stream WHERE offset = ?', [legacyOffset]),
+      );
+      if (eventTopic !== this.name) {
+        throw new CheckpointMigrationError(this.name, consumer, legacyOffset);
+      }
+    }
+
+    tx.execute(
+      'INSERT INTO _honker_stream_consumers (name, topic, offset) VALUES (?, ?, ?) ' +
+        'ON CONFLICT(name, topic) DO NOTHING',
+      [consumer, this.name, legacyOffset],
+    );
+    return legacyOffset;
+  }
+
+  saveOffset(consumer, offset) {
+    const tx = this._db.transaction();
+    try {
+      this._resolveCheckpointTx(unwrapTx(tx), consumer);
+      const changed =
+        scalar(
+          unwrapTx(tx).query('SELECT honker_stream_save_offset(?, ?, ?)', [
+            consumer,
+            this.name,
+            offset,
+          ]),
+        ) === 1;
+      tx.commit();
+      return changed;
+    } catch (err) {
+      try {
+        tx.rollback();
+      } catch {}
+      throw err;
+    }
   }
 
   saveOffsetTx(tx, consumer, offset) {
+    const rawTx = unwrapTx(tx);
+    this._resolveCheckpointTx(rawTx, consumer);
     return (
       scalar(
-        unwrapTx(tx).query('SELECT honker_stream_save_offset(?, ?, ?)', [
-          this.name,
+        rawTx.query('SELECT honker_stream_save_offset(?, ?, ?)', [
           consumer,
+          this.name,
           offset,
         ]),
       ) === 1
@@ -635,10 +705,17 @@ class Stream {
   }
 
   getOffset(consumer) {
-    return this._db._callScalar('SELECT honker_stream_get_offset(?, ?)', [
-      this.name,
-      consumer,
-    ]);
+    const tx = this._db.transaction();
+    try {
+      const offset = this._resolveCheckpointTx(unwrapTx(tx), consumer);
+      tx.commit();
+      return offset;
+    } catch (err) {
+      try {
+        tx.rollback();
+      } catch {}
+      throw err;
+    }
   }
 
   subscribe(consumer, opts = {}) {
@@ -955,6 +1032,7 @@ module.exports = function buildApi(nativeBinding) {
     Stream,
     StreamEvent,
     StreamSubscription,
+    CheckpointMigrationError,
     Listener,
     Scheduler,
     Lock,

--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -92,7 +92,7 @@ class CheckpointMigrationError extends Error {
       `Cannot automatically migrate the Node 0.4.6 checkpoint for stream ` +
         `${JSON.stringify(stream)} and consumer ${JSON.stringify(consumer)}: ` +
         `legacy offset ${offset} is not a retained event in that stream. ` +
-        `Reset or migrate this checkpoint explicitly before upgrading.`,
+        `Call saveOffset(consumer, 0) to reset it, or explicitly save a known offset.`,
     );
     this.name = 'CheckpointMigrationError';
     this.code = 'HONKER_CHECKPOINT_MIGRATION_UNVERIFIABLE';
@@ -634,7 +634,7 @@ class Stream {
   // a normal checkpoint is the offset of an event in this stream. That
   // lets the common upgrade path migrate automatically without guessing
   // about a legitimate checkpoint for the reversed name pair.
-  _resolveCheckpointTx(tx, consumer) {
+  _resolveCheckpointTx(tx, consumer, { allowUnverifiable = false } = {}) {
     const canonicalOffset = scalar(
       tx.query(
         'SELECT offset FROM _honker_stream_consumers WHERE name = ? AND topic = ?',
@@ -656,6 +656,12 @@ class Stream {
         tx.query('SELECT topic FROM _honker_stream WHERE offset = ?', [legacyOffset]),
       );
       if (eventTopic !== this.name) {
+        // Reads must not guess: adopting this row could skip events for
+        // the requested stream. An explicit save is different. It gives
+        // us the caller's intended canonical progress, so leave the
+        // ambiguous legacy row untouched and let the canonical upsert
+        // below establish the new source of truth.
+        if (allowUnverifiable) return 0;
         throw new CheckpointMigrationError(this.name, consumer, legacyOffset);
       }
     }
@@ -671,7 +677,7 @@ class Stream {
   saveOffset(consumer, offset) {
     const tx = this._db.transaction();
     try {
-      this._resolveCheckpointTx(unwrapTx(tx), consumer);
+      this._resolveCheckpointTx(unwrapTx(tx), consumer, { allowUnverifiable: true });
       const changed =
         scalar(
           unwrapTx(tx).query('SELECT honker_stream_save_offset(?, ?, ?)', [
@@ -692,7 +698,7 @@ class Stream {
 
   saveOffsetTx(tx, consumer, offset) {
     const rawTx = unwrapTx(tx);
-    this._resolveCheckpointTx(rawTx, consumer);
+    this._resolveCheckpointTx(rawTx, consumer, { allowUnverifiable: true });
     return (
       scalar(
         rawTx.query('SELECT honker_stream_save_offset(?, ?, ?)', [

--- a/packages/honker-node/index.js
+++ b/packages/honker-node/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-android-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-android-arm-eabi')
         const bindingPackageVersion = require('@russellthehippo/honker-node-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-x64-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-x64-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-ia32-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-arm64-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@russellthehippo/honker-node-darwin-universal')
       const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-darwin-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-darwin-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-freebsd-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-freebsd-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-x64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-x64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm-musleabihf')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-loong64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-loong64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-riscv64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-riscv64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-linux-ppc64-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-linux-s390x-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-arm')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.4.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/packages/honker-node/npm/darwin-arm64/package.json
+++ b/packages/honker-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-darwin-arm64",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "cpu": [
     "arm64"
   ],

--- a/packages/honker-node/npm/darwin-x64/package.json
+++ b/packages/honker-node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-darwin-x64",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "cpu": [
     "x64"
   ],

--- a/packages/honker-node/npm/linux-arm64-gnu/package.json
+++ b/packages/honker-node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-linux-arm64-gnu",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "cpu": [
     "arm64"
   ],

--- a/packages/honker-node/npm/linux-x64-gnu/package.json
+++ b/packages/honker-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-linux-x64-gnu",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "cpu": [
     "x64"
   ],

--- a/packages/honker-node/package-lock.json
+++ b/packages/honker-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@russellthehippo/honker-node",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@russellthehippo/honker-node",
-      "version": "0.4.6",
+      "version": "0.5.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"
@@ -19,10 +19,10 @@
         "@russellthehippo/honker-ext-darwin-x64": "0.4.6",
         "@russellthehippo/honker-ext-linux-arm64-gnu": "0.4.6",
         "@russellthehippo/honker-ext-linux-x64-gnu": "0.4.6",
-        "@russellthehippo/honker-node-darwin-arm64": "0.4.6",
-        "@russellthehippo/honker-node-darwin-x64": "0.4.6",
-        "@russellthehippo/honker-node-linux-arm64-gnu": "0.4.6",
-        "@russellthehippo/honker-node-linux-x64-gnu": "0.4.6"
+        "@russellthehippo/honker-node-darwin-arm64": "0.5.0",
+        "@russellthehippo/honker-node-darwin-x64": "0.5.0",
+        "@russellthehippo/honker-node-linux-arm64-gnu": "0.5.0",
+        "@russellthehippo/honker-node-linux-x64-gnu": "0.5.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1657,74 +1657,16 @@
       ]
     },
     "node_modules/@russellthehippo/honker-node-darwin-arm64": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-darwin-arm64/-/honker-node-darwin-arm64-0.4.6.tgz",
-      "integrity": "sha512-l9ALQhs+ZMRcsrR8tSKqy85vFeHmzpKqJYXXK2pUlziHU5RMq3M0OkcciY9qXtBzkLdpSUnVGMIiarLrZ5WohA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@russellthehippo/honker-node-darwin-x64": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-darwin-x64/-/honker-node-darwin-x64-0.4.6.tgz",
-      "integrity": "sha512-rznG+u1XSBkc12F+BOpfTbj8soS5Dk3HJkuSvSj1WS9lF75YV+VWHKOLXAsqTA0xHEskTwC4mK0y8h0Yu4sXCg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@russellthehippo/honker-node-linux-arm64-gnu": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-linux-arm64-gnu/-/honker-node-linux-arm64-gnu-0.4.6.tgz",
-      "integrity": "sha512-oPHRQGB0jQjuPv3tyU4gExF+jXfkikB5+f54xKAC1nsIo4/2+lOWk6ZppSKsUxil1lrNFv4wO3vlG+C0qk2dvw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@russellthehippo/honker-node-linux-x64-gnu": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-linux-x64-gnu/-/honker-node-linux-x64-gnu-0.4.6.tgz",
-      "integrity": "sha512-2gRx171U1J3b0xylDVxgxDj3OOg0hv2VKQE7vXyEfpPVsIklkAcoIm2mjnotYt8CYW7PB3EjNKsmOIjxKOP2pw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",

--- a/packages/honker-node/package.json
+++ b/packages/honker-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "Node binding for honker \u2014 durable queues, streams, pub/sub, and scheduler on SQLite.",
   "main": "wrapper.js",
   "types": "wrapper.d.ts",
@@ -58,10 +58,10 @@
     "url": "https://github.com/russellromney/honker"
   },
   "optionalDependencies": {
-    "@russellthehippo/honker-node-darwin-arm64": "0.4.6",
-    "@russellthehippo/honker-node-darwin-x64": "0.4.6",
-    "@russellthehippo/honker-node-linux-x64-gnu": "0.4.6",
-    "@russellthehippo/honker-node-linux-arm64-gnu": "0.4.6",
+    "@russellthehippo/honker-node-darwin-arm64": "0.5.0",
+    "@russellthehippo/honker-node-darwin-x64": "0.5.0",
+    "@russellthehippo/honker-node-linux-x64-gnu": "0.5.0",
+    "@russellthehippo/honker-node-linux-arm64-gnu": "0.5.0",
     "@russellthehippo/honker-ext-darwin-arm64": "0.4.6",
     "@russellthehippo/honker-ext-darwin-x64": "0.4.6",
     "@russellthehippo/honker-ext-linux-x64-gnu": "0.4.6",

--- a/packages/honker-node/test/parity.test.js
+++ b/packages/honker-node/test/parity.test.js
@@ -349,7 +349,7 @@ test('stream: canonical checkpoint wins over a legacy-looking row', () => {
   }
 });
 
-test('stream: unverifiable legacy checkpoint fails without creating a canonical row', () => {
+test('stream: unverifiable legacy read fails but an explicit zero reset succeeds', () => {
   const { path: p, cleanup } = tmpdb();
   try {
     const db = honker.open(p);
@@ -377,6 +377,38 @@ test('stream: unverifiable legacy checkpoint fails without creating a canonical 
       ),
       [],
     );
+
+    assert.equal(s.saveOffset('worker-c', 0), true);
+    assert.equal(s.getOffset('worker-c'), 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test('stream: explicit valid save recovers an unverifiable legacy checkpoint', () => {
+  const { path: p, cleanup } = tmpdb();
+  try {
+    const db = honker.open(p);
+    const s = db.stream('orders');
+    const current = s.publish({ i: 1 });
+    const tx = db.transaction();
+    tx.execute(
+      'INSERT INTO _honker_stream_consumers (name, topic, offset) VALUES (?, ?, ?)',
+      ['orders', 'worker-c', 999],
+    );
+    tx.commit();
+
+    assert.equal(s.saveOffset('worker-c', current), true);
+    assert.equal(s.getOffset('worker-c'), current);
+    assert.deepEqual(
+      db.query(
+        'SELECT name, topic, offset FROM _honker_stream_consumers ORDER BY name, topic',
+      ),
+      [
+        { name: 'orders', topic: 'worker-c', offset: 999 },
+        { name: 'worker-c', topic: 'orders', offset: current },
+      ],
+    );
   } finally {
     cleanup();
   }
@@ -398,6 +430,10 @@ test('stream: reversed-name collision fails loudly instead of skipping events', 
       (err) =>
         err instanceof honker.CheckpointMigrationError && err.offset === offset,
     );
+    const orders = db.stream('orders');
+    const ordersOffset = orders.publish({ belongsTo: 'orders' });
+    assert.equal(orders.saveOffset('worker-c', ordersOffset), true);
+    assert.equal(orders.getOffset('worker-c'), ordersOffset);
   } finally {
     cleanup();
   }
@@ -489,6 +525,33 @@ test('stream: saveOffsetTx migrates legacy state in the caller transaction', () 
     assert.equal(s.saveOffsetTx(committed, 'c1', second), true);
     committed.commit();
     assert.equal(s.getOffset('c1'), second);
+  } finally {
+    cleanup();
+  }
+});
+
+test('stream: saveOffsetTx can recover unverifiable legacy state atomically', () => {
+  const { path: p, cleanup } = tmpdb();
+  try {
+    const db = honker.open(p);
+    const s = db.stream('events');
+    const current = s.publish({ i: 1 });
+    const seed = db.transaction();
+    seed.execute(
+      'INSERT INTO _honker_stream_consumers (name, topic, offset) VALUES (?, ?, ?)',
+      ['events', 'c1', 999],
+    );
+    seed.commit();
+
+    const rolledBack = db.transaction();
+    assert.equal(s.saveOffsetTx(rolledBack, 'c1', current), true);
+    rolledBack.rollback();
+    assert.throws(() => s.getOffset('c1'), honker.CheckpointMigrationError);
+
+    const committed = db.transaction();
+    assert.equal(s.saveOffsetTx(committed, 'c1', current), true);
+    committed.commit();
+    assert.equal(s.getOffset('c1'), current);
   } finally {
     cleanup();
   }

--- a/packages/honker-node/test/parity.test.js
+++ b/packages/honker-node/test/parity.test.js
@@ -294,6 +294,156 @@ test('stream: consumer offsets + readFromConsumer', () => {
   }
 });
 
+test('stream: automatically migrates a verified Node 0.4.6 checkpoint', () => {
+  const { path: p, cleanup } = tmpdb();
+  try {
+    const db = honker.open(p);
+    const s = db.stream('orders');
+    const first = s.publish({ i: 1 });
+    const second = s.publish({ i: 2 });
+    const tx = db.transaction();
+    tx.execute(
+      'INSERT INTO _honker_stream_consumers (name, topic, offset) VALUES (?, ?, ?)',
+      ['orders', 'worker-c', first],
+    );
+    tx.commit();
+
+    assert.equal(s.getOffset('worker-c'), first);
+    assert.deepEqual(s.readFromConsumer('worker-c', 10).map((event) => event.payload), [
+      { i: 2 },
+    ]);
+    assert.deepEqual(
+      db.query(
+        'SELECT name, topic, offset FROM _honker_stream_consumers ORDER BY name, topic',
+      ),
+      [
+        { name: 'orders', topic: 'worker-c', offset: first },
+        { name: 'worker-c', topic: 'orders', offset: first },
+      ],
+    );
+
+    assert.equal(s.saveOffset('worker-c', second), true);
+    assert.equal(s.getOffset('worker-c'), second);
+  } finally {
+    cleanup();
+  }
+});
+
+test('stream: canonical checkpoint wins over a legacy-looking row', () => {
+  const { path: p, cleanup } = tmpdb();
+  try {
+    const db = honker.open(p);
+    const s = db.stream('orders');
+    const first = s.publish({ i: 1 });
+    const second = s.publish({ i: 2 });
+    const tx = db.transaction();
+    tx.execute(
+      'INSERT INTO _honker_stream_consumers (name, topic, offset) VALUES (?, ?, ?), (?, ?, ?)',
+      ['worker-c', 'orders', first, 'orders', 'worker-c', second],
+    );
+    tx.commit();
+
+    assert.equal(s.getOffset('worker-c'), first);
+  } finally {
+    cleanup();
+  }
+});
+
+test('stream: unverifiable legacy checkpoint fails without creating a canonical row', () => {
+  const { path: p, cleanup } = tmpdb();
+  try {
+    const db = honker.open(p);
+    const s = db.stream('orders');
+    const tx = db.transaction();
+    tx.execute(
+      'INSERT INTO _honker_stream_consumers (name, topic, offset) VALUES (?, ?, ?)',
+      ['orders', 'worker-c', 999],
+    );
+    tx.commit();
+
+    assert.throws(
+      () => s.getOffset('worker-c'),
+      (err) =>
+        err instanceof honker.CheckpointMigrationError &&
+        err.code === 'HONKER_CHECKPOINT_MIGRATION_UNVERIFIABLE' &&
+        err.stream === 'orders' &&
+        err.consumer === 'worker-c' &&
+        err.offset === 999,
+    );
+    assert.deepEqual(
+      db.query(
+        'SELECT offset FROM _honker_stream_consumers WHERE name = ? AND topic = ?',
+        ['worker-c', 'orders'],
+      ),
+      [],
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('stream: reversed-name collision fails loudly instead of skipping events', () => {
+  const { path: p, cleanup } = tmpdb();
+  try {
+    const db = honker.open(p);
+    const reversed = db.stream('worker-c');
+    const offset = reversed.publish({ belongsTo: 'worker-c' });
+    // This is a valid canonical row for stream "worker-c", consumer
+    // "orders", but it looks like a 0.4.6 legacy row for the reversed
+    // pair. The event topic lets the upgrade path reject that guess.
+    reversed.saveOffset('orders', offset);
+
+    assert.throws(
+      () => db.stream('orders').getOffset('worker-c'),
+      (err) =>
+        err instanceof honker.CheckpointMigrationError && err.offset === offset,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('stream: zero-offset legacy checkpoint migrates without event evidence', () => {
+  const { path: p, cleanup } = tmpdb();
+  try {
+    const db = honker.open(p);
+    const tx = db.transaction();
+    tx.execute(
+      'INSERT INTO _honker_stream_consumers (name, topic, offset) VALUES (?, ?, 0)',
+      ['orders', 'worker-c'],
+    );
+    tx.commit();
+
+    assert.equal(db.stream('orders').getOffset('worker-c'), 0);
+    assert.deepEqual(
+      db.query(
+        'SELECT offset FROM _honker_stream_consumers WHERE name = ? AND topic = ?',
+        ['worker-c', 'orders'],
+      ),
+      [{ offset: 0 }],
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('stream: identical stream and consumer names need no migration', () => {
+  const { path: p, cleanup } = tmpdb();
+  try {
+    const db = honker.open(p);
+    const stream = db.stream('same');
+    const offset = stream.publish({ i: 1 });
+    assert.equal(stream.saveOffset('same', offset), true);
+    assert.equal(stream.getOffset('same'), offset);
+    assert.equal(
+      db.query('SELECT COUNT(*) AS count FROM _honker_stream_consumers')[0].count,
+      1,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 test('stream: saveOffsetTx respects rollback', () => {
   const { path: p, cleanup } = tmpdb();
   try {
@@ -305,6 +455,40 @@ test('stream: saveOffsetTx respects rollback', () => {
     s.saveOffsetTx(tx, 'c1', 2);
     tx.rollback();
     assert.equal(s.getOffset('c1'), 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test('stream: saveOffsetTx migrates legacy state in the caller transaction', () => {
+  const { path: p, cleanup } = tmpdb();
+  try {
+    const db = honker.open(p);
+    const s = db.stream('events');
+    const first = s.publish({ i: 1 });
+    const second = s.publish({ i: 2 });
+    const seed = db.transaction();
+    seed.execute(
+      'INSERT INTO _honker_stream_consumers (name, topic, offset) VALUES (?, ?, ?)',
+      ['events', 'c1', first],
+    );
+    seed.commit();
+
+    const rolledBack = db.transaction();
+    assert.equal(s.saveOffsetTx(rolledBack, 'c1', second), true);
+    rolledBack.rollback();
+    assert.deepEqual(
+      db.query(
+        'SELECT offset FROM _honker_stream_consumers WHERE name = ? AND topic = ?',
+        ['c1', 'events'],
+      ),
+      [],
+    );
+
+    const committed = db.transaction();
+    assert.equal(s.saveOffsetTx(committed, 'c1', second), true);
+    committed.commit();
+    assert.equal(s.getOffset('c1'), second);
   } finally {
     cleanup();
   }

--- a/packages/honker-node/wrapper.d.ts
+++ b/packages/honker-node/wrapper.d.ts
@@ -35,6 +35,13 @@ export interface StreamEvent {
   createdAt: number | null
 }
 
+export class CheckpointMigrationError extends Error {
+  readonly code: 'HONKER_CHECKPOINT_MIGRATION_UNVERIFIABLE'
+  readonly stream: string
+  readonly consumer: string
+  readonly offset: number
+}
+
 export interface QueueOptions {
   visibilityTimeoutS?: number
   maxAttempts?: number

--- a/scripts/proof/check-node-version-alignment.py
+++ b/scripts/proof/check-node-version-alignment.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Keep the Node addon, npm packages, lockfile, and generated loader in sync."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NODE = ROOT / "packages" / "honker-node"
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def main() -> int:
+    errors: list[str] = []
+    package = load_json(NODE / "package.json")
+    version = package["version"]
+
+    cargo_match = re.search(
+        r'^version = "([^"]+)"$', (NODE / "Cargo.toml").read_text(), re.MULTILINE
+    )
+    cargo_version = cargo_match.group(1) if cargo_match else None
+    if cargo_version != version:
+        errors.append(
+            f"Cargo.toml is {cargo_version!r}, package.json is {version}"
+        )
+
+    native_dependencies = package["optionalDependencies"]
+    platform_manifests = sorted((NODE / "npm").glob("*/package.json"))
+    if not platform_manifests:
+        errors.append("no Node platform package manifests found")
+    for path in platform_manifests:
+        platform = load_json(path)
+        if platform["version"] != version:
+            errors.append(f"{path.relative_to(ROOT)} is {platform['version']}, expected {version}")
+        pinned = native_dependencies.get(platform["name"])
+        if pinned != version:
+            errors.append(f"package.json pins {platform['name']} at {pinned!r}, expected {version}")
+
+    lock = load_json(NODE / "package-lock.json")
+    lock_root = lock["packages"][""]
+    if lock["version"] != version or lock_root["version"] != version:
+        errors.append("package-lock.json root version does not match package.json")
+    for path in platform_manifests:
+        name = load_json(path)["name"]
+        pinned = lock_root["optionalDependencies"].get(name)
+        if pinned != version:
+            errors.append(f"package-lock.json pins {name} at {pinned!r}, expected {version}")
+
+    loader = (NODE / "index.js").read_text()
+    loader_versions = re.findall(r"bindingPackageVersion !== '([^']+)'", loader)
+    if not loader_versions:
+        errors.append("index.js has no native package version checks")
+    elif unexpected := sorted(set(loader_versions) - {version}):
+        errors.append(f"index.js checks unexpected native versions: {unexpected}")
+
+    if errors:
+        print("Node package version alignment failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Node package version alignment ok: {version} "
+        f"({len(platform_manifests)} platform packages, {len(loader_versions)} loader checks)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_node_python_interop.py
+++ b/tests/test_node_python_interop.py
@@ -1,0 +1,106 @@
+"""Cross-runtime stream-checkpoint interoperability for Node and Python."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import honker
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NODE_DIR = REPO_ROOT / "packages" / "honker-node"
+
+
+def _node_command():
+    node = shutil.which("node")
+    return [node] if node else None
+
+
+def _node_ready(cmd):
+    if cmd is None:
+        return False
+    probe = subprocess.run(
+        [*cmd, "-e", 'require(".")'],
+        cwd=NODE_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return probe.returncode == 0
+
+
+NODE_CMD = _node_command()
+
+
+def _require_node_interop():
+    if _node_ready(NODE_CMD):
+        return
+    pytest.skip(
+        "Node binding unavailable; install node and run `npm ci` plus "
+        "`npm run build` in packages/honker-node"
+    )
+
+
+def _run_node(script, db_path):
+    proc = subprocess.run(
+        [*NODE_CMD, "-e", script, str(db_path)],
+        cwd=NODE_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="Node 0.4.6 transposes the stream checkpoint consumer and topic",
+)
+def test_node_and_python_share_stream_checkpoints(tmp_path):
+    _require_node_interop()
+    db_path = tmp_path / "node-python-checkpoint.db"
+    stream_name = "orders"
+    consumer = "worker-c"
+    python_offset = 17
+    node_offset = 29
+
+    py_db = honker.open(str(db_path))
+    try:
+        py_stream = py_db.stream(stream_name)
+        py_stream.save_offset(consumer, python_offset)
+
+        observed = _run_node(
+            r'''
+            const honker = require(".");
+
+            const db = honker.open(process.argv[1]);
+            try {
+              const stream = db.stream("orders");
+              const pythonOffsetSeenByNode = stream.getOffset("worker-c");
+              stream.saveOffset("worker-c", 29);
+              console.log(JSON.stringify({ pythonOffsetSeenByNode }));
+            } finally {
+              db.close();
+            }
+            ''',
+            db_path,
+        )
+        node_offset_seen_by_python = py_stream.get_offset(consumer)
+    finally:
+        py_db.close()
+
+    assert (
+        observed["pythonOffsetSeenByNode"] == python_offset
+        and node_offset_seen_by_python == node_offset
+    ), (
+        "Node stream checkpoint key transposition: Python writes "
+        f"(consumer={consumer!r}, topic={stream_name!r}) but Node reads/writes "
+        f"(consumer={stream_name!r}, topic={consumer!r}); "
+        f"Node saw {observed['pythonOffsetSeenByNode']} instead of {python_offset}, "
+        f"and Python saw {node_offset_seen_by_python} instead of {node_offset}"
+    )

--- a/tests/test_node_python_interop.py
+++ b/tests/test_node_python_interop.py
@@ -1,5 +1,6 @@
-"""Cross-runtime stream-checkpoint interoperability for Node and Python."""
+"""User-facing stream-checkpoint interoperability for Node and Python."""
 
+import asyncio
 import json
 import shutil
 import subprocess
@@ -44,9 +45,9 @@ def _require_node_interop():
     )
 
 
-def _run_node(script, db_path):
+def _run_node(script, db_path, *args):
     proc = subprocess.run(
-        [*NODE_CMD, "-e", script, str(db_path)],
+        [*NODE_CMD, "-e", script, str(db_path), *map(str, args)],
         cwd=NODE_DIR,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -56,51 +57,209 @@ def _run_node(script, db_path):
     return json.loads(proc.stdout)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=AssertionError,
-    reason="Node 0.4.6 transposes the stream checkpoint consumer and topic",
-)
-def test_node_and_python_share_stream_checkpoints(tmp_path):
-    _require_node_interop()
-    db_path = tmp_path / "node-python-checkpoint.db"
-    stream_name = "orders"
-    consumer = "worker-c"
-    python_offset = 17
-    node_offset = 29
+def _publish_python_events(stream, db, count=3):
+    for i in range(count):
+        stream.publish({"i": i})
+    return db.query(
+        "SELECT offset FROM _honker_stream WHERE topic=? ORDER BY offset", [stream.name]
+    )
 
+
+def test_python_checkpoint_drives_node_read_from_consumer(tmp_path):
+    _require_node_interop()
+    db_path = tmp_path / "python-to-node-checkpoint.db"
     py_db = honker.open(str(db_path))
     try:
-        py_stream = py_db.stream(stream_name)
-        py_stream.save_offset(consumer, python_offset)
+        stream = py_db.stream("orders")
+        offsets = _publish_python_events(stream, py_db)
+        stream.save_offset("worker-c", offsets[0]["offset"])
 
         observed = _run_node(
-            r'''
+            r"""
             const honker = require(".");
-
             const db = honker.open(process.argv[1]);
             try {
               const stream = db.stream("orders");
-              const pythonOffsetSeenByNode = stream.getOffset("worker-c");
-              stream.saveOffset("worker-c", 29);
-              console.log(JSON.stringify({ pythonOffsetSeenByNode }));
+              const events = stream.readFromConsumer("worker-c", 10);
+              stream.saveOffset("worker-c", events.at(-1).offset);
+              console.log(JSON.stringify({
+                payloads: events.map((event) => event.payload),
+                savedOffset: stream.getOffset("worker-c"),
+              }));
             } finally {
               db.close();
             }
-            ''',
+            """,
             db_path,
         )
-        node_offset_seen_by_python = py_stream.get_offset(consumer)
+
+        assert observed == {
+            "payloads": [{"i": 1}, {"i": 2}],
+            "savedOffset": offsets[2]["offset"],
+        }
+        assert stream.get_offset("worker-c") == offsets[2]["offset"]
     finally:
         py_db.close()
 
-    assert (
-        observed["pythonOffsetSeenByNode"] == python_offset
-        and node_offset_seen_by_python == node_offset
-    ), (
-        "Node stream checkpoint key transposition: Python writes "
-        f"(consumer={consumer!r}, topic={stream_name!r}) but Node reads/writes "
-        f"(consumer={stream_name!r}, topic={consumer!r}); "
-        f"Node saw {observed['pythonOffsetSeenByNode']} instead of {python_offset}, "
-        f"and Python saw {node_offset_seen_by_python} instead of {node_offset}"
+
+def test_node_checkpoint_drives_python_named_subscription(tmp_path):
+    _require_node_interop()
+    db_path = tmp_path / "node-to-python-checkpoint.db"
+    observed = _run_node(
+        r"""
+        const honker = require(".");
+        const db = honker.open(process.argv[1]);
+        try {
+          const stream = db.stream("orders");
+          const offsets = [0, 1, 2].map((i) => stream.publish({ i }));
+          stream.saveOffset("worker-py", offsets[0]);
+          console.log(JSON.stringify({ offsets }));
+        } finally {
+          db.close();
+        }
+        """,
+        db_path,
     )
+
+    py_db = honker.open(str(db_path))
+    try:
+        stream = py_db.stream("orders")
+        assert stream.get_offset("worker-py") == observed["offsets"][0]
+
+        async def consume_remaining():
+            iterator = stream.subscribe(consumer="worker-py")
+            return [
+                (await iterator.__anext__()).payload,
+                (await iterator.__anext__()).payload,
+            ]
+
+        assert asyncio.run(consume_remaining()) == [{"i": 1}, {"i": 2}]
+    finally:
+        py_db.close()
+
+
+def test_node_subscription_resumes_from_python_and_persists_progress(tmp_path):
+    _require_node_interop()
+    db_path = tmp_path / "node-subscription-checkpoint.db"
+    py_db = honker.open(str(db_path))
+    try:
+        stream = py_db.stream("orders")
+        offsets = _publish_python_events(stream, py_db)
+        stream.save_offset("node-subscriber", offsets[0]["offset"])
+
+        observed = _run_node(
+            r"""
+            const honker = require(".");
+            (async () => {
+              const db = honker.open(process.argv[1]);
+              try {
+                const stream = db.stream("orders");
+                const subscription = stream.subscribe("node-subscriber");
+                const next = await subscription.next();
+                subscription.close();
+                console.log(JSON.stringify({
+                  payload: next.value.payload,
+                  offset: next.value.offset,
+                }));
+              } finally {
+                db.close();
+              }
+            })().catch((err) => {
+              console.error(err);
+              process.exitCode = 1;
+            });
+            """,
+            db_path,
+        )
+
+        assert observed == {"payload": {"i": 1}, "offset": offsets[1]["offset"]}
+        assert stream.get_offset("node-subscriber") == offsets[1]["offset"]
+    finally:
+        py_db.close()
+
+
+def test_node_automatically_migrates_verified_0_4_6_checkpoint(tmp_path):
+    _require_node_interop()
+    db_path = tmp_path / "legacy-node-checkpoint.db"
+    py_db = honker.open(str(db_path))
+    try:
+        stream = py_db.stream("orders")
+        offsets = _publish_python_events(stream, py_db)
+        with py_db.transaction() as tx:
+            # Node 0.4.6 wrote (stream, consumer) where the ABI expected
+            # (consumer, stream).
+            tx.execute(
+                "INSERT INTO _honker_stream_consumers (name, topic, offset) "
+                "VALUES (?, ?, ?)",
+                ["orders", "worker-c", offsets[0]["offset"]],
+            )
+
+        observed = _run_node(
+            r"""
+            const honker = require(".");
+            const db = honker.open(process.argv[1]);
+            try {
+              const stream = db.stream("orders");
+              const events = stream.readFromConsumer("worker-c", 10);
+              console.log(JSON.stringify({
+                offset: stream.getOffset("worker-c"),
+                payloads: events.map((event) => event.payload),
+              }));
+            } finally {
+              db.close();
+            }
+            """,
+            db_path,
+        )
+
+        assert observed == {
+            "offset": offsets[0]["offset"],
+            "payloads": [{"i": 1}, {"i": 2}],
+        }
+        assert stream.get_offset("worker-c") == offsets[0]["offset"]
+        rows = py_db.query(
+            "SELECT name, topic FROM _honker_stream_consumers ORDER BY name, topic"
+        )
+        assert rows == [
+            {"name": "orders", "topic": "worker-c"},
+            {"name": "worker-c", "topic": "orders"},
+        ]
+    finally:
+        py_db.close()
+
+
+def test_node_transactional_checkpoint_is_visible_to_python(tmp_path):
+    _require_node_interop()
+    db_path = tmp_path / "node-transactional-checkpoint.db"
+    py_db = honker.open(str(db_path))
+    try:
+        stream = py_db.stream("orders")
+        offsets = _publish_python_events(stream, py_db)
+
+        observed = _run_node(
+            r"""
+            const honker = require(".");
+            const db = honker.open(process.argv[1]);
+            try {
+              const stream = db.stream("orders");
+              const committed = db.transaction();
+              stream.saveOffsetTx(committed, "worker-c", Number(process.argv[2]));
+              committed.commit();
+
+              const rolledBack = db.transaction();
+              stream.saveOffsetTx(rolledBack, "worker-c", Number(process.argv[3]));
+              rolledBack.rollback();
+              console.log(JSON.stringify({ offset: stream.getOffset("worker-c") }));
+            } finally {
+              db.close();
+            }
+            """,
+            db_path,
+            offsets[1]["offset"],
+            offsets[2]["offset"],
+        )
+
+        assert observed["offset"] == offsets[1]["offset"]
+        assert stream.get_offset("worker-c") == offsets[1]["offset"]
+    finally:
+        py_db.close()

--- a/tests/test_node_python_interop.py
+++ b/tests/test_node_python_interop.py
@@ -228,6 +228,53 @@ def test_node_automatically_migrates_verified_0_4_6_checkpoint(tmp_path):
         py_db.close()
 
 
+def test_node_explicit_save_recovers_unverifiable_0_4_6_checkpoint(tmp_path):
+    _require_node_interop()
+    db_path = tmp_path / "unverifiable-node-checkpoint.db"
+    py_db = honker.open(str(db_path))
+    try:
+        with py_db.transaction() as tx:
+            tx.execute(
+                "INSERT INTO _honker_stream_consumers (name, topic, offset) "
+                "VALUES (?, ?, ?)",
+                ["orders", "worker-c", 999],
+            )
+
+        observed = _run_node(
+            r"""
+            const honker = require(".");
+            const db = honker.open(process.argv[1]);
+            try {
+              const stream = db.stream("orders");
+              let readError;
+              try {
+                stream.getOffset("worker-c");
+              } catch (err) {
+                readError = err.code;
+              }
+              const changed = stream.saveOffset("worker-c", 0);
+              console.log(JSON.stringify({
+                readError,
+                changed,
+                recoveredOffset: stream.getOffset("worker-c"),
+              }));
+            } finally {
+              db.close();
+            }
+            """,
+            db_path,
+        )
+
+        assert observed == {
+            "readError": "HONKER_CHECKPOINT_MIGRATION_UNVERIFIABLE",
+            "changed": True,
+            "recoveredOffset": 0,
+        }
+        assert py_db.stream("orders").get_offset("worker-c") == 0
+    finally:
+        py_db.close()
+
+
 def test_node_transactional_checkpoint_is_visible_to_python(tmp_path):
     _require_node_interop()
     db_path = tmp_path / "node-transactional-checkpoint.db"


### PR DESCRIPTION
## Summary

- fixes Node stream checkpoint calls to use the shared `(consumer, topic)` ABI
- automatically migrates a Node 0.4.6 transposed checkpoint when its retained event proves the requested stream
- keeps canonical state authoritative and preserves the legacy row for rollback
- keeps guarded reads strict while allowing explicit `saveOffset` / `saveOffsetTx` recovery from unverifiable legacy rows
- advances the Node root and native platform packages to 0.5.0
- adds CI/release checks that keep Cargo, npm manifests, the lockfile, and generated native loader versions aligned
- runs real Python ↔ Node publish, checkpoint, resume, migration, recovery, and transaction journeys in the Node matrix

## Upgrade behavior

`getOffset`, `readFromConsumer`, and `subscribe` prefer the canonical row. If only the old transposed row exists, Node verifies its offset against `_honker_stream`, copies it transactionally, and continues. If the old offset is missing or belongs to another stream, reads throw typed `CheckpointMigrationError` rather than guess.

An explicit `saveOffset(consumer, 0)` or `saveOffset(consumer, knownOffset)` establishes the caller-supplied canonical state even when the legacy row is unverifiable. `saveOffsetTx` provides the same recovery with commit/rollback atomicity. The ambiguous legacy row remains untouched and canonical state wins afterward, so recovery never requires raw SQL.

Concurrent use of Node 0.4.6 and 0.5.0 for the same consumer remains unsupported during this alpha upgrade.

## User-facing proof

- Python checkpoint → Node `readFromConsumer` resumes at the next event
- Node checkpoint → Python named subscription resumes at the next event
- Node subscription resumes from Python and persists progress back to Python
- a verified 0.4.6 legacy row migrates without replaying from zero
- an unverifiable/pruned legacy row rejects reads but accepts explicit zero and known-offset recovery
- `saveOffsetTx` recovery is invisible after rollback and canonical after commit
- reversed-name collisions cannot be silently adopted
- a clean packed 0.5.0 root + platform install passes native version enforcement and the recovery journey

## Validation

- full Node suite: 105 tests, 103 passed, 2 platform skips, 0 failures
- scoped Python stream + Node interop: 25 passed
- `npm ci` succeeds before 0.5.0 native packages are published
- clean packed npm consumer recovery proof passed with `NAPI_RS_ENFORCE_VERSION_CHECK=1`
- Node version alignment: 4 platform manifests and 26 generated loader checks agree on 0.5.0
- Python compile, Node syntax/test execution, and `git diff --check` passed
