### PR TITLE
Stop the claim waker parking when it misses a deadline

### DIFF
--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -282,6 +282,11 @@ class Job {
   }
 }
 
+// How long the claim waker waits before retrying a deadline it reached but
+// could not claim. Short enough that a contended claim recovers promptly,
+// long enough not to spin on the writer lock.
+const DEADLINE_RETRY_MS = 50;
+
 class ClaimWaker {
   constructor(queue, { idlePollS = 5 } = {}) {
     this._queue = queue;
@@ -296,12 +301,24 @@ class ClaimWaker {
     let job = this._queue.claimOne(workerId);
     if (job) return job;
 
+    // True once we have waited on a run_at/claim_expires_at deadline that
+    // has since passed. next_claim_at only reports deadlines with
+    // run_at > unixepoch(), so it returns 0 the moment one arrives — and
+    // without this, a claim that came back empty right then (a writer lock
+    // held past busy_timeout, a racing worker) would fall through to
+    // idlePollS and park for the whole interval on a queue that has work
+    // ready. Retry briefly instead; a genuinely empty queue never sets it.
+    let deadlinePassed = false;
+
     while (!this._closed && !aborted(opts.signal)) {
       const nextClaimAt = this._queue._nextClaimAt();
       let waitMs = this._idlePollMs;
       if (nextClaimAt && nextClaimAt > 0) {
         const untilDeadline = Math.max(0, nextClaimAt * 1000 - Date.now());
         waitMs = waitMs == null ? untilDeadline : Math.min(waitMs, untilDeadline);
+        deadlinePassed = true;
+      } else if (deadlinePassed) {
+        waitMs = waitMs == null ? DEADLINE_RETRY_MS : Math.min(waitMs, DEADLINE_RETRY_MS);
       }
       await waitForUpdateOrTimeout(this._updates, opts.signal, waitMs);
       if (this._closed || aborted(opts.signal)) return null;

--- a/packages/honker-node/test/parity.test.js
+++ b/packages/honker-node/test/parity.test.js
@@ -856,6 +856,47 @@ test('claimWaker: returns immediately when a job is already pending', async () =
   }
 });
 
+test('claimWaker: a claim that misses its deadline does not park on idlePollS', { timeout: 12_000 }, async () => {
+  const { path: p, cleanup } = tmpdb();
+  try {
+    const db = honker.open(p);
+    const q = db.queue('deadline-miss');
+    const runAt = Math.floor(Date.now() / 1000) + 2;
+    q.enqueue({ hello: 'future' }, { runAt });
+    const waker = q.claimWaker({ idlePollS: 30 });
+
+    // One claim comes back empty exactly at the deadline. That is what a
+    // writer lock held past busy_timeout, or a worker that raced us, looks
+    // like from here. next_claim_at reports 0 from this point on, because
+    // it only lists deadlines with run_at > unixepoch(), so the waker has
+    // nothing left to park on but idlePollS — 30 s, with a claimable job
+    // already in the queue.
+    let missed = false;
+    const realClaim = q.claimOne.bind(q);
+    q.claimOne = (worker) => {
+      if (!missed && Date.now() >= runAt * 1000 - 5) {
+        missed = true;
+        return null;
+      }
+      return realClaim(worker);
+    };
+
+    const t0 = Date.now();
+    const job = await Promise.race([
+      waker.next('w1'),
+      new Promise((resolve) => setTimeout(() => resolve(null), 8000)),
+    ]);
+    const dt = Date.now() - t0;
+    assert.ok(missed, 'the probe never forced a missed claim');
+    assert.ok(job, `waker parked instead of retrying: waited ${dt}ms`);
+    assert.deepEqual(job.payload, { hello: 'future' });
+    job.ack();
+    waker.close();
+  } finally {
+    cleanup();
+  }
+});
+
 test('claimWaker: wakes when runAt deadline arrives', { timeout: 12_000 }, async () => {
   const { path: p, cleanup } = tmpdb();
   try {


### PR DESCRIPTION
The unexplained `claimWaker: wakes when runAt deadline arrives` failure is a **real bug**, not a slow runner. Its own diagnostic said so:

```json
{"runAt":1787728892, "now":1787728898, "waitedMs":8000, "pending":1}
```

The job was pending and claimable, **six seconds past `run_at`**, unclaimed after eight.

## Mechanism

`honker_queue_next_claim_at` only reports deadlines with `run_at > unixepoch()`, so it returns `0` from the instant a deadline arrives. The waker loop reads it, finds nothing to park on, and falls back to `idlePollS`:

```js
const nextClaimAt = this._queue._nextClaimAt();   // 0 once run_at has passed
let waitMs = this._idlePollMs;                     // 30_000 in this test
if (nextClaimAt > 0) waitMs = Math.min(waitMs, ...);
await waitForUpdateOrTimeout(this._updates, opts.signal, waitMs);
job = this._queue.claimOne(workerId);
```

If the claim taken *at* that deadline comes back empty — a writer lock held past the 5 s `busy_timeout`, or another worker taking the row — the waker sleeps the **entire idle interval** on a queue with work ready. At 30 s that reads as a hang, and the 8 s race timeout fires first.

## Fix

Retry briefly once a deadline the waker waited for has passed, instead of idling. A queue that was always empty never sets that flag, so ordinary idle polling is unchanged.

## Reproduced, then fixed

Forcing one claim to return empty at the deadline:

```
without fix: parked, timed out after 8002ms
with fix:    claimed after 1218ms
```

Shipped as a regression test — `fail 1` against unpatched `api.js`, `pass 42` with the fix.

## Notes corrected

The in-code comment said `nextClaimAt: 0` in the diagnostic meant the waker fell back to `idlePollS`. It doesn't — `0` is what that function returns for **any** past-due job, so it proves nothing either way. I read that comment and briefly reported a confirmed fault in the deadline path on the strength of it.

The comment calling the failure Windows-only is also wrong; this came from a Linux run.