### PR TITLE
Refresh the node lockfile after publishing the 0.5.0 natives

### DIFF
--- a/packages/honker-node/package-lock.json
+++ b/packages/honker-node/package-lock.json
@@ -1657,16 +1657,74 @@
       ]
     },
     "node_modules/@russellthehippo/honker-node-darwin-arm64": {
-      "optional": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-darwin-arm64/-/honker-node-darwin-arm64-0.5.0.tgz",
+      "integrity": "sha512-74MEi4yKbDtiw8NweqkHYa0Ou/TdtmgkflmxKLbNZdbyMwbacOtquVGThWXsU1d+TLjrH7PIhYL8mmx4W3Jdag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@russellthehippo/honker-node-darwin-x64": {
-      "optional": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-darwin-x64/-/honker-node-darwin-x64-0.5.0.tgz",
+      "integrity": "sha512-WGV3Wp7Ari9s4PaQS78QdXdc1NBw3TfL5DW5ubtj0PYtgtfbwc/5r83hAU5EuD0RH6YTkTnd3nPKqIe0qE90qw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@russellthehippo/honker-node-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-linux-arm64-gnu/-/honker-node-linux-arm64-gnu-0.5.0.tgz",
+      "integrity": "sha512-8Ljln6Lifeg2642LIpBjo3yTPds44kmxraijcFSGOyd4y9QcYEIVDiyKHuur0JpiZmALOqmmYZpDh4f2bl/Kuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@russellthehippo/honker-node-linux-x64-gnu": {
-      "optional": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-linux-x64-gnu/-/honker-node-linux-x64-gnu-0.5.0.tgz",
+      "integrity": "sha512-pyvvJz24uNq88HzZRZ6m9gu+bgT1SSdk6qPhaXEX41r3a8TSHCYspvXxpYHyXTCIlVZpVXtawS2p4qUU76dj8A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",


### PR DESCRIPTION
**`main` is red right now**, and both open dependabot PRs fail identically. Neither is at fault.

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json are in sync.
npm error Invalid: lock file's @russellthehippo/honker-node-darwin-arm64@
npm error   does not satisfy @russellthehippo/honker-node-darwin-arm64@0.5.0
```

`package.json` pins the four `honker-node-*` natives at 0.5.0. While those versions were unpublished, npm recorded them in `package-lock.json` **with no `version` field** — a valid lockfile at the time. Publishing 0.5.0 made the entries resolvable, and `npm ci` correctly refuses the stale lock.

Nothing in the repo changed. The lockfile went stale relative to a registry that moved underneath it.

`bun.lock` needs no change — `honker-bun` pins only `honker-ext-*`, still at 0.4.6.

## Second occurrence

The same thing happened after the 0.4.6 publish. The regeneration belongs in the publish pass, not as cleanup once CI goes red:

```bash
(cd packages/honker-node && npm install --package-lock-only --no-audit --no-fund)
(cd packages/honker-bun  && bun install --lockfile-only)
```

Verified locally: `npm ci` → `added 68 packages`.