### PR TITLE
feat(bindings): add Ruby and Elixir listeners

### DIFF
--- a/.github/workflows/release-elixir.yml
+++ b/.github/workflows/release-elixir.yml
@@ -50,6 +50,15 @@ jobs:
           mix deps.get
           mix test
           mix hex.build
+          mix hex.build --unpack --output "$RUNNER_TEMP/honker-hex-unpacked"
+
+      - name: Smoke-test the unpacked Hex package
+        working-directory: ${{ runner.temp }}/honker-hex-unpacked
+        env:
+          HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+        run: |
+          MIX_ENV=prod mix deps.get
+          MIX_ENV=prod mix run "$GITHUB_WORKSPACE/scripts/proof/elixir-hex-smoke.exs"
 
       - name: Upload Hex package artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -12,12 +12,12 @@ extension.
 | SQLite extension | load smoke | SQL | SQL | notify SQL only | SQL | SQL | host language watches/reads |
 | Python `honker` | yes | yes | yes | yes | yes | yes | shared Rust watcher |
 | Node `@russellthehippo/honker-node` | yes | yes | yes | yes | yes | yes | shared Rust watcher |
-| Ruby `honker` | yes | yes | yes | notify yes, listen no | yes | yes | extension C ABI |
+| Ruby `honker` | yes | yes | yes | yes | yes | yes | extension C ABI |
 | .NET `Honker` | yes | yes | yes | yes | yes | yes | extension C ABI |
 | Rust `honker` | CI | yes | yes | yes | yes | yes | shared Rust watcher |
 | Go | CI | yes | yes | yes | yes | yes | extension C ABI |
 | Bun `@russellthehippo/honker-bun` | CI | yes | yes | yes | yes | yes | extension C ABI |
-| Elixir `honker` | CI | yes | yes | notify yes, listen no | yes | yes | extension SQL handles |
+| Elixir `honker` | CI | yes | yes | yes | yes | yes | extension SQL handles |
 | C++ | CI | yes | yes | yes | yes | yes | extension C ABI |
 | JVM `dev.honker:honker` | CI + local clean consumer | yes | yes | yes | yes | yes | shared JVM watcher |
 | Kotlin `dev.honker:honker-kotlin` | local + ORM CI | wrapper | Flow wrapper | wrapper | wrapper | wrapper | JVM wrapper |
@@ -170,5 +170,4 @@ Backend contract:
   wrapper reverses topic and consumer at the offset SQL boundary, so its own
   resume path works but another binding will not see the same checkpoint.
 - Long soak on every OS; scary nightly soaks Linux
-- Ruby and Elixir async listen parity with Python/Node/.NET/Rust/Go/Bun/C++
 - Published Maven Central proof for JVM/Kotlin

--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -17,7 +17,7 @@ extension.
 | Rust `honker` | CI | yes | yes | yes | yes | yes | shared Rust watcher |
 | Go | CI | yes | yes | yes | yes | yes | extension C ABI |
 | Bun `@russellthehippo/honker-bun` | CI | yes | yes | yes | yes | yes | extension C ABI |
-| Elixir `honker` | CI | yes | yes | yes | yes | yes | extension SQL handles |
+| Elixir `honker` | yes | yes | yes | yes | yes | yes | extension SQL handles |
 | C++ | CI | yes | yes | yes | yes | yes | extension C ABI |
 | JVM `dev.honker:honker` | CI + local clean consumer | yes | yes | yes | yes | yes | shared JVM watcher |
 | Kotlin `dev.honker:honker-kotlin` | local + ORM CI | wrapper | Flow wrapper | wrapper | wrapper | wrapper | JVM wrapper |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -252,13 +252,11 @@ feature-parity phase should either port those task APIs to every core
 binding or define explicit API tiers so "core binding" has a precise
 meaning before 1.0.
 
-Two listener-surface gaps carry over from the shipped wake-parity work:
-
-- Ruby and Elixir expose extension-backed `notify` and table APIs but
-  still have no async listen / update-watcher API. Add one only if the
-  runtime integration can support a clean cancellation story.
-- Add parity tests exercising a cross-process notification wake in every
-  binding that has a listener API.
+Ruby and Elixir now expose high-level, live-only channel listeners backed by
+one fan-out update hub per database. Ruby listeners support explicit close and
+block cleanup; Elixir subscriptions support explicit `unlisten` and stop when
+their owner process exits. Both bindings include cross-process notification
+wake proofs across their supported watcher backends.
 
 ## Phase Atlas — Map Experimental Backend Edge-Case Behavior
 

--- a/packages/honker-ex/README.md
+++ b/packages/honker-ex/README.md
@@ -43,6 +43,23 @@ case Honker.Queue.claim_one(db, "emails", "worker-1") do
 end
 ```
 
+Live pub/sub subscriptions are channel-filtered and skip notifications that
+already existed when they attached:
+
+```elixir
+{:ok, subscription} = Honker.listen(db, "orders")
+ref = subscription.ref
+
+receive do
+  {:honker_notification, ^ref, notification} ->
+    IO.inspect(notification.payload)
+end
+
+:ok = Honker.unlisten(subscription)
+```
+
+The listener also stops automatically if the subscribing process exits.
+
 Delayed jobs use `run_at:`:
 
 ```elixir

--- a/packages/honker-ex/README.md
+++ b/packages/honker-ex/README.md
@@ -58,7 +58,8 @@ end
 :ok = Honker.unlisten(subscription)
 ```
 
-The listener also stops automatically if the subscribing process exits.
+The listener also stops automatically if the subscribing process exits or the
+database is closed.
 
 Delayed jobs use `run_at:`:
 

--- a/packages/honker-ex/lib/honker.ex
+++ b/packages/honker-ex/lib/honker.ex
@@ -43,7 +43,7 @@ defmodule Honker do
     A Honker database handle. Wraps the Exqlite reference + a
     registry of per-queue options (visibility timeout, max attempts).
     """
-    defstruct [:conn, :path, :watcher_id, queue_opts: %{}]
+    defstruct [:conn, :path, :update_hub, queue_opts: %{}]
   end
 
   @update_table :honker_local_update_seq
@@ -70,20 +70,28 @@ defmodule Honker do
     backend = watcher_backend_param(Keyword.get(opts, :watcher_backend))
     watcher_poll_interval_ms = Keyword.get(opts, :watcher_poll_interval_ms, 1)
 
-    with {:ok, conn} <- Sqlite3.open(path),
-         :ok <- Sqlite3.execute(conn, "PRAGMA busy_timeout = 5000;"),
-         :ok <- Sqlite3.enable_load_extension(conn, true),
-         :ok <- run_bare(conn, "SELECT load_extension(?1)", [extension_path]),
-         :ok <- Sqlite3.enable_load_extension(conn, false),
-         :ok <- Sqlite3.execute(conn, @default_pragmas),
-         :ok <- run_bare(conn, "SELECT honker_bootstrap()", []),
-         {:ok, [watcher_id]} <-
-           query_first(conn, "SELECT honker_update_watcher_open(?1, ?2, ?3)", [
-             path,
-             backend,
-             watcher_poll_interval_ms
-           ]) do
-      {:ok, %Database{conn: conn, path: path, watcher_id: watcher_id}}
+    with {:ok, conn} <- Sqlite3.open(path) do
+      result =
+        with :ok <- Sqlite3.execute(conn, "PRAGMA busy_timeout = 5000;"),
+             :ok <- Sqlite3.enable_load_extension(conn, true),
+             :ok <- run_bare(conn, "SELECT load_extension(?1)", [extension_path]),
+             :ok <- Sqlite3.enable_load_extension(conn, false),
+             :ok <- Sqlite3.execute(conn, @default_pragmas),
+             :ok <- run_bare(conn, "SELECT honker_bootstrap()", []),
+             {:ok, update_hub} <-
+               Honker.UpdateHub.start(path, extension_path, backend, watcher_poll_interval_ms) do
+          {:ok, %Database{conn: conn, path: path, update_hub: update_hub}}
+        end
+
+      case result do
+        {:ok, _db} = ok ->
+          ok
+
+        error ->
+          _ = Sqlite3.enable_load_extension(conn, false)
+          _ = Sqlite3.close(conn)
+          error
+      end
     end
   end
 
@@ -91,8 +99,8 @@ defmodule Honker do
   defp watcher_backend_param(backend) when is_binary(backend), do: backend
   defp watcher_backend_param(backend), do: inspect(backend)
 
-  def close(%Database{conn: conn, watcher_id: watcher_id}) do
-    _ = query_first(conn, "SELECT honker_update_watcher_close(?1)", [watcher_id])
+  def close(%Database{conn: conn, update_hub: update_hub}) do
+    _ = Honker.UpdateHub.close(update_hub)
     Sqlite3.close(conn)
   end
 
@@ -136,6 +144,23 @@ defmodule Honker do
       {:ok, [id]} -> {:ok, id}
       other -> other
     end
+  end
+
+  @doc """
+  Subscribe the calling process to live notifications on `channel`.
+
+  Historical rows are skipped. New notifications arrive as
+  `{:honker_notification, subscription.ref, %Honker.Notification{}}`.
+  Call `unlisten/1` to stop explicitly; the listener also stops when the
+  subscribing process exits.
+  """
+  def listen(%Database{} = db, channel, opts \\ []) do
+    Honker.Listener.start(db, channel, self(), opts)
+  end
+
+  @doc "Stop a live notification subscription. Idempotent."
+  def unlisten(%Honker.Subscription{} = subscription) do
+    Honker.Listener.close(subscription)
   end
 
   @doc """
@@ -242,16 +267,8 @@ defmodule Honker do
   end
 
   @doc false
-  def wait_for_update(%Database{conn: conn, watcher_id: watcher_id}, timeout_ms) do
-    case query_first(conn, "SELECT honker_update_watcher_wait(?1, ?2)", [
-           watcher_id,
-           max(0, timeout_ms)
-         ]) do
-      {:ok, [1]} -> :changed
-      {:ok, [0]} -> :timeout
-      {:ok, [-1]} -> {:error, "honker update watcher closed or died"}
-      other -> other
-    end
+  def wait_for_update(%Database{update_hub: update_hub}, timeout_ms) do
+    Honker.UpdateHub.wait(update_hub, timeout_ms)
   end
 
   @doc false
@@ -267,6 +284,23 @@ defmodule Honker do
 
       err ->
         err
+    end
+  end
+
+  @doc false
+  def query_all(conn, sql, params) do
+    case Sqlite3.prepare(conn, sql) do
+      {:ok, stmt} ->
+        try do
+          with :ok <- Sqlite3.bind(stmt, params) do
+            collect_rows(conn, stmt, [])
+          end
+        after
+          _ = Sqlite3.release(conn, stmt)
+        end
+
+      error ->
+        error
     end
   end
 
@@ -295,6 +329,14 @@ defmodule Honker do
 
       _ ->
         @update_table
+    end
+  end
+
+  defp collect_rows(conn, stmt, rows) do
+    case Sqlite3.step(conn, stmt) do
+      {:row, row} -> collect_rows(conn, stmt, [row | rows])
+      :done -> {:ok, Enum.reverse(rows)}
+      error -> error
     end
   end
 end

--- a/packages/honker-ex/lib/honker.ex
+++ b/packages/honker-ex/lib/honker.ex
@@ -152,7 +152,7 @@ defmodule Honker do
   Historical rows are skipped. New notifications arrive as
   `{:honker_notification, subscription.ref, %Honker.Notification{}}`.
   Call `unlisten/1` to stop explicitly; the listener also stops when the
-  subscribing process exits.
+  subscribing process exits or the database is closed.
   """
   def listen(%Database{} = db, channel, opts \\ []) do
     Honker.Listener.start(db, channel, self(), opts)

--- a/packages/honker-ex/lib/honker/listener.ex
+++ b/packages/honker-ex/lib/honker/listener.ex
@@ -1,0 +1,181 @@
+defmodule Honker.Notification do
+  @moduledoc "A live notification delivered by `Honker.listen/3`."
+  defstruct [:id, :channel, :payload, :created_at]
+end
+
+defmodule Honker.Subscription do
+  @moduledoc "An opaque live-notification subscription."
+  defstruct [:pid, :ref, :channel]
+end
+
+defmodule Honker.Listener do
+  @moduledoc false
+
+  use GenServer
+
+  alias Exqlite.Sqlite3
+  alias Honker.{Database, Notification, Subscription, UpdateHub}
+
+  def start(%Database{} = db, channel, owner, opts) do
+    ref = make_ref()
+
+    case GenServer.start(__MODULE__, {db, to_string(channel), owner, ref, opts}) do
+      {:ok, pid} -> {:ok, %Subscription{pid: pid, ref: ref, channel: to_string(channel)}}
+      error -> error
+    end
+  end
+
+  def close(%Subscription{pid: pid}) do
+    if Process.alive?(pid), do: GenServer.stop(pid, :normal), else: :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  @impl true
+  def init({db, channel, owner, ref, opts}) do
+    fallback_poll_ms = Keyword.get(opts, :fallback_poll_ms, 15_000)
+
+    cond do
+      channel == "" ->
+        {:stop, "channel must not be empty"}
+
+      !is_nil(fallback_poll_ms) and (!is_integer(fallback_poll_ms) or fallback_poll_ms <= 0) ->
+        {:stop, "fallback_poll_ms must be a positive integer or nil"}
+
+      true ->
+        with {:ok, read_conn} <- open_read_connection(db.path) do
+          result =
+            with :ok <- UpdateHub.subscribe(db.update_hub, self()),
+                 {:ok, [last_seen]} <-
+                   Honker.query_first(
+                     read_conn,
+                     "SELECT COALESCE(MAX(id), 0) FROM _honker_notifications WHERE channel = ?1",
+                     [channel]
+                   ) do
+              owner_monitor = Process.monitor(owner)
+              timer = schedule_fallback(fallback_poll_ms)
+              send(self(), :poll)
+
+              {:ok,
+               %{
+                 db: db,
+                 read_conn: read_conn,
+                 channel: channel,
+                 owner: owner,
+                 owner_monitor: owner_monitor,
+                 ref: ref,
+                 last_seen: last_seen || 0,
+                 fallback_poll_ms: fallback_poll_ms,
+                 fallback_timer: timer
+               }}
+            end
+
+          case result do
+            {:ok, _state} = ok ->
+              ok
+
+            error ->
+              _ = Sqlite3.close(read_conn)
+              {:stop, error}
+          end
+        else
+          error -> {:stop, error}
+        end
+    end
+  end
+
+  @impl true
+  def handle_info(:poll, state), do: poll(state)
+
+  def handle_info({:honker_update, hub, _generation}, %{db: %{update_hub: hub}} = state) do
+    poll(state)
+  end
+
+  def handle_info(:fallback_poll, state) do
+    state = %{state | fallback_timer: schedule_fallback(state.fallback_poll_ms)}
+    poll(state)
+  end
+
+  def handle_info({:honker_update_hub_error, hub, reason}, %{db: %{update_hub: hub}} = state) do
+    if reason != :closed do
+      send(state.owner, {:honker_listener_error, state.ref, reason})
+    end
+
+    {:stop, :normal, state}
+  end
+
+  def handle_info(
+        {:DOWN, monitor, :process, owner, _reason},
+        %{owner_monitor: monitor, owner: owner} = state
+      ) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    if state.fallback_timer, do: Process.cancel_timer(state.fallback_timer)
+    _ = UpdateHub.unsubscribe(state.db.update_hub, self())
+    _ = Sqlite3.close(state.read_conn)
+    :ok
+  end
+
+  defp poll(state) do
+    sql = """
+    SELECT id, channel, payload, created_at
+    FROM _honker_notifications
+    WHERE channel = ?1 AND id > ?2
+    ORDER BY id
+    LIMIT 1000
+    """
+
+    case Honker.query_all(state.read_conn, sql, [state.channel, state.last_seen]) do
+      {:ok, rows} ->
+        last_seen =
+          Enum.reduce(rows, state.last_seen, fn [id, channel, payload, created_at], _last ->
+            notification = %Notification{
+              id: id,
+              channel: channel,
+              payload: decode_payload(payload),
+              created_at: created_at
+            }
+
+            send(state.owner, {:honker_notification, state.ref, notification})
+            id
+          end)
+
+        if length(rows) == 1_000, do: send(self(), :poll)
+        {:noreply, %{state | last_seen: last_seen}}
+
+      error ->
+        send(state.owner, {:honker_listener_error, state.ref, error})
+        {:stop, :normal, state}
+    end
+  end
+
+  defp decode_payload(payload) when is_binary(payload) do
+    case Jason.decode(payload) do
+      {:ok, decoded} -> decoded
+      {:error, _} -> payload
+    end
+  end
+
+  defp decode_payload(payload), do: payload
+
+  defp schedule_fallback(nil), do: nil
+  defp schedule_fallback(ms), do: Process.send_after(self(), :fallback_poll, ms)
+
+  defp open_read_connection(path) do
+    with {:ok, conn} <- Sqlite3.open(path) do
+      case Sqlite3.execute(conn, "PRAGMA busy_timeout = 5000; PRAGMA query_only = ON;") do
+        :ok ->
+          {:ok, conn}
+
+        error ->
+          _ = Sqlite3.close(conn)
+          error
+      end
+    end
+  end
+end

--- a/packages/honker-ex/lib/honker/update_hub.ex
+++ b/packages/honker-ex/lib/honker/update_hub.ex
@@ -1,0 +1,310 @@
+defmodule Honker.UpdateHub do
+  @moduledoc false
+
+  use GenServer
+
+  alias Exqlite.Sqlite3
+
+  @wait_slice_ms 100
+
+  def start(path, extension_path, backend, poll_interval_ms) do
+    GenServer.start(__MODULE__, {path, extension_path, backend, poll_interval_ms})
+  end
+
+  def close(pid) when is_pid(pid) do
+    if Process.alive?(pid) do
+      GenServer.call(pid, :close, 5_000)
+    else
+      :ok
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
+  def wait(pid, timeout_ms) when is_pid(pid) do
+    timeout_ms = max(0, timeout_ms)
+    GenServer.call(pid, {:wait, timeout_ms}, timeout_ms + 1_000)
+  end
+
+  def subscribe(pid, subscriber \\ self()) do
+    GenServer.call(pid, {:subscribe, subscriber})
+  end
+
+  def unsubscribe(pid, subscriber \\ self()) do
+    if Process.alive?(pid), do: GenServer.call(pid, {:unsubscribe, subscriber}), else: :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  @impl true
+  def init({path, extension_path, backend, poll_interval_ms}) do
+    Process.flag(:trap_exit, true)
+
+    case open_watcher(path, extension_path, backend, poll_interval_ms) do
+      {:ok, conn, watcher_id} ->
+        hub = self()
+        worker = spawn_link(fn -> wait_loop(hub, conn, watcher_id) end)
+
+        {:ok,
+         %{
+           conn: conn,
+           watcher_id: watcher_id,
+           worker: worker,
+           generation: 0,
+           seen: %{},
+           waiter_monitors: %{},
+           waiters: %{},
+           subscribers: %{},
+           error: nil,
+           closed: false
+         }}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+
+  @impl true
+  def handle_call({:subscribe, subscriber}, _from, state) do
+    cond do
+      state.error ->
+        {:reply, {:error, state.error}, state}
+
+      Map.has_key?(state.subscribers, subscriber) ->
+        {:reply, :ok, state}
+
+      true ->
+        monitor = Process.monitor(subscriber)
+        {:reply, :ok, put_in(state.subscribers[subscriber], monitor)}
+    end
+  end
+
+  def handle_call({:unsubscribe, subscriber}, _from, state) do
+    {:reply, :ok, drop_subscriber(state, subscriber)}
+  end
+
+  def handle_call({:wait, timeout_ms}, {pid, _tag} = from, state) do
+    state = ensure_waiter_monitor(state, pid)
+
+    cond do
+      state.error ->
+        {:reply, {:error, state.error}, state}
+
+      state.generation > Map.get(state.seen, pid, 0) ->
+        {:reply, :changed, put_in(state.seen[pid], state.generation)}
+
+      timeout_ms == 0 ->
+        {:reply, :timeout, state}
+
+      true ->
+        ref = make_ref()
+        timer = Process.send_after(self(), {:wait_timeout, ref}, timeout_ms)
+        waiter = %{from: from, pid: pid, timer: timer}
+        {:noreply, put_in(state.waiters[ref], waiter)}
+    end
+  end
+
+  def handle_call(:close, _from, state) do
+    state = shutdown(state, :closed)
+    {:stop, :normal, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:watcher_changed, state) do
+    generation = state.generation + 1
+
+    Enum.each(state.subscribers, fn {pid, _monitor} ->
+      send(pid, {:honker_update, self(), generation})
+    end)
+
+    seen =
+      Enum.reduce(state.waiters, state.seen, fn {_ref, waiter}, acc ->
+        Process.cancel_timer(waiter.timer)
+        GenServer.reply(waiter.from, :changed)
+        Map.put(acc, waiter.pid, generation)
+      end)
+
+    {:noreply, %{state | generation: generation, seen: seen, waiters: %{}}}
+  end
+
+  def handle_info({:watcher_error, reason}, state) do
+    Enum.each(state.waiters, fn {_ref, waiter} ->
+      Process.cancel_timer(waiter.timer)
+      GenServer.reply(waiter.from, {:error, reason})
+    end)
+
+    Enum.each(state.subscribers, fn {pid, _monitor} ->
+      send(pid, {:honker_update_hub_error, self(), reason})
+    end)
+
+    {:noreply, %{state | error: reason, waiters: %{}}}
+  end
+
+  def handle_info({:wait_timeout, ref}, state) do
+    case Map.pop(state.waiters, ref) do
+      {nil, _waiters} ->
+        {:noreply, state}
+
+      {waiter, waiters} ->
+        GenServer.reply(waiter.from, :timeout)
+        {:noreply, %{state | waiters: waiters}}
+    end
+  end
+
+  def handle_info({:DOWN, monitor, :process, pid, _reason}, state) do
+    cond do
+      state.subscribers[pid] == monitor ->
+        {:noreply, drop_subscriber(state, pid)}
+
+      state.waiter_monitors[pid] == monitor ->
+        {:noreply, drop_waiter_process(state, pid)}
+
+      true ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:EXIT, worker, reason}, %{worker: worker} = state) do
+    if state.closed or reason == :normal do
+      {:noreply, state}
+    else
+      handle_info({:watcher_error, "honker update watcher exited: #{inspect(reason)}"}, state)
+    end
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    unless state.closed do
+      _ = shutdown(state, :closed)
+    end
+
+    :ok
+  end
+
+  defp open_watcher(path, extension_path, backend, poll_interval_ms) do
+    case Sqlite3.open(path) do
+      {:ok, conn} ->
+        result =
+          with :ok <- Sqlite3.execute(conn, "PRAGMA busy_timeout = 5000;"),
+               :ok <- Sqlite3.enable_load_extension(conn, true),
+               :ok <- Honker.run_bare(conn, "SELECT load_extension(?1)", [extension_path]),
+               :ok <- Sqlite3.enable_load_extension(conn, false),
+               {:ok, [watcher_id]} <-
+                 Honker.query_first(conn, "SELECT honker_update_watcher_open(?1, ?2, ?3)", [
+                   path,
+                   backend,
+                   poll_interval_ms
+                 ]) do
+            {:ok, conn, watcher_id}
+          end
+
+        case result do
+          {:ok, _, _} = ok ->
+            ok
+
+          error ->
+            _ = Sqlite3.enable_load_extension(conn, false)
+            _ = Sqlite3.close(conn)
+            error
+        end
+
+      error ->
+        error
+    end
+  end
+
+  defp wait_loop(hub, conn, watcher_id) do
+    receive do
+      {:stop, caller} ->
+        send(caller, {:watcher_stopped, self()})
+    after
+      0 ->
+        case Honker.query_first(conn, "SELECT honker_update_watcher_wait(?1, ?2)", [
+               watcher_id,
+               @wait_slice_ms
+             ]) do
+          {:ok, [1]} ->
+            send(hub, :watcher_changed)
+            wait_loop(hub, conn, watcher_id)
+
+          {:ok, [0]} ->
+            wait_loop(hub, conn, watcher_id)
+
+          {:ok, [-1]} ->
+            send(hub, {:watcher_error, "honker update watcher closed or died"})
+
+          error ->
+            send(hub, {:watcher_error, inspect(error)})
+        end
+    end
+  end
+
+  defp shutdown(%{closed: true} = state, _reason), do: state
+
+  defp shutdown(state, reason) do
+    Enum.each(state.waiters, fn {_ref, waiter} ->
+      Process.cancel_timer(waiter.timer)
+      GenServer.reply(waiter.from, {:error, reason})
+    end)
+
+    Enum.each(state.subscribers, fn {pid, _monitor} ->
+      send(pid, {:honker_update_hub_error, self(), reason})
+    end)
+
+    Enum.each(state.waiter_monitors, fn {_pid, monitor} ->
+      Process.demonitor(monitor, [:flush])
+    end)
+
+    send(state.worker, {:stop, self()})
+
+    receive do
+      {:watcher_stopped, worker} when worker == state.worker -> :ok
+    after
+      1_000 -> Process.exit(state.worker, :kill)
+    end
+
+    _ =
+      Honker.query_first(state.conn, "SELECT honker_update_watcher_close(?1)", [state.watcher_id])
+
+    _ = Sqlite3.close(state.conn)
+    %{state | closed: true, waiters: %{}, subscribers: %{}, waiter_monitors: %{}, seen: %{}}
+  end
+
+  defp drop_subscriber(state, pid) do
+    case Map.pop(state.subscribers, pid) do
+      {nil, _} ->
+        state
+
+      {monitor, subscribers} ->
+        Process.demonitor(monitor, [:flush])
+        %{state | subscribers: subscribers}
+    end
+  end
+
+  defp ensure_waiter_monitor(state, pid) do
+    if Map.has_key?(state.waiter_monitors, pid) do
+      state
+    else
+      put_in(state.waiter_monitors[pid], Process.monitor(pid))
+    end
+  end
+
+  defp drop_waiter_process(state, pid) do
+    waiters =
+      Enum.reduce(state.waiters, %{}, fn {ref, waiter}, acc ->
+        if waiter.pid == pid do
+          Process.cancel_timer(waiter.timer)
+          acc
+        else
+          Map.put(acc, ref, waiter)
+        end
+      end)
+
+    %{
+      state
+      | seen: Map.delete(state.seen, pid),
+        waiter_monitors: Map.delete(state.waiter_monitors, pid),
+        waiters: waiters
+    }
+  end
+end

--- a/packages/honker-ex/mix.exs
+++ b/packages/honker-ex/mix.exs
@@ -4,7 +4,7 @@ defmodule Honker.MixProject do
   def project do
     [
       app: :honker,
-      version: "0.5.0",
+      version: "0.6.0",
       elixir: "~> 1.17",
       description:
         "Durable queues, streams, pub/sub, and scheduler on SQLite. " <>

--- a/packages/honker-ex/test/honker_test.exs
+++ b/packages/honker-ex/test/honker_test.exs
@@ -382,6 +382,16 @@ defmodule HonkerTest do
     end)
   end
 
+  defp receive_notifications(ref, count, timeout_ms \\ 2_000) do
+    Enum.map(1..count, fn _ ->
+      receive do
+        {:honker_notification, ^ref, notification} -> notification
+      after
+        timeout_ms -> flunk("timed out waiting for notification")
+      end
+    end)
+  end
+
   setup do
     case find_extension() do
       nil ->
@@ -534,6 +544,107 @@ defmodule HonkerTest do
     refute_receive {:honker_notification, ^ref, _}, 50
 
     assert :ok = Honker.unlisten(subscription)
+  end
+
+  test "listener fallback recovers when the watcher misses a wake", ctx do
+    {:ok, subscription} = Honker.listen(ctx.db, "orders", fallback_poll_ms: 20)
+    ref = subscription.ref
+    worker = :sys.get_state(ctx.db.update_hub).worker
+    Process.sleep(25)
+    true = :erlang.suspend_process(worker)
+
+    try do
+      {:ok, _} = Honker.notify(ctx.db, "orders", %{"id" => "fallback"})
+      assert_receive {:honker_notification, ^ref, notification}, 1_000
+      assert notification.payload == %{"id" => "fallback"}
+    after
+      if Process.alive?(worker), do: :erlang.resume_process(worker)
+      Honker.unlisten(subscription)
+    end
+  end
+
+  test "listeners drain more than one batch to multiple slow consumers", ctx do
+    {:ok, first} = Honker.listen(ctx.db, "orders", fallback_poll_ms: nil)
+    {:ok, second} = Honker.listen(ctx.db, "orders", fallback_poll_ms: nil)
+
+    {:ok, tx} = Honker.Transaction.begin(ctx.db)
+
+    for i <- 0..1_104 do
+      assert {:ok, _} = Honker.notify_tx(tx, "orders", %{"seq" => i})
+    end
+
+    :ok = Honker.Transaction.commit(tx)
+    Process.sleep(50)
+
+    first_rows = receive_notifications(first.ref, 1_105)
+    second_rows = receive_notifications(second.ref, 1_105)
+    assert Enum.map(first_rows, & &1.payload["seq"]) == Enum.to_list(0..1_104)
+    assert Enum.map(first_rows, & &1.id) == Enum.map(second_rows, & &1.id)
+    refute_receive {:honker_notification, _, _}, 25
+
+    assert :ok = Honker.unlisten(first)
+    assert :ok = Honker.unlisten(second)
+  end
+
+  test "listener churn does not leak subscribers or break future delivery", ctx do
+    for _ <- 1..50 do
+      {:ok, subscription} = Honker.listen(ctx.db, "orders", fallback_poll_ms: nil)
+      assert :ok = Honker.unlisten(subscription)
+    end
+
+    assert map_size(:sys.get_state(ctx.db.update_hub).subscribers) == 0
+    {:ok, subscription} = Honker.listen(ctx.db, "orders", fallback_poll_ms: nil)
+    {:ok, _} = Honker.notify(ctx.db, "orders", %{"ok" => true})
+    assert_receive {:honker_notification, ref, notification}, 2_000
+    assert ref == subscription.ref
+    assert notification.payload == %{"ok" => true}
+    assert :ok = Honker.unlisten(subscription)
+  end
+
+  test "listener survives writer reconnects", ctx do
+    {:ok, subscription} = Honker.listen(ctx.db, "orders", fallback_poll_ms: nil)
+    ref = subscription.ref
+
+    for i <- 0..1 do
+      {:ok, writer} = Honker.open(ctx.db_path, extension_path: ctx.ext)
+      {:ok, _} = Honker.notify(writer, "orders", %{"reconnect" => i})
+      :ok = Honker.close(writer)
+      assert_receive {:honker_notification, ^ref, notification}, 2_000
+      assert notification.payload == %{"reconnect" => i}
+    end
+
+    assert :ok = Honker.unlisten(subscription)
+  end
+
+  test "database replacement surfaces watcher failure to listener", ctx do
+    if :os.type() == {:win32, :nt} do
+      :ok
+    else
+      {:ok, subscription} = Honker.listen(ctx.db, "orders", fallback_poll_ms: nil)
+      ref = subscription.ref
+      listener_monitor = Process.monitor(subscription.pid)
+      Process.sleep(150)
+      replacement = Path.join(Path.dirname(ctx.db_path), "replacement.db")
+      File.write!(replacement, "")
+      File.rename!(replacement, ctx.db_path)
+
+      assert_receive {:honker_listener_error, ^ref, reason}, 2_000
+      assert reason =~ "watcher closed or died"
+      assert_receive {:DOWN, ^listener_monitor, :process, _pid, _reason}, 1_000
+    end
+  end
+
+  test "watcher worker failure is reported and stops listeners", ctx do
+    {:ok, subscription} = Honker.listen(ctx.db, "orders", fallback_poll_ms: nil)
+    ref = subscription.ref
+    listener_monitor = Process.monitor(subscription.pid)
+    worker = :sys.get_state(ctx.db.update_hub).worker
+
+    Process.exit(worker, :kill)
+
+    assert_receive {:honker_listener_error, ^ref, reason}, 1_000
+    assert reason =~ "update watcher exited"
+    assert_receive {:DOWN, ^listener_monitor, :process, _pid, _reason}, 1_000
   end
 
   test "listener stops when its subscribing process exits", ctx do

--- a/packages/honker-ex/test/honker_test.exs
+++ b/packages/honker-ex/test/honker_test.exs
@@ -60,7 +60,13 @@ defmodule HonkerWatcherBackendOptionTest do
 
   test "custom watcher poll interval detects commits" do
     ext = find_extension() || flunk("honker extension not built")
-    dir = Path.join(System.tmp_dir!(), "honker-ex-watch-interval-#{System.unique_integer([:positive])}")
+
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "honker-ex-watch-interval-#{System.unique_integer([:positive])}"
+      )
+
     File.mkdir_p!(dir)
     path = Path.join(dir, "t.db")
 
@@ -324,6 +330,33 @@ defmodule HonkerWatcherBackendQueueTest do
       end
     end
   end
+
+  test "listener backends observe a notification from another process" do
+    ext = find_extension() || flunk("honker extension not built")
+
+    for backend <- @backends do
+      {dir, path} = tmp_db()
+
+      try do
+        if bootstrap(path, ext, backend) != :skip do
+          pin = maybe_pin_shm(path, ext, backend)
+          {:ok, db} = Honker.open(path, extension_path: ext, watcher_backend: backend)
+          {:ok, subscription} = Honker.listen(db, "cross-process", fallback_poll_ms: nil)
+          ref = subscription.ref
+
+          run_helper(["notify", path, ext, "cross-process", ~s({"source":"child"})])
+
+          assert_receive {:honker_notification, ^ref, notification}, 2_000
+          assert notification.payload == %{"source" => "child"}
+          :ok = Honker.unlisten(subscription)
+          Honker.close(db)
+          close_pin(pin)
+        end
+      after
+        File.rm_rf!(dir)
+      end
+    end
+  end
 end
 
 defmodule HonkerTest do
@@ -422,5 +455,117 @@ defmodule HonkerTest do
 
     assert channel == "orders"
     assert Jason.decode!(payload) == %{"id" => 42}
+  end
+
+  test "listen is live-only, channel-filtered, and ordered", ctx do
+    db = ctx.db
+    {:ok, _} = Honker.notify(db, "orders", %{"id" => "historical"})
+    {:ok, subscription} = Honker.listen(db, "orders", fallback_poll_ms: nil)
+    ref = subscription.ref
+
+    refute_receive {:honker_notification, ^ref, _}, 50
+    {:ok, _} = Honker.notify(db, "other", %{"id" => "wrong-channel"})
+    {:ok, _} = Honker.notify(db, "orders", %{"id" => 1})
+    {:ok, _} = Honker.notify(db, "orders", %{"id" => 2})
+
+    assert_receive {:honker_notification, ^ref, first}, 2_000
+    assert_receive {:honker_notification, ^ref, second}, 2_000
+    assert first.payload == %{"id" => 1}
+    assert second.payload == %{"id" => 2}
+    assert first.channel == "orders"
+    assert second.id > first.id
+    assert first.created_at > 0
+    refute_receive {:honker_notification, ^ref, _}, 50
+
+    assert :ok = Honker.unlisten(subscription)
+  end
+
+  test "multiple listeners and wait_for_update all observe one commit", ctx do
+    db = ctx.db
+    {:ok, first} = Honker.listen(db, "orders", fallback_poll_ms: nil)
+    {:ok, second} = Honker.listen(db, "orders", fallback_poll_ms: nil)
+    first_ref = first.ref
+    second_ref = second.ref
+
+    parent = self()
+    waiter = spawn(fn -> send(parent, {:wait_result, Honker.wait_for_update(db, 2_000)}) end)
+
+    {:ok, _} = Honker.notify(db, "orders", %{"id" => 42})
+
+    assert_receive {:honker_notification, ^first_ref, first_notification}, 2_000
+    assert_receive {:honker_notification, ^second_ref, second_notification}, 2_000
+    assert_receive {:wait_result, :changed}, 2_000
+    assert first_notification.id == second_notification.id
+    assert first_notification.payload == %{"id" => 42}
+
+    assert :ok = Honker.unlisten(first)
+    assert :ok = Honker.unlisten(second)
+    refute Process.alive?(waiter)
+  end
+
+  test "listener observes commit but not rollback", ctx do
+    db = ctx.db
+    {:ok, subscription} = Honker.listen(db, "orders", fallback_poll_ms: nil)
+    ref = subscription.ref
+
+    {:ok, tx} = Honker.Transaction.begin(db)
+    {:ok, _} = Honker.notify_tx(tx, "orders", %{"id" => "rolled-back"})
+    :ok = Honker.Transaction.rollback(tx)
+    refute_receive {:honker_notification, ^ref, _}, 50
+
+    {:ok, tx2} = Honker.Transaction.begin(db)
+    {:ok, _} = Honker.notify_tx(tx2, "orders", %{"id" => "committed"})
+    :ok = Honker.Transaction.commit(tx2)
+
+    assert_receive {:honker_notification, ^ref, notification}, 2_000
+    assert notification.payload == %{"id" => "committed"}
+    assert :ok = Honker.unlisten(subscription)
+  end
+
+  test "listener fallback polling does not expose uncommitted rows", ctx do
+    db = ctx.db
+    {:ok, subscription} = Honker.listen(db, "orders", fallback_poll_ms: 10)
+    ref = subscription.ref
+
+    {:ok, tx} = Honker.Transaction.begin(db)
+    {:ok, _} = Honker.notify_tx(tx, "orders", %{"id" => "uncommitted"})
+    refute_receive {:honker_notification, ^ref, _}, 75
+    :ok = Honker.Transaction.rollback(tx)
+    refute_receive {:honker_notification, ^ref, _}, 50
+
+    assert :ok = Honker.unlisten(subscription)
+  end
+
+  test "listener stops when its subscribing process exits", ctx do
+    parent = self()
+
+    owner =
+      spawn(fn ->
+        {:ok, subscription} = Honker.listen(ctx.db, "orders", fallback_poll_ms: nil)
+        send(parent, {:subscription, subscription})
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive {:subscription, subscription}, 1_000
+    listener_monitor = Process.monitor(subscription.pid)
+    Process.exit(owner, :kill)
+    assert_receive {:DOWN, ^listener_monitor, :process, _pid, _reason}, 1_000
+  end
+
+  test "closing a database stops its listeners without reporting an error", ctx do
+    {:ok, subscription} = Honker.listen(ctx.db, "orders", fallback_poll_ms: nil)
+    ref = subscription.ref
+    listener_monitor = Process.monitor(subscription.pid)
+
+    :ok = Honker.close(ctx.db)
+
+    assert_receive {:DOWN, ^listener_monitor, :process, _pid, _reason}, 1_000
+    refute_receive {:honker_listener_error, ^ref, _}, 50
+  end
+
+  test "unlisten is idempotent", ctx do
+    {:ok, subscription} = Honker.listen(ctx.db, "orders")
+    assert :ok = Honker.unlisten(subscription)
+    assert :ok = Honker.unlisten(subscription)
   end
 end

--- a/packages/honker-ex/test/python_interop_test.exs
+++ b/packages/honker-ex/test/python_interop_test.exs
@@ -177,4 +177,33 @@ defmodule HonkerPythonInteropTest do
       assert length(events) == 2
     end
   end
+
+  test "elixir listener receives a live notification from python", ctx do
+    if Map.get(ctx, :skip) do
+      :ok
+    else
+      {:ok, subscription} = Honker.listen(ctx.db, "python-live", fallback_poll_ms: nil)
+      ref = subscription.ref
+
+      script = """
+      import os
+      import honker
+
+      db = honker.open(os.environ["DB_PATH"])
+      with db.transaction() as tx:
+          tx.notify("python-live", {"source": "python", "live": True})
+      """
+
+      {out, status} =
+        System.cmd(ctx.python, ["-c", script],
+          env: [{"PYTHONPATH", python_path()}, {"DB_PATH", ctx.db_path}],
+          stderr_to_stdout: true
+        )
+
+      assert status == 0, out
+      assert_receive {:honker_notification, ^ref, notification}, 2_000
+      assert notification.payload == %{"source" => "python", "live" => true}
+      assert :ok = Honker.unlisten(subscription)
+    end
+  end
 end

--- a/packages/honker-ex/test/watcher_backend_queue_helper.exs
+++ b/packages/honker-ex/test/watcher_backend_queue_helper.exs
@@ -23,6 +23,12 @@ defmodule HonkerWatcherBackendQueueHelper do
     Honker.close(db)
   end
 
+  def main(["notify", path, ext, channel, payload]) do
+    {:ok, db} = Honker.open(path, extension_path: ext)
+    {:ok, _} = Honker.notify(db, channel, Jason.decode!(payload))
+    Honker.close(db)
+  end
+
   defp drain(db, worker_id, acc, deadline_ms) do
     case Honker.Queue.claim_one(db, "shared", worker_id) do
       {:ok, nil} ->
@@ -37,7 +43,8 @@ defmodule HonkerWatcherBackendQueueHelper do
               drain(db, worker_id, acc, deadline_ms)
             end
 
-          {:error, reason} -> raise "watcher failed: #{inspect(reason)}"
+          {:error, reason} ->
+            raise "watcher failed: #{inspect(reason)}"
         end
 
       {:ok, job} ->

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -230,6 +230,19 @@ if (job = q.claim_one("worker-1"))
 end
 ```
 
+Live pub/sub listeners are channel-filtered and skip notifications that
+already existed when they attached:
+
+```ruby
+db.listen("orders") do |notification|
+  puts notification.payload
+end
+```
+
+Without a block, `listen` returns an enumerable listener. Use
+`listener.next(timeout_s: 5)` for a bounded wait and call `listener.close`
+when finished.
+
 Delayed jobs use `run_at:`:
 
 ```ruby

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -241,7 +241,7 @@ end
 
 Without a block, `listen` returns an enumerable listener. Use
 `listener.next(timeout_s: 5)` for a bounded wait and call `listener.close`
-when finished.
+when finished. Closing the database also closes every listener created from it.
 
 Delayed jobs use `run_at:`:
 

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -159,6 +159,264 @@ module Honker
     end
   end
 
+  # Fans one native watcher out to any number of Ruby waiters. The native
+  # watcher owns a single receiver, so callers must not race each other on
+  # CoreWatcher#wait directly.
+  class UpdateHub
+    WAIT_SLICE_S = 0.1
+
+    def initialize(watcher)
+      @watcher = watcher
+      @mutex = Mutex.new
+      @changed = ConditionVariable.new
+      @generation = 0
+      @seen_by_thread = {}
+      @stopping = false
+      @closed = false
+      @disposed = false
+      @error = nil
+      @thread = Thread.new { run }
+      @thread.name = "honker-update-hub" if @thread.respond_to?(:name=)
+    end
+
+    def snapshot
+      @mutex.synchronize { @generation }
+    end
+
+    def closed?
+      @mutex.synchronize { @closed }
+    end
+
+    def signal
+      @mutex.synchronize do
+        return if @closed
+
+        @generation += 1
+        @changed.broadcast
+      end
+    end
+
+    def wait_after(generation, timeout_s = nil)
+      deadline = timeout_s.nil? ? nil : monotonic_now + [timeout_s.to_f, 0.0].max
+      @mutex.synchronize do
+        loop do
+          raise @error if @error
+          return false if @closed
+          return true if @generation > generation
+
+          if deadline
+            remaining = deadline - monotonic_now
+            return false if remaining <= 0
+
+            @changed.wait(@mutex, remaining)
+          else
+            @changed.wait(@mutex)
+          end
+        end
+      end
+    end
+
+    def wait(timeout_s)
+      deadline = monotonic_now + [timeout_s.to_f, 0.0].max
+      key = Thread.current
+      @mutex.synchronize do
+        @seen_by_thread.delete_if { |thread, _generation| !thread.alive? }
+        loop do
+          raise @error if @error
+          return false if @closed
+          if @generation > @seen_by_thread.fetch(key, 0)
+            @seen_by_thread[key] = @generation
+            return true
+          end
+
+          remaining = deadline - monotonic_now
+          return false if remaining <= 0
+
+          @changed.wait(@mutex, remaining)
+        end
+      end
+    end
+
+    def close
+      @mutex.synchronize do
+        return if @disposed
+
+        if @stopping
+          @changed.wait(@mutex) until @disposed
+          return
+        end
+
+        @stopping = true
+      end
+      begin
+        @thread.join
+        @watcher.close
+      ensure
+        @mutex.synchronize do
+          @disposed = true
+          @closed = true
+          @changed.broadcast
+        end
+      end
+    end
+
+    private
+
+    def run
+      loop do
+        break if @mutex.synchronize { @stopping }
+
+        signal if @watcher.wait(WAIT_SLICE_S)
+      end
+    rescue StandardError => e
+      @mutex.synchronize do
+        @error = e
+        @closed = true
+        @changed.broadcast
+      end
+    ensure
+      @mutex.synchronize do
+        @closed = true unless @stopping
+        @changed.broadcast
+      end
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+
+  # A live pub/sub notification. Payloads produced by Database#notify are
+  # JSON-decoded; raw non-JSON SQL payloads are returned unchanged.
+  Notification = Struct.new(:id, :channel, :payload, :created_at)
+
+  class Listener
+    include Enumerable
+
+    def initialize(db, channel, fallback_poll_s: 15.0)
+      raise ArgumentError, "channel must not be empty" if channel.to_s.empty?
+      if !fallback_poll_s.nil? && !fallback_poll_s.to_f.positive?
+        raise ArgumentError, "fallback_poll_s must be positive or nil"
+      end
+
+      @db = db
+      @channel = channel.to_s
+      @fallback_poll_s = fallback_poll_s&.to_f
+      @buffer = []
+      @state_mutex = Mutex.new
+      @active_calls = 0
+      @closed = false
+      @read_db = SQLite3::Database.new(@db.path)
+      @read_db.busy_timeout = 5000
+      @read_db.execute("PRAGMA query_only = ON")
+      @last_seen = @read_db.get_first_value(
+        "SELECT COALESCE(MAX(id), 0) FROM _honker_notifications WHERE channel = ?",
+        [@channel],
+      ).to_i
+    rescue StandardError
+      @read_db&.close
+      raise
+    end
+
+    attr_reader :channel
+
+    def next(timeout_s: nil)
+      read_db = begin_call
+      return nil unless read_db
+
+      deadline = timeout_s.nil? ? nil : monotonic_now + [timeout_s.to_f, 0.0].max
+      loop do
+        return nil if closed?
+        return @buffer.shift unless @buffer.empty?
+
+        generation = @db.update_snapshot
+        refill(read_db)
+        next unless @buffer.empty?
+
+        remaining = deadline && deadline - monotonic_now
+        return nil if remaining && remaining <= 0
+
+        wait_s = [remaining, @fallback_poll_s].compact.min
+        @db.wait_for_update_after(generation, wait_s)
+        return nil if @db.updates_closed?
+      end
+    ensure
+      end_call if read_db
+    end
+
+    def each
+      return enum_for(:each) unless block_given?
+
+      while (notification = self.next)
+        yield notification
+      end
+    end
+
+    def close
+      should_signal = @state_mutex.synchronize do
+        next false if @closed
+
+        @closed = true
+        close_read_db_if_idle
+        true
+      end
+      @db.signal_update if should_signal
+      nil
+    end
+
+    def closed?
+      @state_mutex.synchronize { @closed }
+    end
+
+    private
+
+    def refill(read_db)
+      rows = read_db.execute(
+        "SELECT id, channel, payload, created_at " \
+        "FROM _honker_notifications " \
+        "WHERE channel = ? AND id > ? ORDER BY id LIMIT 1000",
+        [@channel, @last_seen],
+      )
+      rows.each do |id, channel, payload, created_at|
+        @last_seen = id.to_i
+        @buffer << Notification.new(id.to_i, channel, decode_payload(payload), created_at.to_i)
+      end
+    end
+
+    def begin_call
+      @state_mutex.synchronize do
+        return nil if @closed
+
+        @active_calls += 1
+        @read_db
+      end
+    end
+
+    def end_call
+      @state_mutex.synchronize do
+        @active_calls -= 1
+        close_read_db_if_idle
+      end
+    end
+
+    def close_read_db_if_idle
+      return unless @closed && @active_calls.zero? && @read_db
+
+      @read_db.close
+      @read_db = nil
+    end
+
+    def decode_payload(payload)
+      JSON.parse(payload)
+    rescue JSON::ParserError, TypeError
+      payload
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+
   DEFAULT_PRAGMAS = <<~SQL
     PRAGMA journal_mode = WAL;
     PRAGMA synchronous = NORMAL;
@@ -174,7 +432,7 @@ module Honker
   # extension loaded. The constructor bootstraps the schema; safe to
   # open the same path from multiple processes.
   class Database
-    attr_reader :db
+    attr_reader :db, :path
 
     def initialize(path, extension_path: nil, watcher_backend: nil,
                    watcher_poll_interval_ms: nil,
@@ -187,8 +445,8 @@ module Honker
       end
 
       resolved_extension = extension_resolver.resolve(extension_path)
+      @path = path
       @db = SQLite3::Database.new(path)
-      @local_update_seq = 0
       @db.busy_timeout = 5000
       @db.execute("PRAGMA mmap_size = 0")
       @db.enable_load_extension(true)
@@ -196,24 +454,48 @@ module Honker
       @db.enable_load_extension(false)
       @db.execute_batch(DEFAULT_PRAGMAS)
       @db.execute("SELECT honker_bootstrap()")
-      @watcher = CoreWatcher.new(path, resolved_extension, watcher_backend, watcher_poll_interval_ms)
+      watcher = CoreWatcher.new(path, resolved_extension, watcher_backend, watcher_poll_interval_ms)
+      @updates = UpdateHub.new(watcher)
     end
 
     def close
-      @watcher&.close
+      @updates&.close
       @db&.close
     end
 
     def mark_updated
-      @local_update_seq += 1
+      @updates.signal
     end
 
     def update_snapshot
-      @local_update_seq
+      @updates.snapshot
     end
 
     def wait_for_update(timeout_s)
-      @watcher.wait(timeout_s)
+      @updates.wait(timeout_s)
+    end
+
+    def wait_for_update_after(generation, timeout_s)
+      @updates.wait_after(generation, timeout_s)
+    end
+
+    def signal_update
+      @updates.signal
+    end
+
+    def updates_closed?
+      @updates.closed?
+    end
+
+    def listen(channel, fallback_poll_s: 15.0)
+      listener = Listener.new(self, channel, fallback_poll_s: fallback_poll_s)
+      return listener unless block_given?
+
+      begin
+        listener.each { |notification| yield notification }
+      ensure
+        listener.close
+      end
     end
 
     # Returns a Queue handle for a named queue.

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -196,10 +196,18 @@ module Honker
       end
     end
 
-    def wait_after(generation, timeout_s = nil)
+    # Wake blocked waiters without claiming that SQLite changed. Listener
+    # cancellation uses this path so closing one listener cannot create a
+    # spurious Database#wait_for_update result for unrelated callers.
+    def wake
+      @mutex.synchronize { @changed.broadcast unless @closed }
+    end
+
+    def wait_after(generation, timeout_s = nil, &cancelled)
       deadline = timeout_s.nil? ? nil : monotonic_now + [timeout_s.to_f, 0.0].max
       @mutex.synchronize do
         loop do
+          return false if cancelled&.call
           raise @error if @error
           return false if @closed
           return true if @generation > generation
@@ -304,7 +312,9 @@ module Honker
       @fallback_poll_s = fallback_poll_s&.to_f
       @buffer = []
       @state_mutex = Mutex.new
+      @state_changed = ConditionVariable.new
       @active_calls = 0
+      @active_threads = Hash.new(0)
       @closed = false
       @read_db = SQLite3::Database.new(@db.path)
       @read_db.busy_timeout = 5000
@@ -337,9 +347,15 @@ module Honker
         return nil if remaining && remaining <= 0
 
         wait_s = [remaining, @fallback_poll_s].compact.min
-        @db.wait_for_update_after(generation, wait_s)
-        return nil if @db.updates_closed?
+        @db.wait_for_update_after(generation, wait_s) { closed? }
+        if @db.updates_closed?
+          close
+          return nil
+        end
       end
+    rescue StandardError
+      close
+      raise
     ensure
       end_call if read_db
     end
@@ -353,14 +369,25 @@ module Honker
     end
 
     def close
-      should_signal = @state_mutex.synchronize do
+      should_wake = @state_mutex.synchronize do
         next false if @closed
 
         @closed = true
         close_read_db_if_idle
         true
       end
-      @db.signal_update if should_signal
+
+      if should_wake
+        @db.wake_update_waiters
+        @db.unregister_listener(self)
+      end
+
+      @state_mutex.synchronize do
+        unless @active_threads.key?(Thread.current)
+          @state_changed.wait(@state_mutex) until @active_calls.zero?
+          close_read_db_if_idle
+        end
+      end
       nil
     end
 
@@ -388,6 +415,7 @@ module Honker
         return nil if @closed
 
         @active_calls += 1
+        @active_threads[Thread.current] += 1
         @read_db
       end
     end
@@ -395,7 +423,10 @@ module Honker
     def end_call
       @state_mutex.synchronize do
         @active_calls -= 1
+        @active_threads[Thread.current] -= 1
+        @active_threads.delete(Thread.current) if @active_threads[Thread.current].zero?
         close_read_db_if_idle
+        @state_changed.broadcast if @active_calls.zero?
       end
     end
 
@@ -456,9 +487,21 @@ module Honker
       @db.execute("SELECT honker_bootstrap()")
       watcher = CoreWatcher.new(path, resolved_extension, watcher_backend, watcher_poll_interval_ms)
       @updates = UpdateHub.new(watcher)
+      @listeners_mutex = Mutex.new
+      @listeners = {}
+      @closed = false
     end
 
     def close
+      listeners = @listeners_mutex.synchronize do
+        return if @closed
+
+        @closed = true
+        registered = @listeners.keys
+        @listeners.clear
+        registered
+      end
+      listeners.each(&:close)
       @updates&.close
       @db&.close
     end
@@ -475,20 +518,30 @@ module Honker
       @updates.wait(timeout_s)
     end
 
-    def wait_for_update_after(generation, timeout_s)
-      @updates.wait_after(generation, timeout_s)
+    def wait_for_update_after(generation, timeout_s, &cancelled)
+      @updates.wait_after(generation, timeout_s, &cancelled)
     end
 
-    def signal_update
-      @updates.signal
+    def wake_update_waiters
+      @updates.wake
     end
 
     def updates_closed?
       @updates.closed?
     end
 
+    def closed?
+      @listeners_mutex.synchronize { @closed }
+    end
+
     def listen(channel, fallback_poll_s: 15.0)
+      raise Error, "database is closed" if closed?
+
       listener = Listener.new(self, channel, fallback_poll_s: fallback_poll_s)
+      unless register_listener(listener)
+        listener.close
+        raise Error, "database is closed"
+      end
       return listener unless block_given?
 
       begin
@@ -496,6 +549,22 @@ module Honker
       ensure
         listener.close
       end
+    end
+
+    # Internal listener lifecycle hooks. They are public only because the
+    # Listener is a separate object rather than a nested implementation detail.
+    def register_listener(listener)
+      @listeners_mutex.synchronize do
+        return false if @closed
+
+        @listeners[listener] = true
+        true
+      end
+    end
+
+    def unregister_listener(listener)
+      @listeners_mutex.synchronize { @listeners.delete(listener) }
+      nil
     end
 
     # Returns a Queue handle for a named queue.

--- a/packages/honker-ruby/lib/honker/version.rb
+++ b/packages/honker-ruby/lib/honker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Honker
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/packages/honker-ruby/spec/honker_spec.rb
+++ b/packages/honker-ruby/spec/honker_spec.rb
@@ -72,6 +72,12 @@ def queue_writer_helper(path, ext, first, count)
   db.close
 end
 
+def notification_writer_helper(path, ext, channel, payload)
+  db = Honker::Database.new(path, extension_path: ext)
+  db.notify(channel, JSON.parse(payload))
+  db.close
+end
+
 if ARGV.first == "--honker-queue-worker"
   _, path, ext, backend, worker_id, ready_path, result_path = ARGV
   queue_worker_helper(path, ext, backend, worker_id, ready_path, result_path)
@@ -79,6 +85,10 @@ if ARGV.first == "--honker-queue-worker"
 elsif ARGV.first == "--honker-queue-writer"
   _, path, ext, first, count = ARGV
   queue_writer_helper(path, ext, Integer(first), Integer(count))
+  exit! 0
+elsif ARGV.first == "--honker-notification-writer"
+  _, path, ext, channel, payload = ARGV
+  notification_writer_helper(path, ext, channel, payload)
   exit! 0
 end
 
@@ -322,6 +332,30 @@ class HonkerWatcherBackendQueueTest < Minitest::Test
       assert_int_set(read_result(result), 60)
     end
   end
+
+  def test_listener_backends_observe_a_notification_from_another_process
+    each_backend do |path, ext, backend|
+      db = Honker::Database.new(path, extension_path: ext, watcher_backend: backend)
+      listener = db.listen("cross-process", fallback_poll_s: nil)
+      writer = Process.spawn(
+        RbConfig.ruby,
+        __FILE__,
+        "--honker-notification-writer",
+        path,
+        ext,
+        "cross-process",
+        JSON.dump({ "source" => "child" }),
+      )
+
+      wait_process(writer)
+      notification = listener.next(timeout_s: 2)
+      refute_nil notification
+      assert_equal({ "source" => "child" }, notification.payload)
+    ensure
+      listener&.close
+      db&.close
+    end
+  end
 end
 
 class HonkerTest < Minitest::Test
@@ -387,5 +421,131 @@ class HonkerTest < Minitest::Test
     assert_equal "orders", row[0]
     assert_equal({ "id" => 42 }, JSON.parse(row[1]))
     db.close
+  end
+
+  def test_listen_is_live_only_and_channel_filtered
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    db.notify("orders", { id: "historical" })
+    listener = db.listen("orders", fallback_poll_s: nil)
+
+    assert_nil listener.next(timeout_s: 0.05)
+    db.notify("other", { id: "wrong-channel" })
+    db.notify("orders", { id: 1 })
+    db.notify("orders", { id: 2 })
+
+    first = listener.next(timeout_s: 2)
+    second = listener.next(timeout_s: 2)
+    assert_equal({ "id" => 1 }, first.payload)
+    assert_equal({ "id" => 2 }, second.payload)
+    assert_equal "orders", first.channel
+    assert_operator second.id, :>, first.id
+    assert_operator first.created_at, :>, 0
+  ensure
+    listener&.close
+    db&.close
+  end
+
+  def test_multiple_listeners_do_not_steal_wakes
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    first = db.listen("orders", fallback_poll_s: nil)
+    second = db.listen("orders", fallback_poll_s: nil)
+
+    db.notify("orders", { id: 42 })
+    one = first.next(timeout_s: 2)
+    two = second.next(timeout_s: 2)
+
+    assert_equal({ "id" => 42 }, one.payload)
+    assert_equal one.id, two.id
+  ensure
+    first&.close
+    second&.close
+    db&.close
+  end
+
+  def test_listener_observes_commit_but_not_rollback
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    listener = db.listen("orders", fallback_poll_s: nil)
+
+    db.transaction do |tx|
+      db.notify_tx(tx, "orders", { id: "rolled-back" })
+      tx.rollback!
+    end
+    assert_nil listener.next(timeout_s: 0.05)
+
+    db.transaction do |tx|
+      db.notify_tx(tx, "orders", { id: "committed" })
+    end
+    notification = listener.next(timeout_s: 2)
+    assert_equal({ "id" => "committed" }, notification.payload)
+  ensure
+    listener&.close
+    db&.close
+  end
+
+  def test_listener_fallback_poll_does_not_expose_uncommitted_rows
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    listener = db.listen("orders", fallback_poll_s: 0.01)
+    result = ::Queue.new
+    reader = Thread.new { result << listener.next(timeout_s: 0.2) }
+
+    db.transaction do |tx|
+      db.notify_tx(tx, "orders", { id: "uncommitted" })
+      sleep 0.05
+      tx.rollback!
+    end
+
+    reader.join
+    assert_nil result.pop
+  ensure
+    listener&.close
+    db&.close
+  end
+
+  def test_listener_close_is_idempotent
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    listener = db.listen("orders")
+    listener.close
+    listener.close
+
+    assert listener.closed?
+    assert_nil listener.next(timeout_s: 0)
+  ensure
+    db&.close
+  end
+
+  def test_listen_block_yields_and_closes_automatically
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    writer = Honker::Database.new(@db_path, extension_path: @ext)
+    write_thread = Thread.new do
+      sleep 0.02
+      writer.notify("orders", { id: 42 })
+    end
+
+    notification = db.listen("orders", fallback_poll_s: nil) do |received|
+      break received
+    end
+
+    write_thread.join
+    assert_equal({ "id" => 42 }, notification.payload)
+  ensure
+    writer&.close
+    db&.close
+  end
+
+  def test_database_close_unblocks_a_listener
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    listener = db.listen("orders", fallback_poll_s: nil)
+    result = ::Queue.new
+    reader = Thread.new { result << listener.next }
+
+    sleep 0.02
+    db.close
+    db = nil
+
+    assert reader.join(1), "listener remained blocked after database close"
+    assert_nil result.pop
+  ensure
+    listener&.close
+    db&.close
   end
 end

--- a/packages/honker-ruby/spec/honker_spec.rb
+++ b/packages/honker-ruby/spec/honker_spec.rb
@@ -501,15 +501,148 @@ class HonkerTest < Minitest::Test
     db&.close
   end
 
+  def test_listener_fallback_recovers_when_a_wake_is_missed
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    writer = Honker::Database.new(@db_path, extension_path: @ext)
+    listener = db.listen("orders", fallback_poll_s: 0.02)
+    wait_started = ::Queue.new
+
+    db.define_singleton_method(:wait_for_update_after) do |_generation, timeout_s, &_cancelled|
+      wait_started << true if wait_started.empty?
+      sleep(timeout_s)
+      false
+    end
+
+    result = ::Queue.new
+    reader = Thread.new { result << listener.next(timeout_s: 1) }
+    wait_started.pop
+    writer.notify("orders", { id: "fallback" })
+
+    assert reader.join(1), "fallback polling did not recover the missed wake"
+    assert_equal({ "id" => "fallback" }, result.pop.payload)
+  ensure
+    listener&.close
+    writer&.close
+    db&.close
+  end
+
+  def test_listener_drains_more_than_one_batch_to_multiple_slow_consumers
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    first = db.listen("orders", fallback_poll_s: nil)
+    second = db.listen("orders", fallback_poll_s: nil)
+
+    db.transaction do |tx|
+      1_105.times { |i| db.notify_tx(tx, "orders", { seq: i }) }
+    end
+    sleep 0.05
+
+    first_rows = Array.new(1_105) { first.next(timeout_s: 2) }
+    second_rows = Array.new(1_105) { second.next(timeout_s: 2) }
+    assert_equal (0...1_105).to_a, first_rows.map { |row| row.payload["seq"] }
+    assert_equal first_rows.map(&:id), second_rows.map(&:id)
+    assert_nil first.next(timeout_s: 0)
+    assert_nil second.next(timeout_s: 0)
+  ensure
+    first&.close
+    second&.close
+    db&.close
+  end
+
+  def test_listener_churn_does_not_leak_or_break_future_delivery
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    50.times { db.listen("orders", fallback_poll_s: nil).close }
+
+    assert_empty db.instance_variable_get(:@listeners)
+    listener = db.listen("orders", fallback_poll_s: nil)
+    db.notify("orders", { ok: true })
+    assert_equal({ "ok" => true }, listener.next(timeout_s: 2).payload)
+  ensure
+    listener&.close
+    db&.close
+  end
+
+  def test_listener_survives_writer_reconnects
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    listener = db.listen("orders", fallback_poll_s: nil)
+    writer = nil
+
+    2.times do |i|
+      writer = Honker::Database.new(@db_path, extension_path: @ext)
+      writer.notify("orders", { reconnect: i })
+      writer.close
+      assert_equal({ "reconnect" => i }, listener.next(timeout_s: 2).payload)
+    end
+  ensure
+    writer&.close
+    listener&.close
+    db&.close
+  end
+
+  def test_database_replacement_surfaces_watcher_failure_to_listener
+    skip "file identity replacement is not supported on Windows" if Gem.win_platform?
+
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    listener = db.listen("orders", fallback_poll_s: nil)
+    sleep 0.15
+    replacement = File.join(@tmpdir, "replacement.db")
+    File.write(replacement, "")
+    File.rename(replacement, @db_path)
+
+    error = assert_raises(Honker::Error) { listener.next(timeout_s: 2) }
+    assert_match(/watcher closed or died/, error.message)
+    assert listener.closed?
+  ensure
+    listener&.close
+    db&.close
+  end
+
+  def test_update_hub_propagates_watcher_failure
+    watcher = Object.new
+    watcher.define_singleton_method(:wait) do |_timeout_s|
+      raise Honker::Error, "injected watcher failure"
+    end
+    watcher.define_singleton_method(:close) { nil }
+    hub = Honker::UpdateHub.new(watcher)
+
+    error = assert_raises(Honker::Error) { hub.wait_after(0, 1) }
+    assert_equal "injected watcher failure", error.message
+  ensure
+    hub&.close
+  end
+
   def test_listener_close_is_idempotent
     db = Honker::Database.new(@db_path, extension_path: @ext)
     listener = db.listen("orders")
+    sleep 0.02
+    generation = db.update_snapshot
     listener.close
     listener.close
 
     assert listener.closed?
     assert_nil listener.next(timeout_s: 0)
+    assert_equal generation, db.update_snapshot
+    refute db.wait_for_update(0), "closing a listener manufactured a database update"
   ensure
+    db&.close
+  end
+
+  def test_listener_close_only_cancels_that_listener
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    listener = db.listen("orders", fallback_poll_s: nil)
+    listener_result = ::Queue.new
+    update_result = ::Queue.new
+    reader = Thread.new { listener_result << listener.next }
+    waiter = Thread.new { update_result << db.wait_for_update(0.15) }
+    sleep 0.02
+
+    listener.close
+
+    assert reader.join(0.5), "listener close did not cancel its blocked next call"
+    assert_nil listener_result.pop
+    assert waiter.join(0.5), "database update waiter did not reach its timeout"
+    refute update_result.pop, "listener close was reported as a database update"
+  ensure
+    listener&.close
     db&.close
   end
 
@@ -544,6 +677,23 @@ class HonkerTest < Minitest::Test
 
     assert reader.join(1), "listener remained blocked after database close"
     assert_nil result.pop
+    assert listener.closed?
+    assert_nil listener.instance_variable_get(:@read_db)
+  ensure
+    listener&.close
+    db&.close
+  end
+
+  def test_database_closes_an_idle_listener_and_rejects_new_listeners
+    db = Honker::Database.new(@db_path, extension_path: @ext)
+    listener = db.listen("orders", fallback_poll_s: nil)
+
+    db.close
+
+    assert listener.closed?
+    assert_nil listener.instance_variable_get(:@read_db)
+    error = assert_raises(Honker::Error) { db.listen("orders") }
+    assert_equal "database is closed", error.message
   ensure
     listener&.close
     db&.close

--- a/scripts/proof/elixir-hex-smoke.exs
+++ b/scripts/proof/elixir-hex-smoke.exs
@@ -1,0 +1,40 @@
+extension_path =
+  System.get_env("HONKER_EXTENSION_PATH") ||
+    raise "HONKER_EXTENSION_PATH is required"
+
+dir =
+  Path.join(
+    System.tmp_dir!(),
+    "honker-elixir-package-proof-#{System.unique_integer([:positive])}"
+  )
+
+File.mkdir_p!(dir)
+db_path = Path.join(dir, "app.db")
+
+try do
+  {:ok, db} = Honker.open(db_path, extension_path: extension_path)
+  {:ok, subscription} = Honker.listen(db, "release-proof", fallback_poll_ms: nil)
+  {:ok, _id} = Honker.notify(db, "release-proof", %{"installed_hex" => true})
+
+  receive do
+    {:honker_notification, ref, notification} when ref == subscription.ref ->
+      unless notification.payload == %{"installed_hex" => true} do
+        raise "notification mismatch: #{inspect(notification.payload)}"
+      end
+  after
+    2_000 -> raise "listener timed out"
+  end
+
+  monitor = Process.monitor(subscription.pid)
+  :ok = Honker.close(db)
+
+  receive do
+    {:DOWN, ^monitor, :process, _pid, _reason} -> :ok
+  after
+    1_000 -> raise "database close did not stop listener"
+  end
+after
+  File.rm_rf!(dir)
+end
+
+IO.puts("elixir Hex package smoke ok")

--- a/scripts/proof/ruby-gem-smoke.rb
+++ b/scripts/proof/ruby-gem-smoke.rb
@@ -17,7 +17,15 @@ Dir.mktmpdir("honker-ruby-proof-") do |dir|
   raise "claim failed" unless job && job.id == id
   raise "payload mismatch" unless job.payload["to"] == "alice@example.com"
   raise "ack failed" unless job.ack
+
+  listener = db.listen("release-proof", fallback_poll_s: nil)
+  db.notify("release-proof", { installed_gem: true })
+  notification = listener.next(timeout_s: 2)
+  raise "listener timed out" unless notification
+  raise "notification mismatch" unless notification.payload == { "installed_gem" => true }
+
   db.close
+  raise "database close did not close listener" unless listener.closed?
 end
 
 puts "ruby gem smoke ok"

--- a/tests/test_ruby_python_interop.py
+++ b/tests/test_ruby_python_interop.py
@@ -1,9 +1,4 @@
-"""Cross-binding interop between Ruby and Python.
-
-Ruby is currently an extension-backed binding rather than a core
-watcher binding. This test still matters: both packages must agree on
-the on-disk schema, queue semantics, and notification payload format.
-"""
+"""Cross-binding interop between Ruby and Python."""
 
 import json
 import os
@@ -169,3 +164,51 @@ def test_ruby_and_python_share_queue_stream_and_notification_tables(tmp_path):
     assert observed["acked"] == 25
     assert observed["notification"] == {"source": "python", "count": 25}
     assert observed["event_count"] == 2
+
+
+def test_ruby_listener_receives_a_live_notification_from_python(tmp_path):
+    _require_ruby_interop()
+    db_path = tmp_path / "python-writer-ruby-listener.db"
+    py_db = honker.open(str(db_path))
+    env = os.environ.copy()
+    env["DB_PATH"] = str(db_path)
+    env["HONKER_EXTENSION_PATH"] = str(EXT_PATH)
+    script = r'''
+    require "json"
+    require "honker"
+
+    $stdout.sync = true
+    db = Honker::Database.new(
+      ENV.fetch("DB_PATH"),
+      extension_path: ENV.fetch("HONKER_EXTENSION_PATH"),
+    )
+    listener = db.listen("python-live", fallback_poll_s: nil)
+    puts "READY"
+    notification = listener.next(timeout_s: 5)
+    raise "listener timed out" unless notification
+    puts JSON.generate(notification.payload)
+    listener.close
+    db.close
+    '''
+    proc = subprocess.Popen(
+        [*RUBY_CMD, "-Ilib", "-e", script],
+        cwd=RUBY_DIR,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        assert proc.stdout.readline().strip() == "READY"
+        with py_db.transaction() as tx:
+            tx.notify("python-live", {"source": "python", "live": True})
+        stdout, stderr = proc.communicate(timeout=10)
+
+        assert proc.returncode == 0, stderr
+        assert json.loads(stdout) == {"source": "python", "live": True}
+    finally:
+        py_db.close()
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)


### PR DESCRIPTION
## Summary

- add high-level live-only, channel-filtered listeners to the Ruby and Elixir bindings
- fan one native/SQL update watcher out to multiple listeners and legacy waiters without wake stealing
- use dedicated read connections so fallback polling never exposes uncommitted rows
- add explicit listener cleanup, database-close behavior, and Elixir subscribing-process cleanup
- add packaged-consumer and Python interoperability proofs
- advance both packages from 0.5.0 to 0.6.0 for the new public listener APIs
- update binding capabilities and the site pointer only when these APIs land

The latency gate and capability audit were split into and merged through #115. This PR is now based directly on `main`; its diff contains only listener implementation and lifecycle hardening.

## Listener contract

- live-only snapshot at attach time
- channel-filtered, ordered delivery with JSON decoding and raw-payload fallback
- commit-only visibility, including fallback polling during an open transaction
- one update hub per database; multiple listeners and waiters all observe a commit
- bounded and idempotent cleanup; Elixir listeners monitor their subscribing process

## Verification

- Ruby: all seven spec files passed; focused listener/parity run 43 tests, 158 assertions
- Elixir: full suite passed; focused listener/parity run 43 tests passed after lifecycle changes
- cross-process listener proofs passed for both bindings and all locally available watcher backends
- Elixir Hex and Ruby gem smoke consumers exercise listener delivery
- `mix compile --warnings-as-errors`
- Ruby 0.6.0 package proof: generic source gem plus x86_64 Linux, ARM64 Linux, and Apple Silicon native gems all built, installed, and passed consumer smokes ([run](https://github.com/russellromney/honker/actions/runs/32934226207))
- Elixir 0.6.0 package proof: full tests, Hex build/unpack, production dependency install, and unpacked consumer smoke passed ([run](https://github.com/russellromney/honker/actions/runs/32934226331))
- prior combined-tree CI: 24/24 jobs passed
- fresh CI passed on commit `0f4c527` atop merged #116 and #115

## Docs dependency

The matching site listener examples are isolated in honker-site#12. Until this PR lands, merged honker-site#11 accurately reports Ruby and Elixir as `listen: wait-api`.