### PR TITLE
Fix the last two timing assertions that report the runner

### DIFF
--- a/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
+++ b/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
@@ -981,10 +981,17 @@ class HonkerJvmTest {
         // Deliberately loose. This runs on shared PR runners where absolute
         // wall-clock assertions flake; tightening them toward the real ~3 ms
         // buys no signal the bench does not already give and costs red builds.
+        // Median only. p90 of 12 samples is the second-worst of 12 process
+        // spawns — an order statistic that is defined by its outliers, so on
+        // a shared runner it reports contention rather than Honker. It has
+        // gone red at 314 ms while the median stayed near the real 3 ms.
+        //
+        // A degradation that matters moves the median too, and that is what
+        // this catches. A watcher that stops firing entirely never reaches
+        // here at all: the child gives up after 10 s against a 30 s fallback
+        // and exits 2, failing child.waitFor() above.
         assertTrue(percentile(samples, 0.50) < 50,
             "listener wake p50 was too slow: sorted=" + samples + " byIteration=" + inOrder);
-        assertTrue(percentile(samples, 0.90) < 250,
-            "listener wake p90 was too slow: sorted=" + samples + " byIteration=" + inOrder);
     }
 
     @Test

--- a/packages/honker-node/test/parity.test.js
+++ b/packages/honker-node/test/parity.test.js
@@ -865,6 +865,13 @@ test('claimWaker: wakes when runAt deadline arrives', { timeout: 12_000 }, async
     const msUntilDue = runAt * 1000 - Date.now();
     q.enqueue({ hello: 'future' }, { runAt });
     const waker = q.claimWaker({ idlePollS: 30 });
+    // Captured before the wait, while it still decides anything. Sampled
+    // after the timeout it is always 0, because next_claim_at only reports
+    // deadlines with run_at > unixepoch() and by then run_at has passed.
+    const nextClaimAtBeforeWait = db._callScalar(
+      'SELECT honker_queue_next_claim_at(?)',
+      ['deadline'],
+    );
     const t0 = Date.now();
     const job = await Promise.race([
       waker.next('w1'),
@@ -872,16 +879,22 @@ test('claimWaker: wakes when runAt deadline arrives', { timeout: 12_000 }, async
     ]);
     const dt = Date.now() - t0;
     if (!job) {
-      // Windows-only so far; does not reproduce on macOS or Linux.
-      // Report the state that decides the wait so the next failure says
-      // why. nextClaimAt of 0 means the waker fell back to idlePollS,
-      // which is a different bug from the deadline being computed wrong.
+      // Seen on Windows and on ubuntu-latest. Report the state that
+      // decides the wait.
+      //
+      // nextClaimAtBeforeWait is the deciding value: it should equal runAt.
+      // 0 there means the waker had no deadline to park on and fell back to
+      // idlePollS, which is a different bug from the deadline being computed
+      // wrong. nextClaimAtAfter is expected to be 0 once run_at has passed
+      // and proves nothing on its own — an earlier read of it was taken as
+      // evidence of the fallback and is not.
       const diag = {
         runAt,
         msUntilDue,
         waitedMs: dt,
+        nextClaimAtBeforeWait,
         now: Math.floor(Date.now() / 1000),
-        nextClaimAt: db._callScalar('SELECT honker_queue_next_claim_at(?)', ['deadline']),
+        nextClaimAtAfter: db._callScalar('SELECT honker_queue_next_claim_at(?)', ['deadline']),
         unixepoch: db._callScalar('SELECT unixepoch()'),
         journalMode: db._callScalar('PRAGMA journal_mode'),
         pending: db._callScalar(


### PR DESCRIPTION
Audited every wall-clock assertion in the repo — Rust, Python, Node, .NET, JVM.

**Most are already safe.** They assert against a fallback interval orders of magnitude larger, so the bound separates *fast path fired* from *fallback fired* rather than policing a latency: node's `updateEvents` (500 ms vs a real ~2 ms), the .NET worker wakes (2 s vs ~2 ms), `claimWaker` on `setImmediate` (guarded by a `Promise.race` that fires first). The .NET `run_at` check is a **lower** bound — contention can't trip it, since contention only makes things slower.

Two were not.

## JVM listener wake — drop p90, keep the median

`p90` of 12 samples is the second-worst of 12 process spawns. That's an order statistic defined by its outliers, so on a shared runner it measures the runner. It went red at **314 ms** while the median sat near the real **3 ms**.

A degradation that matters moves the median, which is what remains. A watcher that stops firing never reaches the assertion at all — the child gives up after 10 s against a 30 s fallback and fails `child.waitFor()`.

## Node claimWaker runAt — fix the diagnostic, not the bound

The bound here is fine (`msUntilDue + 5000` against a 30 s `idlePollS`). The **diagnostic** was wrong:

```
"nextClaimAt":0 ... comment: "nextClaimAt of 0 means the waker fell back to idlePollS"
```

`honker_queue_next_claim_at` only reports deadlines with `run_at > unixepoch()`. Sampled after the timeout, `run_at` has passed, so it returns 0 **whether or not anything misbehaved**. I read that comment and briefly concluded there was a confirmed bug in the deadline path. There isn't — not from this evidence.

Now captured before the wait, where `0` genuinely means the waker had no deadline to park on. The post-hoc read is kept and clearly labelled as proving nothing.

## What is still unexplained

The ubuntu-latest failure had `pending: 1`, `now` **6 seconds past** `run_at`, and the job unclaimed after 8 s. That is not a bound being too tight. It doesn't reproduce locally — 41/41 pass with the deadline honored at 1597 ms. The in-code note said "Windows-only"; it isn't any more, and that's corrected.

The next occurrence will say whether the waker parked on the wrong deadline.

Verified: node 41/41, JVM target test passes.