### PR TITLE
feat(node): add typed job payloads and details

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,9 @@ jobs:
         run: |
           npm ci
           npx napi build --platform --release --features kernel-watcher,shm-fast-path
+      - name: Test Node TypeScript declarations
+        working-directory: packages/honker-node
+        run: npm run test:types
       - name: Test Node ↔ Python stream checkpoint journeys
         shell: bash
         run: |
@@ -466,7 +469,7 @@ jobs:
       - name: Test (basic — node only)
         working-directory: packages/honker-node
         shell: bash
-        run: node --test test/api.test.js test/basic.js
+        run: node --test test/api.test.js test/basic.js test/typed_jobs_e2e.js
       - name: Test (parity — node API surface)
         working-directory: packages/honker-node
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@
 - Regression test claims a job at a deadline with one claim forced to
   return empty: it fails on the unpatched `api.js` and passes on the fix.
 
+## Unreleased — typed Node jobs
+
+- Node `Queue`, `Job`, `JobSnapshot`, `ClaimWaker`, and `Outbox` APIs now carry
+  a payload generic that defaults to `JsonValue`, preserving existing callers
+  while allowing application-specific payload contracts.
+- `Queue.getJob()` and `Queue.cancel()` are included in the public TypeScript
+  declarations. Claimed jobs and job snapshots expose state, priority,
+  scheduling, attempt, worker, creation, claim-expiry, and job-expiry details.
+- The Rust claim ABI now returns the complete live-job snapshot, so claimed
+  jobs provide the same operational details as `getJob()`.
+- **Behavior change:** Node `getJob()` now returns the documented camelCase
+  `JobSnapshot` shape instead of exposing the SQL ABI's raw snake_case row.
+
 ## Unreleased — Node checkpoint interoperability (Phase Robinson)
 
 - Node stream checkpoint calls now use the shared SQL ABI's canonical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,25 @@
   scheduling, attempt, worker, creation, claim-expiry, and job-expiry details.
 - The Rust claim ABI now returns the complete live-job snapshot, so claimed
   jobs provide the same operational details as `getJob()`.
+- Every job field carries TSDoc. All four timestamps (`runAt`, `createdAt`,
+  `claimExpiresAt`, `expiresAt`) are Unix epoch seconds, not milliseconds, and
+  now say so on hover. `Job` declares `implements JobSnapshot<TPayload>`, so a
+  field added to one shape and not the other fails the type test.
+- `Job.claimExpiresAt` is `number`, not `number | null`. A claimed job always
+  holds a lease, so that null branch could never be taken. `JobSnapshot` keeps
+  `number | null` for pending jobs.
 - **Behavior change:** Node `getJob()` now returns the documented camelCase
   `JobSnapshot` shape instead of exposing the SQL ABI's raw snake_case row.
-  It also returns `null` for a job that belongs to a different queue, instead
-  of returning that queue's row. Job ids are globally unique, so the previous
-  unscoped lookup could hand back a payload that did not match the queue's
-  declared `TPayload`. `cancel()` is unchanged and remains not queue-scoped.
+  `row.run_at` becomes `job.runAt` and reads back as `undefined` under the old
+  name, and `payload` arrives already JSON-decoded, so an existing
+  `JSON.parse(row.payload)` must be dropped.
+- **Behavior change:** Node `getJob()` returns `null` for a job that belongs to
+  a different queue, instead of returning that queue's row. Job ids are globally
+  unique, so the previous unscoped lookup could hand back a payload that did not
+  match the queue's declared `TPayload`. There is no unscoped replacement yet
+  (#134); callers that relied on the global lookup can run
+  `SELECT honker_get_job(?)` on their own connection, which still returns the
+  raw snake_case row. `cancel()` is unchanged and remains not queue-scoped.
 
 ## Unreleased — Node checkpoint interoperability (Phase Robinson)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
   jobs provide the same operational details as `getJob()`.
 - **Behavior change:** Node `getJob()` now returns the documented camelCase
   `JobSnapshot` shape instead of exposing the SQL ABI's raw snake_case row.
+  It also returns `null` for a job that belongs to a different queue, instead
+  of returning that queue's row. Job ids are globally unique, so the previous
+  unscoped lookup could hand back a payload that did not match the queue's
+  declared `TPayload`. `cancel()` is unchanged and remains not queue-scoped.
 
 ## Unreleased — Node checkpoint interoperability (Phase Robinson)
 

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -648,7 +648,7 @@ fn dead_letter_exhausted_claimable(conn: &Connection, queue: &str) -> rusqlite::
     Ok(count)
 }
 
-/// Returns JSON text: `[{"id":1,"queue":"...","payload":"...","worker_id":"...","attempts":N,"claim_expires_at":T}, ...]`
+/// Returns JSON text containing the complete claimed-job snapshot.
 pub fn claim_batch(
     conn: &Connection,
     queue: &str,
@@ -679,8 +679,10 @@ pub fn claim_batch(
            ORDER BY priority DESC, run_at ASC, id ASC
            LIMIT ?3
          )
-         RETURNING id, queue, payload, worker_id, attempts, claim_expires_at",
+         RETURNING id, queue, payload, state, priority, run_at, worker_id,
+                   claim_expires_at, attempts, max_attempts, created_at, expires_at",
     )?;
+    #[allow(clippy::type_complexity)]
     let rows = stmt.query_map(rusqlite::params![worker_id, queue, n, timeout_s], |row| {
         Ok((
             row.get::<_, i64>(0)?,
@@ -689,20 +691,45 @@ pub fn claim_batch(
             row.get::<_, String>(3)?,
             row.get::<_, i64>(4)?,
             row.get::<_, i64>(5)?,
+            row.get::<_, String>(6)?,
+            row.get::<_, i64>(7)?,
+            row.get::<_, i64>(8)?,
+            row.get::<_, i64>(9)?,
+            row.get::<_, i64>(10)?,
+            row.get::<_, Option<i64>>(11)?,
         ))
     })?;
     let mut out = Vec::new();
     for row in rows {
-        let (id, q, payload, w, attempts, claim_expires_at) = row?;
+        let (
+            id,
+            q,
+            payload,
+            state,
+            priority,
+            run_at,
+            w,
+            claim_expires_at,
+            attempts,
+            max_attempts,
+            created_at,
+            expires_at,
+        ) = row?;
         // payload stays a JSON string (double-encoded on the wire) so
         // every binding's existing parse path keeps working.
         out.push(json!({
             "id": id,
             "queue": q,
             "payload": payload,
+            "state": state,
+            "priority": priority,
+            "run_at": run_at,
             "worker_id": w,
             "attempts": attempts,
             "claim_expires_at": claim_expires_at,
+            "max_attempts": max_attempts,
+            "created_at": created_at,
+            "expires_at": expires_at,
         }));
     }
     Ok(Value::Array(out).to_string())
@@ -1738,6 +1765,7 @@ fn now_unix(conn: &Connection) -> rusqlite::Result<i64> {
 mod real_arg_tests {
     use crate::{attach_honker_functions, bootstrap_honker_schema};
     use rusqlite::Connection;
+    use serde_json::Value;
 
     fn db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
@@ -1761,6 +1789,42 @@ mod real_arg_tests {
             )
             .unwrap();
         assert!(id > 0);
+    }
+
+    #[test]
+    fn claim_batch_returns_the_complete_job_snapshot() {
+        let conn = db();
+        let id: i64 = conn
+            .query_row(
+                "SELECT honker_enqueue('emails', '{\"to\":\"alice@example.com\"}',
+                                       NULL, NULL, 7, 5, 600)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+
+        let claimed: String = conn
+            .query_row(
+                "SELECT honker_claim_batch('emails', 'worker-1', 1, 300)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let rows: Value = serde_json::from_str(&claimed).unwrap();
+        let job = &rows[0];
+
+        assert_eq!(job["id"], id);
+        assert_eq!(job["queue"], "emails");
+        assert_eq!(job["payload"], r#"{"to":"alice@example.com"}"#);
+        assert_eq!(job["state"], "processing");
+        assert_eq!(job["priority"], 7);
+        assert_eq!(job["worker_id"], "worker-1");
+        assert_eq!(job["attempts"], 1);
+        assert_eq!(job["max_attempts"], 5);
+        assert!(job["run_at"].as_i64().unwrap() > 0);
+        assert!(job["claim_expires_at"].as_i64().unwrap() > 0);
+        assert!(job["created_at"].as_i64().unwrap() > 0);
+        assert!(job["expires_at"].as_i64().unwrap() > 0);
     }
 
     #[test]

--- a/packages/honker-node/README.md
+++ b/packages/honker-node/README.md
@@ -62,6 +62,28 @@ Delayed jobs use `runAt`:
 q.enqueue({ to: "later@example.com" }, { runAt: Math.floor(Date.now() / 1000) + 10 });
 ```
 
+TypeScript callers can give a queue a payload contract. Claimed jobs and
+`getJob()` snapshots preserve it:
+
+```ts
+interface EmailPayload {
+  to: string;
+  template: "welcome" | "receipt";
+}
+
+const emails = db.queue<EmailPayload>("emails");
+emails.enqueue({ to: "alice@example.com", template: "welcome" });
+
+const job = emails.claimOne("worker-1");
+if (job) {
+  console.log(job.payload.template, job.priority, job.runAt, job.createdAt);
+  job.ack();
+}
+```
+
+Payload generics describe the expected JSON shape at compile time; Honker does
+not perform runtime schema validation.
+
 Recurring schedules use `schedule`:
 
 ```js

--- a/packages/honker-node/README.md
+++ b/packages/honker-node/README.md
@@ -82,7 +82,40 @@ if (job) {
 ```
 
 Payload generics describe the expected JSON shape at compile time; Honker does
-not perform runtime schema validation.
+not perform runtime schema validation. Anything that can write to the queue —
+another process, another language binding, or a raw `honker_enqueue` on your own
+SQLite connection — decides what actually comes back, so validate at the boundary
+when the producer is not under your control.
+
+Every job carries the same twelve fields, whether it came from a claim or from
+`getJob()`:
+
+| field | |
+| --- | --- |
+| `id` `queue` `payload` | identity and body; `payload` is already JSON-decoded |
+| `state` | `"pending"` or `"processing"` |
+| `priority` `attempts` `maxAttempts` | scheduling and retry budget |
+| `runAt` `createdAt` `claimExpiresAt` `expiresAt` | **Unix epoch seconds, not milliseconds** |
+
+`workerId`, `claimExpiresAt`, and `expiresAt` are `null` when they do not apply
+(an unclaimed job, a job with no TTL). On a claimed job `workerId` and
+`claimExpiresAt` are always set. For a `Date`, multiply: `new Date(job.createdAt * 1000)`.
+
+### Upgrading `getJob()` from 0.5.1
+
+`getJob()` used to hand back the SQL layer's raw row. It now returns the decoded
+camelCase snapshot above. Two things change for existing callers:
+
+- `row.run_at` is now `job.runAt`, and so on for every snake_case field. The old
+  names read back as `undefined` rather than throwing.
+- `payload` is already decoded. Drop any `JSON.parse(row.payload)` around it.
+
+`getJob()` is also scoped to its own queue now: it returns `null` for a job owned
+by a different queue, where it previously returned that queue's row. Job ids are
+globally unique, so the old lookup could hand `emails` an SMS payload. There is
+no unscoped replacement yet (tracked in issue #134) — until then, call the SQL
+function directly on your own connection with `SELECT honker_get_job(?)`, which
+still returns the raw snake_case row. `cancel()` is unchanged and stays global.
 
 Recurring schedules use `schedule`:
 

--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -260,9 +260,15 @@ class Job {
     this.id = row.id;
     this.queue = row.queue;
     this.payload = parseJson(row.payload);
+    this.state = row.state;
+    this.priority = row.priority;
+    this.runAt = row.run_at;
     this.workerId = row.worker_id;
     this.attempts = row.attempts;
     this.claimExpiresAt = row.claim_expires_at ?? null;
+    this.maxAttempts = row.max_attempts;
+    this.createdAt = row.created_at;
+    this.expiresAt = row.expires_at ?? null;
   }
 
   ack() {
@@ -466,7 +472,21 @@ class Queue {
   getJob(jobId) {
     const raw = this._db._callScalar('SELECT honker_get_job(?)', [jobId]);
     if (!raw) return null;
-    return JSON.parse(raw);
+    const row = JSON.parse(raw);
+    return {
+      id: row.id,
+      queue: row.queue,
+      payload: parseJson(row.payload),
+      state: row.state,
+      priority: row.priority,
+      runAt: row.run_at,
+      workerId: row.worker_id ?? null,
+      claimExpiresAt: row.claim_expires_at ?? null,
+      attempts: row.attempts,
+      maxAttempts: row.max_attempts,
+      createdAt: row.created_at,
+      expiresAt: row.expires_at ?? null,
+    };
   }
 }
 

--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -468,11 +468,15 @@ class Queue {
   }
 
   /** Read a single job row by id. Returns the row object or null if
-   *  the job has been ack'd, dead'd, or never existed. */
+   *  the job has been ack'd, dead'd, never existed, or belongs to a
+   *  different queue. Job ids are globally unique, so the id alone
+   *  cannot say which queue owns the row; scoping the lookup to this
+   *  queue keeps the payload type honest. */
   getJob(jobId) {
     const raw = this._db._callScalar('SELECT honker_get_job(?)', [jobId]);
     if (!raw) return null;
     const row = JSON.parse(raw);
+    if (row.queue !== this.name) return null;
     return {
       id: row.id,
       queue: row.queue,

--- a/packages/honker-node/index.js
+++ b/packages/honker-node/index.js
@@ -78,7 +78,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-android-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-android-arm64/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -94,7 +94,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-android-arm-eabi')
         const bindingPackageVersion = require('@russellthehippo/honker-node-android-arm-eabi/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -115,7 +115,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-win32-x64-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-x64-gnu/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -131,7 +131,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-win32-x64-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-x64-msvc/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -148,7 +148,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-win32-ia32-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-ia32-msvc/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -164,7 +164,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-win32-arm64-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-arm64-msvc/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -183,7 +183,7 @@ function requireNative() {
       const binding = require('@russellthehippo/honker-node-darwin-universal')
       const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-universal/package.json').version
       if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -199,7 +199,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-darwin-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-x64/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -215,7 +215,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-darwin-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-arm64/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -235,7 +235,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-freebsd-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-freebsd-x64/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -251,7 +251,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-freebsd-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-freebsd-arm64/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -272,7 +272,7 @@ function requireNative() {
           const binding = require('@russellthehippo/honker-node-linux-x64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-x64-musl/package.json').version
           if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -288,7 +288,7 @@ function requireNative() {
           const binding = require('@russellthehippo/honker-node-linux-x64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-x64-gnu/package.json').version
           if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -306,7 +306,7 @@ function requireNative() {
           const binding = require('@russellthehippo/honker-node-linux-arm64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm64-musl/package.json').version
           if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -322,7 +322,7 @@ function requireNative() {
           const binding = require('@russellthehippo/honker-node-linux-arm64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm64-gnu/package.json').version
           if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -340,7 +340,7 @@ function requireNative() {
           const binding = require('@russellthehippo/honker-node-linux-arm-musleabihf')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm-musleabihf/package.json').version
           if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -356,7 +356,7 @@ function requireNative() {
           const binding = require('@russellthehippo/honker-node-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm-gnueabihf/package.json').version
           if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -374,7 +374,7 @@ function requireNative() {
           const binding = require('@russellthehippo/honker-node-linux-loong64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-loong64-musl/package.json').version
           if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -390,7 +390,7 @@ function requireNative() {
           const binding = require('@russellthehippo/honker-node-linux-loong64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-loong64-gnu/package.json').version
           if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -408,7 +408,7 @@ function requireNative() {
           const binding = require('@russellthehippo/honker-node-linux-riscv64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-riscv64-musl/package.json').version
           if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -424,7 +424,7 @@ function requireNative() {
           const binding = require('@russellthehippo/honker-node-linux-riscv64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-riscv64-gnu/package.json').version
           if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+            throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -441,7 +441,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-linux-ppc64-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-linux-ppc64-gnu/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -457,7 +457,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-linux-s390x-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-linux-s390x-gnu/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -477,7 +477,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-openharmony-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-arm64/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -493,7 +493,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-openharmony-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-x64/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -509,7 +509,7 @@ function requireNative() {
         const binding = require('@russellthehippo/honker-node-openharmony-arm')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-arm/package.json').version
         if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          throw new Error(`Native binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/packages/honker-node/package-lock.json
+++ b/packages/honker-node/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.5.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
-        "@napi-rs/cli": "^3.0.0"
+        "@napi-rs/cli": "^3.0.0",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">= 20"
@@ -2005,6 +2006,20 @@
       "workspaces": [
         "website"
       ]
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",

--- a/packages/honker-node/package.json
+++ b/packages/honker-node/package.json
@@ -47,10 +47,12 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "node --test test/extension.js test/api.test.js test/basic.js test/parity.test.js test/cross_lang_python_to_node.js test/cross_lang_node_to_python.js test/cross_lang_supporting.js test/watcher_backends.js test/watcher_backends_e2e.js test/watcher_backends_queue_e2e.js test/phase_mantle.js"
+    "test": "npm run test:types && node --test test/extension.js test/api.test.js test/basic.js test/parity.test.js test/cross_lang_python_to_node.js test/cross_lang_node_to_python.js test/cross_lang_supporting.js test/watcher_backends.js test/watcher_backends_e2e.js test/watcher_backends_queue_e2e.js test/phase_mantle.js test/typed_jobs_e2e.js",
+    "test:types": "tsc -p test/types/tsconfig.json"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^3.0.0"
+    "@napi-rs/cli": "^3.0.0",
+    "typescript": "^5.9.3"
   },
   "license": "MIT OR Apache-2.0",
   "repository": {

--- a/packages/honker-node/test/parity.test.js
+++ b/packages/honker-node/test/parity.test.js
@@ -74,8 +74,14 @@ test('queue: enqueue + claimOne + ack', () => {
     assert.ok(job);
     assert.equal(job.queue, 'emails');
     assert.deepEqual(job.payload, { to: 'alice@example.com' });
+    assert.equal(job.state, 'processing');
+    assert.equal(job.priority, 0);
+    assert.ok(job.runAt > 0);
     assert.equal(job.workerId, 'w1');
     assert.equal(job.attempts, 1);
+    assert.equal(job.maxAttempts, 3);
+    assert.ok(job.createdAt > 0);
+    assert.equal(job.expiresAt, null);
     assert.equal(job.ack(), true);
     assert.equal(q.claimOne('w1'), null);
   } finally {

--- a/packages/honker-node/test/phase_mantle.js
+++ b/packages/honker-node/test/phase_mantle.js
@@ -139,8 +139,16 @@ test('queue.getJob returns row, cancel removes pending', () => {
     const row = q.getJob(jid);
     assert.equal(row.queue, 'emails');
     assert.equal(row.state, 'pending');
-    assert.deepEqual(JSON.parse(row.payload), { to: 'alice@example.com' });
+    assert.deepEqual(row.payload, { to: 'alice@example.com' });
     assert.equal(row.id, jid);
+    assert.equal(row.priority, 0);
+    assert.ok(row.runAt > 0);
+    assert.equal(row.workerId, null);
+    assert.equal(row.claimExpiresAt, null);
+    assert.equal(row.attempts, 0);
+    assert.equal(row.maxAttempts, 3);
+    assert.ok(row.createdAt > 0);
+    assert.equal(row.expiresAt, null);
 
     assert.equal(q.cancel(jid), true);
     assert.equal(q.cancel(jid), false); // idempotent

--- a/packages/honker-node/test/typed_jobs_e2e.js
+++ b/packages/honker-node/test/typed_jobs_e2e.js
@@ -52,17 +52,25 @@ test('typed job details survive a producer-to-consumer process journey', () => {
     db.close();
     db = null;
 
+    // A distinctive visibility timeout so claimExpiresAt cannot be confused
+    // with any other timestamp on the job: runAt and createdAt sit at ~+0 and
+    // expiresAt at ~+600, while this claim's deadline lands at ~+77.
+    const visibilityTimeoutS = 77;
     const consumerOutput = runNode(`
       const honker = require('.');
       const db = honker.open(process.argv[1]);
-      const job = db.queue('emails').claimOne('worker-e2e');
+      const job = db.queue('emails', { visibilityTimeoutS: ${visibilityTimeoutS} })
+        .claimOne('worker-e2e');
       console.log(JSON.stringify({
+        fields: Object.keys(job).filter((k) => !k.startsWith('_')),
         id: job.id,
+        queue: job.queue,
         payload: job.payload,
         state: job.state,
         priority: job.priority,
         runAt: job.runAt,
         workerId: job.workerId,
+        claimExpiresAt: job.claimExpiresAt,
         attempts: job.attempts,
         maxAttempts: job.maxAttempts,
         createdAt: job.createdAt,
@@ -73,6 +81,7 @@ test('typed job details survive a producer-to-consumer process journey', () => {
     `, dbPath);
     const claimed = JSON.parse(consumerOutput);
     assert.equal(claimed.id, jobId);
+    assert.equal(claimed.queue, 'emails');
     assert.deepEqual(claimed.payload, snapshot.payload);
     assert.equal(claimed.state, 'processing');
     assert.equal(claimed.priority, 7);
@@ -83,6 +92,29 @@ test('typed job details survive a producer-to-consumer process journey', () => {
     assert.equal(claimed.createdAt, snapshot.createdAt);
     assert.equal(claimed.expiresAt, snapshot.expiresAt);
     assert.equal(claimed.acked, true);
+
+    // The claim lease. Nothing else pins this field, and every other timestamp
+    // on the job is far outside this window, so a mapping that returned runAt,
+    // createdAt, or expiresAt here fails.
+    assert.equal(typeof claimed.claimExpiresAt, 'number');
+    assert.ok(
+      claimed.claimExpiresAt >= claimed.createdAt + visibilityTimeoutS,
+      `claimExpiresAt ${claimed.claimExpiresAt} is before createdAt + ${visibilityTimeoutS}`,
+    );
+    assert.ok(
+      claimed.claimExpiresAt <= claimed.createdAt + visibilityTimeoutS + 120,
+      `claimExpiresAt ${claimed.claimExpiresAt} is far past createdAt + ${visibilityTimeoutS}`,
+    );
+
+    // A claimed Job and a JobSnapshot must expose the same twelve fields.
+    // Without this, a field added to one shape and not the other ships silently.
+    const JOB_FIELDS = [
+      'attempts', 'claimExpiresAt', 'createdAt', 'expiresAt', 'id',
+      'maxAttempts', 'payload', 'priority', 'queue', 'runAt', 'state',
+      'workerId',
+    ];
+    assert.deepEqual(claimed.fields.slice().sort(), JOB_FIELDS);
+    assert.deepEqual(Object.keys(snapshot).sort(), JOB_FIELDS);
 
     db = honker.open(dbPath);
     assert.equal(db.queue('emails').getJob(jobId), null);
@@ -141,6 +173,33 @@ test('a claimed job reports its own run_at, not its created_at', () => {
     assert.equal(job.runAt, runAt);
     assert.notEqual(job.runAt, job.createdAt);
     assert.equal(job.createdAt, snapshot.createdAt);
+  } finally {
+    try { db?.close(); } catch {}
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a JSON null payload comes back as null, not as the string "null"', () => {
+  // `Job<T>.payload` and `JobSnapshot<T>.payload` are declared as `T`, but the
+  // generic is an unchecked assertion: honker never inspects payload shape. A
+  // JSON null is the one violation reachable from any producer with no raw SQL
+  // at all, so pin what a reader actually gets. The TSDoc on
+  // `JobSnapshot.payload` documents this; this test keeps that doc honest.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'honker-null-payload-'));
+  const dbPath = path.join(dir, 'app.db');
+  let db;
+  try {
+    db = honker.open(dbPath);
+    const q = db.queue('nullable');
+    const id = q.enqueue(null);
+
+    const snapshot = q.getJob(id);
+    assert.equal(snapshot.payload, null);
+
+    const job = q.claimOne('worker-null');
+    assert.equal(job.id, id);
+    assert.equal(job.payload, null);
+    assert.equal(job.ack(), true);
   } finally {
     try { db?.close(); } catch {}
     fs.rmSync(dir, { recursive: true, force: true });

--- a/packages/honker-node/test/typed_jobs_e2e.js
+++ b/packages/honker-node/test/typed_jobs_e2e.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const honker = require('..');
+
+function runNode(script, dbPath) {
+  const result = spawnSync(process.execPath, ['-e', script, dbPath], {
+    cwd: path.join(__dirname, '..'),
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result.stdout.trim();
+}
+
+test('typed job details survive a producer-to-consumer process journey', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'honker-typed-jobs-e2e-'));
+  const dbPath = path.join(dir, 'app.db');
+  let db;
+  try {
+    const producerOutput = runNode(`
+      const honker = require('.');
+      const db = honker.open(process.argv[1]);
+      const queue = db.queue('emails', { maxAttempts: 5 });
+      const id = queue.enqueue(
+        { recipient: 'alice@example.com', template: 'welcome' },
+        { priority: 7, expires: 600 },
+      );
+      console.log(id);
+      db.close();
+    `, dbPath);
+    const jobId = Number(producerOutput);
+    assert.ok(jobId > 0);
+
+    db = honker.open(dbPath);
+    const snapshot = db.queue('emails').getJob(jobId);
+    assert.deepEqual(snapshot.payload, {
+      recipient: 'alice@example.com',
+      template: 'welcome',
+    });
+    assert.equal(snapshot.state, 'pending');
+    assert.equal(snapshot.priority, 7);
+    assert.equal(snapshot.maxAttempts, 5);
+    assert.ok(snapshot.runAt > 0);
+    assert.ok(snapshot.createdAt > 0);
+    assert.ok(snapshot.expiresAt >= snapshot.createdAt + 599);
+    db.close();
+    db = null;
+
+    const consumerOutput = runNode(`
+      const honker = require('.');
+      const db = honker.open(process.argv[1]);
+      const job = db.queue('emails').claimOne('worker-e2e');
+      console.log(JSON.stringify({
+        id: job.id,
+        payload: job.payload,
+        state: job.state,
+        priority: job.priority,
+        runAt: job.runAt,
+        workerId: job.workerId,
+        attempts: job.attempts,
+        maxAttempts: job.maxAttempts,
+        createdAt: job.createdAt,
+        expiresAt: job.expiresAt,
+        acked: job.ack(),
+      }));
+      db.close();
+    `, dbPath);
+    const claimed = JSON.parse(consumerOutput);
+    assert.equal(claimed.id, jobId);
+    assert.deepEqual(claimed.payload, snapshot.payload);
+    assert.equal(claimed.state, 'processing');
+    assert.equal(claimed.priority, 7);
+    assert.equal(claimed.workerId, 'worker-e2e');
+    assert.equal(claimed.attempts, 1);
+    assert.equal(claimed.maxAttempts, 5);
+    assert.equal(claimed.runAt, snapshot.runAt);
+    assert.equal(claimed.createdAt, snapshot.createdAt);
+    assert.equal(claimed.expiresAt, snapshot.expiresAt);
+    assert.equal(claimed.acked, true);
+
+    db = honker.open(dbPath);
+    assert.equal(db.queue('emails').getJob(jobId), null);
+  } finally {
+    try { db?.close(); } catch {}
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/honker-node/test/typed_jobs_e2e.js
+++ b/packages/honker-node/test/typed_jobs_e2e.js
@@ -116,3 +116,33 @@ test('getJob is scoped to its own queue', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('a claimed job reports its own run_at, not its created_at', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'honker-runat-backdated-'));
+  const dbPath = path.join(dir, 'app.db');
+  let db;
+  try {
+    db = honker.open(dbPath);
+    const q = db.queue('backdated');
+
+    // Back-date run_at so it differs from created_at while the job stays
+    // claimable. A *delay* would push run_at into the future, which makes the
+    // job unclaimable — which is why every other test here compares two values
+    // that are equal to the second and cannot tell the two fields apart.
+    const runAt = Math.floor(Date.now() / 1000) - 100;
+    const id = q.enqueue({ hello: 'backdated' }, { runAt });
+
+    const snapshot = q.getJob(id);
+    assert.equal(snapshot.runAt, runAt);
+    assert.notEqual(snapshot.runAt, snapshot.createdAt);
+
+    const job = q.claimOne('worker-backdated');
+    assert.equal(job.id, id);
+    assert.equal(job.runAt, runAt);
+    assert.notEqual(job.runAt, job.createdAt);
+    assert.equal(job.createdAt, snapshot.createdAt);
+  } finally {
+    try { db?.close(); } catch {}
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/honker-node/test/typed_jobs_e2e.js
+++ b/packages/honker-node/test/typed_jobs_e2e.js
@@ -91,3 +91,28 @@ test('typed job details survive a producer-to-consumer process journey', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('getJob is scoped to its own queue', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'honker-getjob-scope-'));
+  const dbPath = path.join(dir, 'app.db');
+  let db;
+  try {
+    db = honker.open(dbPath);
+    const emails = db.queue('emails');
+    const sms = db.queue('sms');
+
+    // Two queues with incompatible payload contracts. Job ids are globally
+    // unique, so a raw id lookup would happily hand an SMS row to `emails`.
+    const smsId = sms.enqueue({ phone: '+15550100', body: 'hello' });
+
+    assert.equal(emails.getJob(smsId), null);
+
+    const owned = sms.getJob(smsId);
+    assert.deepEqual(owned.payload, { phone: '+15550100', body: 'hello' });
+    assert.equal(owned.queue, 'sms');
+    assert.equal(owned.id, smsId);
+  } finally {
+    try { db?.close(); } catch {}
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/honker-node/test/types/tsconfig.json
+++ b/packages/honker-node/test/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["typed-jobs.ts"]
+}

--- a/packages/honker-node/test/types/typed-jobs.ts
+++ b/packages/honker-node/test/types/typed-jobs.ts
@@ -22,12 +22,47 @@ if (pending) {
   pending.runAt.toFixed(0)
 }
 
+// A pending snapshot has no claim, so the compiler must force a null check on
+// the two claim-only fields. Without this the `Job` narrowing below would be
+// vacuous — both types would just be nullable everywhere.
+if (pending) {
+  // @ts-expect-error workerId is null while a job is pending
+  pending.workerId.toUpperCase()
+  // @ts-expect-error claimExpiresAt is null while a job is pending
+  pending.claimExpiresAt.toFixed(0)
+}
+
 const claimed: Job<EmailPayload> | null = queue.claimOne('worker-1')
 if (claimed) {
   claimed.payload.template satisfies 'welcome' | 'receipt'
   claimed.state satisfies 'processing'
   claimed.priority.toFixed(0)
+  // Holding a claim is what makes these two non-null. No check needed.
+  claimed.workerId.toUpperCase()
+  claimed.claimExpiresAt.toFixed(0)
+  claimed.expiresAt satisfies number | null
 }
+
+// A claimed job is a snapshot you hold a claim on: every reader that takes a
+// JobSnapshot must accept a Job. `implements JobSnapshot<TPayload>` on the
+// class declaration enforces the other direction, so a field added to one and
+// not the other fails this compile.
+function describe<T>(job: JobSnapshot<T>): number {
+  return job.createdAt
+}
+if (claimed) {
+  describe<EmailPayload>(claimed)
+}
+
+// The payload generic must survive the async iterator too, which is the shape
+// a real worker loop uses.
+async function work(signal: AbortSignal): Promise<void> {
+  for await (const job of queue.claim('worker-3', { signal })) {
+    job.payload.variables.firstName?.toUpperCase()
+    job.ack()
+  }
+}
+void work
 
 const waker = queue.claimWaker()
 const nextJob: Promise<Job<EmailPayload> | null> = waker.next('worker-2')

--- a/packages/honker-node/test/types/typed-jobs.ts
+++ b/packages/honker-node/test/types/typed-jobs.ts
@@ -1,0 +1,50 @@
+import { open, type Job, type JobSnapshot } from '../..'
+
+interface EmailPayload {
+  recipient: string
+  template: 'welcome' | 'receipt'
+  variables: Record<string, string>
+}
+
+const db = open('typed-jobs.db')
+const queue = db.queue<EmailPayload>('emails')
+
+queue.enqueue({
+  recipient: 'alice@example.com',
+  template: 'welcome',
+  variables: { firstName: 'Alice' },
+})
+
+const pending: JobSnapshot<EmailPayload> | null = queue.getJob(1)
+if (pending) {
+  pending.payload.recipient.toUpperCase()
+  pending.state satisfies 'pending' | 'processing'
+  pending.runAt.toFixed(0)
+}
+
+const claimed: Job<EmailPayload> | null = queue.claimOne('worker-1')
+if (claimed) {
+  claimed.payload.template satisfies 'welcome' | 'receipt'
+  claimed.state satisfies 'processing'
+  claimed.priority.toFixed(0)
+}
+
+const waker = queue.claimWaker()
+const nextJob: Promise<Job<EmailPayload> | null> = waker.next('worker-2')
+void nextJob
+
+const outbox = db.outbox<EmailPayload>('email-delivery', async (payload, job) => {
+  payload.variables.firstName.toUpperCase()
+  job.payload.recipient.toUpperCase()
+})
+outbox.enqueue({
+  recipient: 'bob@example.com',
+  template: 'receipt',
+  variables: {},
+})
+
+// @ts-expect-error recipient is required by the queue payload contract
+queue.enqueue({ template: 'welcome', variables: {} })
+
+waker.close()
+db.close()

--- a/packages/honker-node/wrapper.d.ts
+++ b/packages/honker-node/wrapper.d.ts
@@ -194,7 +194,34 @@ export class Queue<TPayload = JsonValue> {
   ackBatch(ids: number[], workerId: string): number
   sweepExpired(): number
   claimWaker(opts?: { idlePollS?: number | null }): ClaimWaker<TPayload>
+  /**
+   * Delete a pending or processing job by id. Returns true iff a row was
+   * removed. Idempotent on a missing job.
+   *
+   * NOT queue-scoped: job ids are globally unique, and `cancel` will remove a
+   * job belonging to any queue, not just this one. This is deliberately
+   * asymmetric with {@link Queue.getJob}, which does scope to its own queue.
+   * A read-then-check in JavaScript would not be atomic — a worker can claim
+   * or complete the job between the check and the delete — so correct scoping
+   * needs the filter pushed into the core. Pass only ids you know this queue
+   * owns.
+   *
+   * Cancel does NOT interrupt a worker that is currently running the handler
+   * for this job. The worker keeps executing until its handler returns. What
+   * cancel does is invalidate the worker's claim: its next `ack()` or
+   * `heartbeat()` returns false, the same shape as an expired claim. If you
+   * need the handler to actually stop, build that signal into your app;
+   * honker does not propagate cancellation to running handlers.
+   */
   cancel(jobId: number): boolean
+  /**
+   * Read a single job row by id.
+   *
+   * Returns null if the job has been ack'd, dead'd, never existed, or belongs
+   * to a different queue. The lookup is scoped to this queue: because job ids
+   * are globally unique, an unscoped lookup could return a row whose payload
+   * does not match `TPayload`.
+   */
   getJob(jobId: number): JobSnapshot<TPayload> | null
 }
 

--- a/packages/honker-node/wrapper.d.ts
+++ b/packages/honker-node/wrapper.d.ts
@@ -102,39 +102,120 @@ export class Lock {
   heartbeat(ttlS: number): boolean
 }
 
+/**
+ * The states a live job can be in. Acked and dead-lettered jobs leave the live
+ * table, so they are never observed here.
+ */
 export type JobState = 'pending' | 'processing'
 
+/**
+ * A read-only view of one live job, as returned by {@link Queue.getJob}.
+ *
+ * Every timestamp is **Unix epoch seconds**, not milliseconds. Use
+ * `new Date(job.createdAt * 1000)` to get a JS `Date`.
+ *
+ * A claimed {@link Job} carries the same twelve fields plus its completion
+ * methods, so a `Job<T>` can be passed anywhere a `JobSnapshot<T>` is expected.
+ */
 export interface JobSnapshot<TPayload = JsonValue> {
+  /** Job id. Globally unique across every queue in the database. */
   readonly id: number
+  /** Name of the queue that owns this job. */
   readonly queue: string
+  /**
+   * The stored payload, JSON-decoded.
+   *
+   * `TPayload` is an **unchecked assertion**, not a validated schema. Honker
+   * stores the payload as text and never inspects its shape, so whatever can
+   * write to this queue — another process, another language binding, or a raw
+   * `honker_enqueue` through your own SQLite connection — decides what comes
+   * back. A producer may write JSON `null`, which arrives here as `null`
+   * despite the declared type. Validate at the boundary when the producer is
+   * not entirely under your control.
+   */
   readonly payload: TPayload
+  /** `'pending'` (waiting to run) or `'processing'` (claimed by a worker). */
   readonly state: JobState
+  /** Higher runs first. Defaults to 0. */
   readonly priority: number
+  /** Earliest time the job may be claimed, in Unix epoch seconds. */
   readonly runAt: number
+  /** Worker holding the current claim, or null while the job is pending. */
   readonly workerId: string | null
+  /**
+   * When the current claim lapses and the job becomes reclaimable, in Unix
+   * epoch seconds. Null while the job is pending.
+   */
   readonly claimExpiresAt: number | null
+  /** Claims made so far. The job is dead-lettered once this reaches `maxAttempts`. */
   readonly attempts: number
+  /** Claim budget, fixed at enqueue time from the queue's `maxAttempts`. */
   readonly maxAttempts: number
+  /** When the job was enqueued, in Unix epoch seconds. */
   readonly createdAt: number
+  /**
+   * When the job stops being claimable regardless of state, in Unix epoch
+   * seconds, or null if it never expires. Set from `EnqueueOptions.expires`.
+   */
   readonly expiresAt: number | null
 }
 
-export class Job<TPayload = JsonValue> {
+/**
+ * A job this worker currently holds a claim on, returned by
+ * {@link Queue.claimOne}, {@link Queue.claimBatch}, {@link Queue.claim}, and
+ * {@link ClaimWaker.next}.
+ *
+ * Structurally a {@link JobSnapshot} — the same twelve fields, the same
+ * Unix-epoch-second timestamps — narrowed by what holding a claim guarantees:
+ * `state` is always `'processing'`, and `workerId` and `claimExpiresAt` are
+ * never null.
+ *
+ * Call exactly one of `ack`, `retry`, or `fail` when you are done. Each returns
+ * false when the claim is no longer yours, which happens if it lapsed or the
+ * job was cancelled.
+ */
+export class Job<TPayload = JsonValue> implements JobSnapshot<TPayload> {
+  /** Job id. Globally unique across every queue in the database. */
   readonly id: number
+  /** Name of the queue that owns this job. */
   readonly queue: string
+  /**
+   * The stored payload, JSON-decoded. `TPayload` is an unchecked assertion —
+   * see {@link JobSnapshot.payload}.
+   */
   readonly payload: TPayload
+  /** Always `'processing'`: holding a claim is what makes this a `Job`. */
   readonly state: 'processing'
+  /** Higher runs first. Defaults to 0. */
   readonly priority: number
+  /** Earliest time the job could be claimed, in Unix epoch seconds. */
   readonly runAt: number
+  /** The worker id this job was claimed with. Never null on a claimed job. */
   readonly workerId: string
+  /**
+   * When this claim lapses, in Unix epoch seconds. Never null on a claimed
+   * job. Past it another worker may reclaim the job and `ack()` returns false.
+   * Push it out with `heartbeat()`.
+   */
+  readonly claimExpiresAt: number
+  /** Claims made so far, including this one, so always at least 1. */
   readonly attempts: number
-  readonly claimExpiresAt: number | null
+  /** Claim budget, fixed at enqueue time from the queue's `maxAttempts`. */
   readonly maxAttempts: number
+  /** When the job was enqueued, in Unix epoch seconds. */
   readonly createdAt: number
+  /**
+   * When the job stops being claimable regardless of state, in Unix epoch
+   * seconds, or null if it never expires.
+   */
   readonly expiresAt: number | null
+  /** Mark the job done and remove it. False if the claim is no longer ours. */
   ack(): boolean
+  /** Return the job to the queue, optionally after `delayS` seconds. */
   retry(delayS?: number, error?: string): boolean
+  /** Dead-letter the job now, without spending its remaining attempts. */
   fail(error?: string): boolean
+  /** Push `claimExpiresAt` out by `extendS` seconds. False if the claim lapsed. */
   heartbeat(extendS: number): boolean
 }
 
@@ -215,12 +296,23 @@ export class Queue<TPayload = JsonValue> {
    */
   cancel(jobId: number): boolean
   /**
-   * Read a single job row by id.
+   * Read a single job by id, as a {@link JobSnapshot}.
    *
    * Returns null if the job has been ack'd, dead'd, never existed, or belongs
    * to a different queue. The lookup is scoped to this queue: because job ids
    * are globally unique, an unscoped lookup could return a row whose payload
    * does not match `TPayload`.
+   *
+   * Two breaking changes landed here together, both since 0.5.1:
+   *
+   * 1. The return value is now the decoded camelCase `JobSnapshot` instead of
+   *    the SQL ABI's raw row. `row.run_at` is now `snapshot.runAt`, and
+   *    `payload` is already JSON-decoded — do not `JSON.parse` it again.
+   * 2. The lookup is queue-scoped. Code that used any queue handle as a global
+   *    by-id lookup now gets null for jobs owned by other queues. There is no
+   *    unscoped replacement yet; until one lands (see honker issue #134), reach
+   *    for the SQL function directly on your own connection:
+   *    `SELECT honker_get_job(?)`, which still returns the raw snake_case row.
    */
   getJob(jobId: number): JobSnapshot<TPayload> | null
 }

--- a/packages/honker-node/wrapper.d.ts
+++ b/packages/honker-node/wrapper.d.ts
@@ -102,21 +102,44 @@ export class Lock {
   heartbeat(ttlS: number): boolean
 }
 
-export class Job {
+export type JobState = 'pending' | 'processing'
+
+export interface JobSnapshot<TPayload = JsonValue> {
   readonly id: number
   readonly queue: string
-  readonly payload: JsonValue
+  readonly payload: TPayload
+  readonly state: JobState
+  readonly priority: number
+  readonly runAt: number
+  readonly workerId: string | null
+  readonly claimExpiresAt: number | null
+  readonly attempts: number
+  readonly maxAttempts: number
+  readonly createdAt: number
+  readonly expiresAt: number | null
+}
+
+export class Job<TPayload = JsonValue> {
+  readonly id: number
+  readonly queue: string
+  readonly payload: TPayload
+  readonly state: 'processing'
+  readonly priority: number
+  readonly runAt: number
   readonly workerId: string
   readonly attempts: number
   readonly claimExpiresAt: number | null
+  readonly maxAttempts: number
+  readonly createdAt: number
+  readonly expiresAt: number | null
   ack(): boolean
   retry(delayS?: number, error?: string): boolean
   fail(error?: string): boolean
   heartbeat(extendS: number): boolean
 }
 
-export class ClaimWaker {
-  next(workerId: string, opts?: { signal?: AbortSignal }): Promise<Job | null>
+export class ClaimWaker<TPayload = JsonValue> {
+  next(workerId: string, opts?: { signal?: AbortSignal }): Promise<Job<TPayload> | null>
   close(): void
 }
 
@@ -159,18 +182,20 @@ export class Scheduler {
   run(owner: string, signal?: AbortSignal): Promise<void>
 }
 
-export class Queue {
+export class Queue<TPayload = JsonValue> {
   readonly name: string
   readonly visibilityTimeoutS: number
   readonly maxAttempts: number
-  enqueue(payload: JsonValue, opts?: EnqueueOptions): number
-  enqueueTx(tx: Transaction | any, payload: JsonValue, opts?: EnqueueOptions): number
-  claimBatch(workerId: string, n: number): Job[]
-  claimOne(workerId: string): Job | null
-  claim(workerId: string, opts?: { idlePollS?: number | null, signal?: AbortSignal }): AsyncIterableIterator<Job>
+  enqueue(payload: TPayload, opts?: EnqueueOptions): number
+  enqueueTx(tx: Transaction | any, payload: TPayload, opts?: EnqueueOptions): number
+  claimBatch(workerId: string, n: number): Job<TPayload>[]
+  claimOne(workerId: string): Job<TPayload> | null
+  claim(workerId: string, opts?: { idlePollS?: number | null, signal?: AbortSignal }): AsyncIterableIterator<Job<TPayload>>
   ackBatch(ids: number[], workerId: string): number
   sweepExpired(): number
-  claimWaker(opts?: { idlePollS?: number | null }): ClaimWaker
+  claimWaker(opts?: { idlePollS?: number | null }): ClaimWaker<TPayload>
+  cancel(jobId: number): boolean
+  getJob(jobId: number): JobSnapshot<TPayload> | null
 }
 
 export interface OutboxOptions {
@@ -179,13 +204,13 @@ export interface OutboxOptions {
   baseBackoffS?: number
 }
 
-export class Outbox {
+export class Outbox<TPayload = JsonValue> {
   readonly name: string
-  readonly queue: Queue
+  readonly queue: Queue<TPayload>
   readonly maxAttempts: number
   readonly baseBackoffS: number
-  enqueue(payload: JsonValue, opts?: EnqueueOptions): number
-  enqueueTx(tx: Transaction | any, payload: JsonValue, opts?: EnqueueOptions): number
+  enqueue(payload: TPayload, opts?: EnqueueOptions): number
+  enqueueTx(tx: Transaction | any, payload: TPayload, opts?: EnqueueOptions): number
   runWorker(workerId: string, opts?: { idlePollS?: number | null, signal?: AbortSignal }): Promise<void>
 }
 
@@ -198,8 +223,8 @@ export class Database {
   pruneNotifications(olderThanS?: number | null, maxKeep?: number | null): number
   notify(channel: string, payload: JsonValue): number
   notifyTx(tx: Transaction | any, channel: string, payload: JsonValue): number
-  queue(name: string, opts?: QueueOptions): Queue
-  outbox(name: string, delivery: (payload: JsonValue, job: Job) => any | Promise<any>, opts?: OutboxOptions): Outbox
+  queue<TPayload = JsonValue>(name: string, opts?: QueueOptions): Queue<TPayload>
+  outbox<TPayload = JsonValue>(name: string, delivery: (payload: TPayload, job: Job<TPayload>) => any | Promise<any>, opts?: OutboxOptions): Outbox<TPayload>
   stream(name: string): Stream
   listen(channel: string, opts?: { fallbackPollS?: number | null }): Listener
   scheduler(): Scheduler

--- a/scripts/proof/check-node-version-alignment.py
+++ b/scripts/proof/check-node-version-alignment.py
@@ -60,6 +60,25 @@ def main() -> int:
     elif unexpected := sorted(set(loader_versions) - {version}):
         errors.append(f"index.js checks unexpected native versions: {unexpected}")
 
+    # The version the guard compares and the version its error message names
+    # are generated separately. A stale index.js can compare correctly while
+    # telling the user to install the wrong version, so check both.
+    message_versions = re.findall(
+        r"Native binding package version mismatch, expected ([^ ]+) but got", loader
+    )
+    if not message_versions:
+        errors.append("index.js has no native package version mismatch messages")
+    elif unexpected := sorted(set(message_versions) - {version}):
+        errors.append(
+            f"index.js mismatch messages name unexpected versions: {unexpected} "
+            f"(regenerate with `napi build`)"
+        )
+    elif len(message_versions) != len(loader_versions):
+        errors.append(
+            f"index.js has {len(loader_versions)} version checks but "
+            f"{len(message_versions)} mismatch messages"
+        )
+
     if errors:
         print("Node package version alignment failed:", file=sys.stderr)
         for error in errors:


### PR DESCRIPTION
## Summary

- Add a TypeScript payload type to Node queues, jobs, claim wakers, and outboxes. It defaults to `JsonValue` so existing code keeps working.
- Add typed camelCase job snapshots from `getJob()`.
- Add the missing `getJob()` and `cancel()` type declarations.
- Return full job details from the core claim call.
- Make `getJob()` return null for a job from another queue.
- Add docs and TypeScript compile tests.
- Fix stale native-loader version messages and check those messages in CI.

## Behavior changes

`getJob()` now maps the core snake_case row to the documented camelCase `JobSnapshot` shape. `CHANGELOG.md` calls this out because the runtime method existed before its TypeScript declaration.

`getJob()` now returns null when the job belongs to another queue. Job IDs are unique across the database, so the old ID-only lookup could return an SMS payload from `emails.getJob(smsId)`. That would break the new `JobSnapshot<TPayload>` type. The check stays in the Node wrapper. `honker_get_job(?)` does not change.

`cancel()` is still global and the docs now say so. Reading the job first and cancelling in a second query would have a race. #134 tracks the core and binding changes needed to fix that safely.

## Scope

Queue events are separate work in #125. They are not part of this PR. #123 tracks the core and Node event work. #137 tracks event APIs for other bindings.

## Verification

- `cargo test -p honker-core --release`
- `npm test` in `packages/honker-node` - 116 tests, 114 passed, 2 Windows-only skips
- Full Python test suite
- `make lint`
- Separate-process Node producer, `getJob()` reader, and consumer/ack test
- Strict TypeScript public API compile test
- Cross-queue `getJob()` regression test
- Node version check now covers both loader guards and their error messages

## Follow-up issues

- #133 - Return SQLite errors instead of hiding them. `fail()` can otherwise lose a damaged job row.
- #134 - Make global database methods and queue-scoped methods consistent.
- #135 - Add a stable `claimed_at` value.
- #136 - Add full job details and typed payloads to every binding.

Closes #119
