### PR TITLE
Make the cross-process wake test prove the mechanism, not the clock

### DIFF
--- a/tests/test_cross_process_wake_latency.py
+++ b/tests/test_cross_process_wake_latency.py
@@ -16,9 +16,9 @@ Kept as a test because the claim is load-bearing and the bench
 """
 
 import os
-import math
 import subprocess
 import sys
+import threading
 import time
 
 import pytest
@@ -37,7 +37,14 @@ pytestmark = pytest.mark.skipif(
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PACKAGES_ROOT = os.path.join(REPO_ROOT, "packages")
 
-SAMPLES = 30  # small enough to keep CI fast; p99 stable at 30+ samples
+SAMPLES = 30  # small enough to keep CI fast
+
+# Separates "the watcher fired" from "nothing fired". It is not a latency
+# bound: the published figure is gated by bench/wake_latency_bench.py in the
+# wake-latency CI job, which runs alone on its own runner. This file runs
+# under pytest-xdist alongside every other worker, so wall-clock here
+# measures runner contention as much as Honker.
+WAKE_TIMEOUT_S = 10.0
 
 
 _LISTENER_SCRIPT = r"""
@@ -51,7 +58,9 @@ db = honker.open({db_path!r})
 
 
 async def main():
-    listener = db.listen("wake")
+    # No fallback poll. A broken watcher then produces no wake at all
+    # rather than a slow one, so this cannot pass by falling back.
+    listener = db.listen("wake", fallback_poll_s=None)
     print("READY", flush=True)
     async for _ in listener:
         print("WAKE", flush=True)
@@ -60,6 +69,19 @@ async def main():
 
 asyncio.run(main())
 """
+
+
+def _readline_within(proc, timeout_s: float):
+    """One line from proc.stdout, or None if it does not arrive in time."""
+    result: list = []
+
+    def read():
+        result.append(proc.stdout.readline())
+
+    reader = threading.Thread(target=read, daemon=True)
+    reader.start()
+    reader.join(timeout_s)
+    return result[0] if result else None
 
 
 def _run_sample(db_path: str) -> float:
@@ -83,8 +105,16 @@ def _run_sample(db_path: str) -> float:
         t0 = time.perf_counter()
         with db.transaction() as tx:
             tx.notify("wake", "ping")
-        wake = proc.stdout.readline()
+        # Bounded: with the fallback disabled a dead watcher never writes
+        # WAKE, and an unbounded readline would hang the suite instead of
+        # failing it. WAKE_TIMEOUT_S is far above any contention this test
+        # has been seen under and far below the 15 s fallback it replaced.
+        wake = _readline_within(proc, WAKE_TIMEOUT_S)
         t1 = time.perf_counter()
+        assert wake is not None, (
+            f"no wake within {WAKE_TIMEOUT_S}s with the fallback poll disabled; "
+            "the update watcher did not fire"
+        )
         assert wake.strip() == "WAKE", f"listener: {wake!r}"
         return (t1 - t0) * 1000.0
     finally:
@@ -95,44 +125,32 @@ def _run_sample(db_path: str) -> float:
             proc.wait()
 
 
-def test_cross_process_wake_latency_p99_under_bound(tmp_path):
+def test_cross_process_wake_is_watcher_driven(tmp_path):
+    """Every sample wakes a listener in another process with the fallback
+    poll disabled, so the update watcher is the only thing that can have
+    delivered it.
+
+    This does not police the published latency figure. That is
+    bench/wake_latency_bench.py, gated at p50 < 5 ms in the wake-latency
+    CI job, which runs alone. This file runs under pytest-xdist next to
+    every other worker, where wall-clock reflects runner contention as
+    much as Honker: a p50 bound of 50 ms here has gone red at 55 ms while
+    the dedicated bench measured 2.959 ms on the same runner class.
+    """
     db_path = str(tmp_path / "wake.db")
 
-    # Pre-create the WAL so first-sample latency doesn't include
-    # journal bootstrap.
+    # Pre-create the WAL so the first sample doesn't include journal
+    # bootstrap.
     import honker
+
     db = honker.open(db_path)
     with db.transaction() as tx:
         tx.execute("CREATE TABLE _warmup (i INTEGER)")
     del db
 
     times_ms = [_run_sample(db_path) for _ in range(SAMPLES)]
-    times_ms.sort()
 
-    # Under pytest-xdist parallel load, the subprocess running the
-    # listener can get scheduled out for hundreds of ms at a time;
-    # the update watcher thread doesn't tick, the wake fires late. Using
-    # max-of-samples as "p99" means a single outlier from OS
-    # scheduling failed the assertion. Use real percentiles: p50
-    # and p90. With 30 samples, p90 tolerates up to 3 outliers, which
-    # is enough to absorb scheduler noise while still catching
-    # anything that shifts the distribution.
-    def percentile(samples, pct):
-        # Nearest-rank percentile, zero-indexed. For 30 samples,
-        # p90 is sample 27, which tolerates 3 slow scheduler outliers
-        # like the comment above says.
-        return samples[math.ceil(len(samples) * pct) - 1]
-
-    p50 = percentile(times_ms, 0.5)
-    p90 = percentile(times_ms, 0.9)
-    median_bound = 50.0   # real p50 ~= 2.9 ms on an Apple M1 Pro
-    p90_bound = 750.0     # CI runners can schedule out subprocesses for 100+ ms
-
-    assert p50 < median_bound, (
-        f"cross-process wake p50 = {p50:.2f} ms exceeds {median_bound} ms; "
-        f"samples (sorted) = {times_ms}"
-    )
-    assert p90 < p90_bound, (
-        f"cross-process wake p90 = {p90:.2f} ms exceeds {p90_bound} ms; "
-        f"samples (sorted) = {times_ms}"
-    )
+    assert len(times_ms) == SAMPLES
+    # Reported, not asserted — a failure elsewhere in this file is easier to
+    # read with the distribution in hand.
+    print(f"cross-process wake ms (in order): {[round(t, 2) for t in times_ms]}")


### PR DESCRIPTION
This test asserted `p50 < 50 ms` / `p90 < 750 ms` on wall-clock measured **under pytest-xdist**, next to every other worker. It went red on a Linux runner:

```
cross-process wake p50 = 55.48 ms exceeds 50.0 ms
samples = [1.76, 1.77, 1.77, 1.78, 1.79, 1.83, 2.85, 13.6, 21.1, 30.7,
           40.6, 41.5, 50.8, 55.5, 69.3, ... 240, 363, 365]
```

Half the samples above the bound. The dedicated bench measured **2.959 ms** on the same runner class — running alone. So the numbers here describe contention as much as they describe Honker.

I checked whether that spread was a leak accumulating per iteration, since it matched the JVM flake's shape. It isn't: 30 iterations locally are flat at 2.2 ms, first-5 mean 2.20 vs last-5 mean 2.22.

## Why the assertions go

The published figure already has a real gate — `bench/wake_latency_bench.py` in the `wake-latency` job, `p50 < 5 ms` over 500 samples, alone on its own runner. Two gates on one property, and the worse one was the one going red.

## What this test proves now

That the wake is **watcher-driven at all**, cross-process, from Python — which nothing else covers.

- `fallback_poll_s=None`, so a watcher that never fires produces **no wake** instead of a slow one. Previously the 15 s fallback still delivered and only the latency bound caught it, which is why the assertions couldn't simply be deleted.
- The read is bounded. With no fallback, an unbounded `readline` would hang the suite rather than fail it.
- The distribution is printed, not asserted.

## Load-bearing

Pointing the listener at a channel the notify doesn't touch:

```
AssertionError: no wake within 10.0s with the fallback poll disabled;
the update watcher did not fire
1 failed
```

Reverting → `1 passed`.