### PR TITLE
feat(node): add transactional queue lifecycle events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,7 +469,7 @@ jobs:
       - name: Test (basic — node only)
         working-directory: packages/honker-node
         shell: bash
-        run: node --test test/api.test.js test/basic.js test/typed_jobs_e2e.js
+        run: node --test test/api.test.js test/basic.js test/typed_jobs_e2e.js test/queue_events.test.js test/queue_events_e2e.js
       - name: Test (parity — node API surface)
         working-directory: packages/honker-node
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@
 - `configureQueueEvents({ retentionTarget, includePayload })` persists one
   feed-wide policy. `retentionTarget` is approximate because topic-specific
   cleanup runs in bounded chunks rather than adding a delete to every job
-  transaction; `includePayload` applies to every queue and defaults to false.
+  transaction; its scheduling is coordinated in SQLite across short-lived
+  connections and processes. `includePayload` applies to every queue and
+  defaults to false.
 - Explicit replay checkpoints that predate retained history now throw
   `QueueEventOffsetExpiredError`. Omitting `fromOffset` starts at the oldest
   retained event, while `queueEventListener()` defaults to live events at the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,27 @@
 - Regression test claims a job at a deadline with one claim forced to
   return empty: it fails on the unpatched `api.js` and passes on the fix.
 
+## Unreleased — transactional Node queue lifecycle events
+
+- New opt-in, Rust-core queue lifecycle feed for `enqueued`, `claimed`,
+  `completed`, `retry_scheduled`, `dead_lettered`, and `cancelled` transitions.
+  Events commit atomically with the queue mutation and are observable across
+  processes through the Node async iterator or EventEmitter-style listener.
+- `configureQueueEvents({ retentionTarget, includePayload })` persists one
+  feed-wide policy. `retentionTarget` is approximate because topic-specific
+  cleanup runs in bounded chunks rather than adding a delete to every job
+  transaction; `includePayload` applies to every queue and defaults to false.
+- Explicit replay checkpoints that predate retained history now throw
+  `QueueEventOffsetExpiredError`. Omitting `fromOffset` starts at the oldest
+  retained event, while `queueEventListener()` defaults to live events at the
+  latest offset and errors clearly when the feed is disabled.
+- Terminal events include a stable `reason` (`explicit_failure`,
+  `attempts_exhausted`, or `job_expired`) separately from human-readable error
+  text. The internal queue-event topic rejects public stream publications.
+- Queue-event configuration is cached per connection for 100 ms. Disabled
+  mutations retain their lean SQL paths, batch transitions configure and trim
+  once, and a steady-state performance floor guards against per-event cleanup.
+
 ## Unreleased — typed Node jobs
 
 - Node `Queue`, `Job`, `JobSnapshot`, `ClaimWaker`, and `Outbox` APIs now carry

--- a/bench/queue_events_bench.py
+++ b/bench/queue_events_bench.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Measure queue-event costs through the public Python queue API.
+
+Build/install the local binding first, then run:
+
+    .venv/bin/python bench/queue_events_bench.py --jobs 10000
+
+This reports disabled and enabled throughput. The CI regression assertion for
+the disabled batch path lives in ``tests/test_performance_floors.py``; this
+script is for comparing fuller before/after profiles without flaky wall-clock
+thresholds in every test job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+import time
+from pathlib import Path
+
+import honker
+
+
+def configure(db, *, enabled: bool, include_payload: bool) -> None:
+    with db.transaction() as tx:
+        tx.query(
+            "SELECT honker_queue_events_configure(?, 1000000, ?)",
+            [int(enabled), int(include_payload)],
+        )
+
+
+def run_mode(directory: Path, mode: str, jobs: int) -> dict[str, float | str]:
+    db_path = str(directory / f"{mode}.db")
+    db = honker.open(db_path)
+    enabled = mode != "disabled"
+    configure(db, enabled=enabled, include_payload=mode == "enabled-payload")
+    # Python intentionally has no public queue-events binding yet. Reopen after
+    # the raw transactional configure call so the timed writer starts with a
+    # fresh core cache, matching a normal producer process.
+    db.close()
+    db = honker.open(db_path)
+    queue = db.queue("bench", visibility_timeout_s=300)
+    payload = {"id": 1, "kind": "queue-event-benchmark"}
+
+    started = time.perf_counter()
+    with db.transaction() as tx:
+        for _ in range(jobs):
+            queue.enqueue(payload, tx=tx)
+    enqueue_seconds = time.perf_counter() - started
+
+    claimed = queue.claim_batch("bench-worker", jobs)
+    ids = [job.id for job in claimed]
+    started = time.perf_counter()
+    acked = queue.ack_batch(ids, "bench-worker")
+    ack_seconds = time.perf_counter() - started
+    assert acked == jobs
+    db.close()
+
+    return {
+        "mode": mode,
+        "enqueue_jobs_per_second": jobs / enqueue_seconds,
+        "enqueue_seconds": enqueue_seconds,
+        "ack_jobs_per_second": jobs / ack_seconds,
+        "ack_seconds": ack_seconds,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--jobs", type=int, default=10_000)
+    args = parser.parse_args()
+    if args.jobs < 1:
+        parser.error("--jobs must be positive")
+
+    with tempfile.TemporaryDirectory(prefix="honker-queue-events-bench-") as temp:
+        directory = Path(temp)
+        results = [
+            run_mode(directory, mode, args.jobs)
+            for mode in ("disabled", "enabled", "enabled-payload")
+        ]
+    print(json.dumps({"jobs": args.jobs, "results": results}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/queue_events_bench.py
+++ b/bench/queue_events_bench.py
@@ -22,19 +22,28 @@ from pathlib import Path
 import honker
 
 
-def configure(db, *, enabled: bool, include_payload: bool) -> None:
+def configure(
+    db, *, enabled: bool, include_payload: bool, retention_target: int
+) -> None:
     with db.transaction() as tx:
         tx.query(
-            "SELECT honker_queue_events_configure(?, 1000000, ?)",
-            [int(enabled), int(include_payload)],
+            "SELECT honker_queue_events_configure(?, ?, ?)",
+            [int(enabled), retention_target, int(include_payload)],
         )
 
 
-def run_mode(directory: Path, mode: str, jobs: int) -> dict[str, float | str]:
+def run_mode(
+    directory: Path, mode: str, jobs: int, retention_target: int
+) -> dict[str, float | str | int]:
     db_path = str(directory / f"{mode}.db")
     db = honker.open(db_path)
     enabled = mode != "disabled"
-    configure(db, enabled=enabled, include_payload=mode == "enabled-payload")
+    configure(
+        db,
+        enabled=enabled,
+        include_payload=mode == "enabled-payload",
+        retention_target=retention_target,
+    )
     # Python intentionally has no public queue-events binding yet. Reopen after
     # the raw transactional configure call so the timed writer starts with a
     # fresh core cache, matching a normal producer process.
@@ -42,6 +51,11 @@ def run_mode(directory: Path, mode: str, jobs: int) -> dict[str, float | str]:
     db = honker.open(db_path)
     queue = db.queue("bench", visibility_timeout_s=300)
     payload = {"id": 1, "kind": "queue-event-benchmark"}
+
+    if mode == "enabled-at-target":
+        with db.transaction() as tx:
+            for _ in range(retention_target):
+                queue.enqueue(payload, tx=tx)
 
     started = time.perf_counter()
     with db.transaction() as tx:
@@ -55,6 +69,10 @@ def run_mode(directory: Path, mode: str, jobs: int) -> dict[str, float | str]:
     acked = queue.ack_batch(ids, "bench-worker")
     ack_seconds = time.perf_counter() - started
     assert acked == jobs
+    retained_events = db.query(
+        "SELECT COUNT(*) AS count FROM _honker_stream "
+        "WHERE topic = '_honker:queue-events:v1'"
+    )[0]["count"]
     db.close()
 
     return {
@@ -63,23 +81,41 @@ def run_mode(directory: Path, mode: str, jobs: int) -> dict[str, float | str]:
         "enqueue_seconds": enqueue_seconds,
         "ack_jobs_per_second": jobs / ack_seconds,
         "ack_seconds": ack_seconds,
+        "retained_events": retained_events,
     }
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--jobs", type=int, default=10_000)
+    parser.add_argument("--retention-target", type=int, default=10_000)
     args = parser.parse_args()
     if args.jobs < 1:
         parser.error("--jobs must be positive")
+    if args.retention_target < 1:
+        parser.error("--retention-target must be positive")
 
     with tempfile.TemporaryDirectory(prefix="honker-queue-events-bench-") as temp:
         directory = Path(temp)
         results = [
-            run_mode(directory, mode, args.jobs)
-            for mode in ("disabled", "enabled", "enabled-payload")
+            run_mode(directory, mode, args.jobs, args.retention_target)
+            for mode in (
+                "disabled",
+                "enabled",
+                "enabled-at-target",
+                "enabled-payload",
+            )
         ]
-    print(json.dumps({"jobs": args.jobs, "results": results}, indent=2))
+    print(
+        json.dumps(
+            {
+                "jobs": args.jobs,
+                "retention_target": args.retention_target,
+                "results": results,
+            },
+            indent=2,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -51,7 +51,6 @@ struct QueueEventConfigCache {
     encoded: AtomicU64,
     expires_at_ms: AtomicU64,
     bypass_until_autocommit: AtomicBool,
-    events_since_trim: AtomicU64,
 }
 
 impl Default for QueueEventConfigCache {
@@ -60,7 +59,6 @@ impl Default for QueueEventConfigCache {
             encoded: AtomicU64::new(0),
             expires_at_ms: AtomicU64::new(0),
             bypass_until_autocommit: AtomicBool::new(false),
-            events_since_trim: AtomicU64::new(0),
         }
     }
 }
@@ -71,7 +69,6 @@ struct QueueEventEmitter<'a> {
     occurred_at: i64,
     last_offset: Option<i64>,
     emitted_events: u64,
-    cache: Option<&'a QueueEventConfigCache>,
 }
 
 /// Read an integer argument, accepting the REAL that dynamically typed
@@ -2142,14 +2139,23 @@ pub fn queue_events_configure(
     }
     conn.execute(
         "INSERT INTO _honker_queue_event_config
-           (singleton, enabled, retention_target, include_payload)
-         VALUES (1, ?1, ?2, ?3)
+           (singleton, enabled, retention_target, include_payload, events_since_trim)
+         VALUES (1, ?1, ?2, ?3, 0)
          ON CONFLICT(singleton) DO UPDATE SET
            enabled = excluded.enabled,
            retention_target = excluded.retention_target,
-           include_payload = excluded.include_payload",
+           include_payload = excluded.include_payload,
+           events_since_trim = 0",
         rusqlite::params![enabled as i64, retention_target, include_payload as i64],
     )?;
+    if let Some(trim_through) = trim_queue_events(conn, retention_target)? {
+        conn.execute(
+            "UPDATE _honker_queue_event_config
+             SET trimmed_through_offset = MAX(trimmed_through_offset, ?1)
+             WHERE singleton = 1",
+            [trim_through],
+        )?;
+    }
     Ok(1)
 }
 
@@ -2279,20 +2285,6 @@ impl QueueEventConfigCache {
     fn invalidate(&self) {
         self.expires_at_ms.store(0, Ordering::Release);
         self.encoded.store(0, Ordering::Relaxed);
-        self.events_since_trim.store(0, Ordering::Relaxed);
-    }
-
-    fn should_trim(&self, emitted_events: u64, interval: u64) -> bool {
-        let previous = self
-            .events_since_trim
-            .fetch_add(emitted_events, Ordering::Relaxed);
-        let total = previous.saturating_add(emitted_events);
-        if total < interval {
-            return false;
-        }
-        self.events_since_trim
-            .store(total % interval, Ordering::Relaxed);
-        true
     }
 }
 
@@ -2347,7 +2339,6 @@ fn queue_event_emitter<'a>(
         occurred_at: now_unix(conn)?,
         last_offset: None,
         emitted_events: 0,
-        cache,
     }))
 }
 
@@ -2400,47 +2391,71 @@ impl QueueEventEmitter<'_> {
             return Ok(());
         }
 
-        let interval = queue_event_trim_interval(self.config.retention_target);
-        if let Some(cache) = self.cache
-            && !cache.should_trim(self.emitted_events, interval)
-        {
+        // Count emissions in the database, not in a connection-local cache.
+        // Queue writers commonly open short-lived connections and may run in
+        // several processes; the singleton row makes trim scheduling global,
+        // serialized with the queue mutation, and rollback-safe. Batch
+        // mutations still update the counter only once.
+        let (events_since_trim, retention_target): (i64, i64) = self.conn.query_row(
+            "UPDATE _honker_queue_event_config
+             SET events_since_trim = events_since_trim + ?1
+             WHERE singleton = 1
+             RETURNING events_since_trim, retention_target",
+            [self.emitted_events as i64],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        let interval = queue_event_trim_interval(retention_target) as i64;
+        if events_since_trim < interval {
             return Ok(());
         }
 
-        // Find the (retention_target + 1)-th newest queue event, then delete it and
-        // everything older on this topic. Generic stream traffic uses the
-        // same global offset sequence but must never consume queue-event
-        // retention. Batch callers still trim once after their final event.
-        let trim_through = {
-            let mut stmt = self.conn.prepare_cached(
-                "SELECT offset FROM _honker_stream
-                 WHERE topic = ?1
-                 ORDER BY offset DESC
-                 LIMIT 1 OFFSET ?2",
-            )?;
-            match stmt.query_row(
-                rusqlite::params![QUEUE_EVENTS_TOPIC, self.config.retention_target],
-                |row| row.get::<_, i64>(0),
-            ) {
-                Ok(offset) => Some(offset),
-                Err(rusqlite::Error::QueryReturnedNoRows) => None,
-                Err(error) => return Err(error),
-            }
-        };
+        let trim_through = trim_queue_events(self.conn, retention_target)?;
         if let Some(trim_through) = trim_through {
-            let mut delete = self
-                .conn
-                .prepare_cached("DELETE FROM _honker_stream WHERE topic = ?1 AND offset <= ?2")?;
-            delete.execute(rusqlite::params![QUEUE_EVENTS_TOPIC, trim_through])?;
             self.conn.execute(
                 "UPDATE _honker_queue_event_config
-                 SET trimmed_through_offset = MAX(trimmed_through_offset, ?1)
+                 SET events_since_trim = events_since_trim % ?1,
+                     trimmed_through_offset = MAX(trimmed_through_offset, ?2)
                  WHERE singleton = 1",
-                [trim_through],
+                rusqlite::params![interval, trim_through],
+            )?;
+        } else {
+            self.conn.execute(
+                "UPDATE _honker_queue_event_config
+                 SET events_since_trim = events_since_trim % ?1
+                 WHERE singleton = 1",
+                [interval],
             )?;
         }
         Ok(())
     }
+}
+
+/// Delete queue events beyond the configured target and return the newest
+/// deleted offset. Offsets are global to all stream topics, so both the
+/// threshold lookup and deletion must explicitly select the reserved topic.
+fn trim_queue_events(conn: &Connection, retention_target: i64) -> rusqlite::Result<Option<i64>> {
+    let trim_through = {
+        let mut stmt = conn.prepare_cached(
+            "SELECT offset FROM _honker_stream
+             WHERE topic = ?1
+             ORDER BY offset DESC
+             LIMIT 1 OFFSET ?2",
+        )?;
+        match stmt.query_row(
+            rusqlite::params![QUEUE_EVENTS_TOPIC, retention_target],
+            |row| row.get::<_, i64>(0),
+        ) {
+            Ok(offset) => Some(offset),
+            Err(rusqlite::Error::QueryReturnedNoRows) => None,
+            Err(error) => return Err(error),
+        }
+    };
+    if let Some(trim_through) = trim_through {
+        let mut delete =
+            conn.prepare_cached("DELETE FROM _honker_stream WHERE topic = ?1 AND offset <= ?2")?;
+        delete.execute(rusqlite::params![QUEUE_EVENTS_TOPIC, trim_through])?;
+    }
+    Ok(trim_through)
 }
 
 pub fn queue_events_read_since(
@@ -3196,6 +3211,110 @@ mod queue_event_tests {
             )
             .unwrap();
         assert_eq!(after_trim, 100);
+        assert!(status["trimmed_through_offset"].as_i64().unwrap() > 0);
+    }
+
+    #[test]
+    fn retention_accounting_survives_connection_churn() {
+        let uri = format!(
+            "file:honker-queue-event-retention-{}?mode=memory&cache=shared",
+            std::process::id()
+        );
+        let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_CREATE
+            | OpenFlags::SQLITE_OPEN_URI;
+        let keeper = Connection::open_with_flags(&uri, flags).unwrap();
+        attach_honker_functions(&keeper).unwrap();
+        bootstrap_honker_schema(&keeper).unwrap();
+        keeper
+            .query_row("SELECT honker_queue_events_configure(1, 20, 0)", [], |r| {
+                r.get::<_, i64>(0)
+            })
+            .unwrap();
+
+        // Model request-scoped and multi-process clients: every mutation gets
+        // a fresh SQLite connection and therefore a fresh config cache.
+        for _ in 0..45 {
+            let writer = Connection::open_with_flags(&uri, flags).unwrap();
+            attach_honker_functions(&writer).unwrap();
+            sql_enqueue(&writer, "short-lived-writers");
+        }
+
+        let retained: i64 = keeper
+            .query_row(
+                "SELECT COUNT(*) FROM _honker_stream WHERE topic = ?1",
+                [QUEUE_EVENTS_TOPIC],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let (events_since_trim, trimmed_through): (i64, i64) = keeper
+            .query_row(
+                "SELECT events_since_trim, trimmed_through_offset
+                 FROM _honker_queue_event_config WHERE singleton = 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(retained, 21);
+        assert_eq!(events_since_trim, 1);
+        assert!(trimmed_through > 0);
+        assert!(queue_events_read_since(&keeper, 0, None, 100).is_err());
+    }
+
+    #[test]
+    fn retention_counter_is_transactional() {
+        let conn = db();
+        queue_events_configure(&conn, true, 100, false).unwrap();
+
+        conn.execute_batch("BEGIN IMMEDIATE").unwrap();
+        sql_enqueue(&conn, "rolled-back-counter");
+        assert_eq!(
+            conn.query_row(
+                "SELECT events_since_trim FROM _honker_queue_event_config",
+                [],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap(),
+            1
+        );
+        conn.execute_batch("ROLLBACK").unwrap();
+        assert_eq!(
+            conn.query_row(
+                "SELECT events_since_trim FROM _honker_queue_event_config",
+                [],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn lowering_retention_trims_existing_events_immediately() {
+        let conn = db();
+        queue_events_configure(&conn, true, 100, false).unwrap();
+        for _ in 0..5 {
+            enqueue(&conn, "reconfigured", "{}", None, None, 0, 3, None).unwrap();
+        }
+
+        queue_events_configure(&conn, true, 3, false).unwrap();
+        let status = event_status(&conn);
+        let retained: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM _honker_stream WHERE topic = ?1",
+                [QUEUE_EVENTS_TOPIC],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let events_since_trim: i64 = conn
+            .query_row(
+                "SELECT events_since_trim FROM _honker_queue_event_config",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, 3);
+        assert_eq!(events_since_trim, 0);
         assert!(status["trimmed_through_offset"].as_i64().unwrap() > 0);
     }
 }

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -2160,6 +2160,7 @@ pub fn queue_events_configure(
 }
 
 pub fn queue_events_status(conn: &Connection) -> rusqlite::Result<String> {
+    let mut schema_available = true;
     let config = match conn.query_row(
         "SELECT enabled, retention_target, include_payload, trimmed_through_offset
              FROM _honker_queue_event_config WHERE singleton = 1",
@@ -2175,7 +2176,13 @@ pub fn queue_events_status(conn: &Connection) -> rusqlite::Result<String> {
     ) {
         Ok(config) => Some(config),
         Err(rusqlite::Error::QueryReturnedNoRows) => None,
-        Err(error) => return Err(error),
+        Err(error) => {
+            if queue_event_config_table_exists(conn)? {
+                return Err(error);
+            }
+            schema_available = false;
+            None
+        }
     };
     let (enabled, retention_target, include_payload, trimmed_through_offset) =
         config.unwrap_or((false, 10_000, false, 0));
@@ -2185,6 +2192,7 @@ pub fn queue_events_status(conn: &Connection) -> rusqlite::Result<String> {
         |row| Ok((row.get(0)?, row.get(1)?)),
     )?;
     Ok(json!({
+        "schema_available": schema_available,
         "enabled": enabled,
         "retention_target": retention_target,
         "include_payload": include_payload,
@@ -2230,21 +2238,24 @@ fn load_queue_event_config(conn: &Connection) -> rusqlite::Result<Option<QueueEv
             // has not created the opt-in config table yet. Queue mutations
             // must remain backwards-compatible in that mixed-version case;
             // the absence of configuration means events are disabled.
-            let table_exists: i64 = conn.query_row(
-                "SELECT EXISTS(
-                   SELECT 1 FROM sqlite_schema
-                   WHERE type = 'table' AND name = '_honker_queue_event_config'
-                 )",
-                [],
-                |r| r.get(0),
-            )?;
-            if table_exists == 0 {
+            if !queue_event_config_table_exists(conn)? {
                 Ok(None)
             } else {
                 Err(error)
             }
         }
     }
+}
+
+fn queue_event_config_table_exists(conn: &Connection) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(
+           SELECT 1 FROM sqlite_schema
+           WHERE type = 'table' AND name = '_honker_queue_event_config'
+         )",
+        [],
+        |row| Ok(row.get::<_, i64>(0)? != 0),
+    )
 }
 
 impl QueueEventConfigCache {
@@ -2850,6 +2861,10 @@ mod queue_event_tests {
         let conn = db();
         conn.execute("DROP TABLE _honker_queue_event_config", [])
             .unwrap();
+
+        let status = event_status(&conn);
+        assert_eq!(status["schema_available"], false);
+        assert_eq!(status["enabled"], false);
 
         let id = enqueue(&conn, "emails", "{}", None, None, 0, 3, None).unwrap();
         claim_batch(&conn, "emails", "legacy-worker", 1, 300).unwrap();

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -22,8 +22,12 @@ use rusqlite::Connection;
 use rusqlite::functions::{Context, FunctionFlags};
 use rusqlite::types::ValueRef;
 use serde_json::{Value, json};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 
 const QUEUE_EVENTS_TOPIC: &str = "_honker:queue-events:v1";
+const QUEUE_EVENT_CONFIG_CACHE_TTL: Duration = Duration::from_millis(100);
 
 struct QueueEventRecord<'a> {
     event_type: &'a str,
@@ -34,6 +38,35 @@ struct QueueEventRecord<'a> {
     worker_id: Option<&'a str>,
     run_at: Option<i64>,
     error: Option<&'a str>,
+}
+
+#[derive(Clone, Copy)]
+struct QueueEventConfig {
+    max_events: i64,
+    include_payload: bool,
+}
+
+struct QueueEventConfigCache {
+    encoded: AtomicU64,
+    expires_at_ms: AtomicU64,
+    bypass_until_autocommit: AtomicBool,
+}
+
+impl Default for QueueEventConfigCache {
+    fn default() -> Self {
+        Self {
+            encoded: AtomicU64::new(0),
+            expires_at_ms: AtomicU64::new(0),
+            bypass_until_autocommit: AtomicBool::new(false),
+        }
+    }
+}
+
+struct QueueEventEmitter<'a> {
+    conn: &'a Connection,
+    config: QueueEventConfig,
+    occurred_at: i64,
+    last_offset: Option<i64>,
 }
 
 /// Read an integer argument, accepting the REAL that dynamically typed
@@ -103,27 +136,50 @@ fn to_sql_err<E: std::fmt::Display>(e: E) -> rusqlite::Error {
 /// per-connection: creating the same function twice is a rusqlite
 /// error, so call exactly once per connection.
 pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
+    let queue_event_cache = Arc::new(QueueEventConfigCache::default());
+
     conn.create_scalar_function("honker_bootstrap", 0, FunctionFlags::SQLITE_UTF8, |ctx| {
         let db = unsafe { ctx.get_connection() }?;
         super::bootstrap_honker_schema(&db).map_err(to_sql_err)?;
         Ok(1i64)
     })?;
 
-    conn.create_scalar_function("honker_claim_batch", 4, FunctionFlags::SQLITE_UTF8, |ctx| {
-        let queue: String = ctx.get(0)?;
-        let worker_id: String = ctx.get(1)?;
-        let n: i64 = arg_i64(ctx, 2)?;
-        let timeout_s: i64 = arg_i64(ctx, 3)?;
-        let db = unsafe { ctx.get_connection() }?;
-        claim_batch(&db, &queue, &worker_id, n, timeout_s).map_err(to_sql_err)
-    })?;
+    let claim_event_cache = Arc::clone(&queue_event_cache);
+    conn.create_scalar_function(
+        "honker_claim_batch",
+        4,
+        FunctionFlags::SQLITE_UTF8,
+        move |ctx| {
+            let queue: String = ctx.get(0)?;
+            let worker_id: String = ctx.get(1)?;
+            let n: i64 = arg_i64(ctx, 2)?;
+            let timeout_s: i64 = arg_i64(ctx, 3)?;
+            let db = unsafe { ctx.get_connection() }?;
+            claim_batch_with_cache(
+                &db,
+                &queue,
+                &worker_id,
+                n,
+                timeout_s,
+                Some(&claim_event_cache),
+            )
+            .map_err(to_sql_err)
+        },
+    )?;
 
-    conn.create_scalar_function("honker_ack_batch", 2, FunctionFlags::SQLITE_UTF8, |ctx| {
-        let ids_json: String = ctx.get(0)?;
-        let worker_id: String = ctx.get(1)?;
-        let db = unsafe { ctx.get_connection() }?;
-        ack_batch(&db, &ids_json, &worker_id).map_err(to_sql_err)
-    })?;
+    let ack_batch_event_cache = Arc::clone(&queue_event_cache);
+    conn.create_scalar_function(
+        "honker_ack_batch",
+        2,
+        FunctionFlags::SQLITE_UTF8,
+        move |ctx| {
+            let ids_json: String = ctx.get(0)?;
+            let worker_id: String = ctx.get(1)?;
+            let db = unsafe { ctx.get_connection() }?;
+            ack_batch_with_cache(&db, &ids_json, &worker_id, Some(&ack_batch_event_cache))
+                .map_err(to_sql_err)
+        },
+    )?;
 
     conn.create_scalar_function(
         "honker_queue_next_claim_at",
@@ -136,14 +192,15 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
         },
     )?;
 
+    let sweep_event_cache = Arc::clone(&queue_event_cache);
     conn.create_scalar_function(
         "honker_sweep_expired",
         1,
         FunctionFlags::SQLITE_UTF8,
-        |ctx| {
+        move |ctx| {
             let queue: String = ctx.get(0)?;
             let db = unsafe { ctx.get_connection() }?;
-            sweep_expired(&db, &queue).map_err(to_sql_err)
+            sweep_expired_with_cache(&db, &queue, Some(&sweep_event_cache)).map_err(to_sql_err)
         },
     )?;
 
@@ -279,14 +336,16 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     // job_id}` to the output array. Caller typically holds
     // `_honker_locks` entry 'honker-scheduler' for mutual
     // exclusion across scheduler processes.
+    let scheduler_tick_event_cache = Arc::clone(&queue_event_cache);
     conn.create_scalar_function(
         "honker_scheduler_tick",
         1,
         FunctionFlags::SQLITE_UTF8,
-        |ctx| {
+        move |ctx| {
             let now_unix: i64 = arg_i64(ctx, 0)?;
             let db = unsafe { ctx.get_connection() }?;
-            scheduler_tick(&db, now_unix).map_err(to_sql_err)
+            scheduler_tick_with_cache(&db, now_unix, Some(&scheduler_tick_event_cache))
+                .map_err(to_sql_err)
         },
     )?;
 
@@ -442,35 +501,43 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     // else if `run_at` is not NULL, use that literal; else use
     // `unixepoch()`. `expires` is `unixepoch() + expires` if non-NULL,
     // else NULL (never expires).
-    conn.create_scalar_function("honker_enqueue", 7, FunctionFlags::SQLITE_UTF8, |ctx| {
-        let queue: String = ctx.get(0)?;
-        let payload: String = ctx.get(1)?;
-        let run_at: Option<i64> = arg_opt_i64(ctx, 2)?;
-        let delay: Option<i64> = arg_opt_i64(ctx, 3)?;
-        let priority: i64 = arg_i64(ctx, 4)?;
-        let max_attempts: i64 = arg_i64(ctx, 5)?;
-        let expires: Option<i64> = arg_opt_i64(ctx, 6)?;
-        let db = unsafe { ctx.get_connection() }?;
-        enqueue(
-            &db,
-            &queue,
-            &payload,
-            run_at,
-            delay,
-            priority,
-            max_attempts,
-            expires,
-        )
-        .map_err(to_sql_err)
-    })?;
+    let enqueue_event_cache = Arc::clone(&queue_event_cache);
+    conn.create_scalar_function(
+        "honker_enqueue",
+        7,
+        FunctionFlags::SQLITE_UTF8,
+        move |ctx| {
+            let queue: String = ctx.get(0)?;
+            let payload: String = ctx.get(1)?;
+            let run_at: Option<i64> = arg_opt_i64(ctx, 2)?;
+            let delay: Option<i64> = arg_opt_i64(ctx, 3)?;
+            let priority: i64 = arg_i64(ctx, 4)?;
+            let max_attempts: i64 = arg_i64(ctx, 5)?;
+            let expires: Option<i64> = arg_opt_i64(ctx, 6)?;
+            let db = unsafe { ctx.get_connection() }?;
+            enqueue_with_cache(
+                &db,
+                &queue,
+                &payload,
+                run_at,
+                delay,
+                priority,
+                max_attempts,
+                expires,
+                Some(&enqueue_event_cache),
+            )
+            .map_err(to_sql_err)
+        },
+    )?;
 
     // honker_ack(job_id, worker_id) -> 1 if ack'd, 0 if claim expired /
     // not ours.
-    conn.create_scalar_function("honker_ack", 2, FunctionFlags::SQLITE_UTF8, |ctx| {
+    let ack_event_cache = Arc::clone(&queue_event_cache);
+    conn.create_scalar_function("honker_ack", 2, FunctionFlags::SQLITE_UTF8, move |ctx| {
         let job_id: i64 = arg_i64(ctx, 0)?;
         let worker_id: String = ctx.get(1)?;
         let db = unsafe { ctx.get_connection() }?;
-        ack(&db, job_id, &worker_id).map_err(to_sql_err)
+        ack_with_cache(&db, job_id, &worker_id, Some(&ack_event_cache)).map_err(to_sql_err)
     })?;
 
     // honker_retry(job_id, worker_id, delay_s, error) -> 1 if retried /
@@ -478,23 +545,34 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
     // moves the row to `_honker_dead` instead of flipping it back
     // to pending. Fires a notify on the queue's channel on successful
     // pending-flip (so waiting workers wake).
-    conn.create_scalar_function("honker_retry", 4, FunctionFlags::SQLITE_UTF8, |ctx| {
+    let retry_event_cache = Arc::clone(&queue_event_cache);
+    conn.create_scalar_function("honker_retry", 4, FunctionFlags::SQLITE_UTF8, move |ctx| {
         let job_id: i64 = arg_i64(ctx, 0)?;
         let worker_id: String = ctx.get(1)?;
         let delay_s: i64 = arg_i64(ctx, 2)?;
         let error: String = ctx.get(3)?;
         let db = unsafe { ctx.get_connection() }?;
-        retry(&db, job_id, &worker_id, delay_s, &error).map_err(to_sql_err)
+        retry_with_cache(
+            &db,
+            job_id,
+            &worker_id,
+            delay_s,
+            &error,
+            Some(&retry_event_cache),
+        )
+        .map_err(to_sql_err)
     })?;
 
     // honker_fail(job_id, worker_id, error) -> 1 if failed-to-dead, 0 if
     // not our claim.
-    conn.create_scalar_function("honker_fail", 3, FunctionFlags::SQLITE_UTF8, |ctx| {
+    let fail_event_cache = Arc::clone(&queue_event_cache);
+    conn.create_scalar_function("honker_fail", 3, FunctionFlags::SQLITE_UTF8, move |ctx| {
         let job_id: i64 = arg_i64(ctx, 0)?;
         let worker_id: String = ctx.get(1)?;
         let error: String = ctx.get(2)?;
         let db = unsafe { ctx.get_connection() }?;
-        fail(&db, job_id, &worker_id, &error).map_err(to_sql_err)
+        fail_with_cache(&db, job_id, &worker_id, &error, Some(&fail_event_cache))
+            .map_err(to_sql_err)
     })?;
 
     // honker_heartbeat(job_id, worker_id, extend_s) -> 1 if extended, 0
@@ -509,10 +587,11 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
 
     // honker_cancel(job_id) -> 1 if a pending/processing row was removed,
     // 0 otherwise. Idempotent on missing.
-    conn.create_scalar_function("honker_cancel", 1, FunctionFlags::SQLITE_UTF8, |ctx| {
+    let cancel_event_cache = Arc::clone(&queue_event_cache);
+    conn.create_scalar_function("honker_cancel", 1, FunctionFlags::SQLITE_UTF8, move |ctx| {
         let job_id: i64 = arg_i64(ctx, 0)?;
         let db = unsafe { ctx.get_connection() }?;
-        cancel(&db, job_id).map_err(to_sql_err)
+        cancel_with_cache(&db, job_id, Some(&cancel_event_cache)).map_err(to_sql_err)
     })?;
 
     // honker_get_job(job_id) -> JSON object on hit, empty string on miss.
@@ -602,16 +681,20 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
 
     // Queue lifecycle events are an opt-in, bounded stream maintained
     // transactionally by the queue mutation functions below.
+    let configure_event_cache = Arc::clone(&queue_event_cache);
     conn.create_scalar_function(
         "honker_queue_events_configure",
         3,
         FunctionFlags::SQLITE_UTF8,
-        |ctx| {
+        move |ctx| {
             let enabled = arg_i64(ctx, 0)? != 0;
             let max_events = arg_i64(ctx, 1)?;
             let include_payload = arg_i64(ctx, 2)? != 0;
             let db = unsafe { ctx.get_connection() }?;
-            queue_events_configure(&db, enabled, max_events, include_payload).map_err(to_sql_err)
+            let configured = queue_events_configure(&db, enabled, max_events, include_payload)
+                .map_err(to_sql_err)?;
+            configure_event_cache.invalidate_after_configure(&db);
+            Ok(configured)
         },
     )?;
     conn.create_scalar_function(
@@ -644,7 +727,11 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
 /// processing with an expired visibility timeout. In-flight claims
 /// that still hold a valid timeout are left alone so the holder can
 /// still ack / retry / fail.
-fn dead_letter_exhausted_claimable(conn: &Connection, queue: &str) -> rusqlite::Result<i64> {
+fn dead_letter_exhausted_claimable(
+    conn: &Connection,
+    queue: &str,
+    cache: Option<&QueueEventConfigCache>,
+) -> rusqlite::Result<i64> {
     let mut select = conn.prepare_cached(
         "DELETE FROM _honker_live
          WHERE queue = ?1
@@ -682,6 +769,7 @@ fn dead_letter_exhausted_claimable(conn: &Connection, queue: &str) -> rusqlite::
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'max attempts exceeded', ?8)",
     )?;
     let count = rows.len() as i64;
+    let mut emitter = queue_event_emitter(conn, cache)?;
     for (id, queue, payload, priority, run_at, max_attempts, attempts, created_at) in rows {
         insert.execute(rusqlite::params![
             id,
@@ -693,9 +781,8 @@ fn dead_letter_exhausted_claimable(conn: &Connection, queue: &str) -> rusqlite::
             attempts,
             created_at
         ])?;
-        emit_queue_event(
-            conn,
-            QueueEventRecord {
+        if let Some(emitter) = emitter.as_mut() {
+            emitter.emit(QueueEventRecord {
                 event_type: "dead_lettered",
                 job_id: id,
                 queue: &queue,
@@ -704,25 +791,40 @@ fn dead_letter_exhausted_claimable(conn: &Connection, queue: &str) -> rusqlite::
                 worker_id: None,
                 run_at: Some(run_at),
                 error: Some("max attempts exceeded"),
-            },
-        )?;
+            })?;
+        }
+    }
+    if let Some(emitter) = emitter {
+        emitter.finish()?;
     }
     Ok(count)
 }
 
 /// Returns JSON text containing the complete claimed-job snapshot.
-pub fn claim_batch(
+#[cfg(test)]
+fn claim_batch(
     conn: &Connection,
     queue: &str,
     worker_id: &str,
     n: i64,
     timeout_s: i64,
 ) -> rusqlite::Result<String> {
+    claim_batch_with_cache(conn, queue, worker_id, n, timeout_s, None)
+}
+
+fn claim_batch_with_cache(
+    conn: &Connection,
+    queue: &str,
+    worker_id: &str,
+    n: i64,
+    timeout_s: i64,
+    cache: Option<&QueueEventConfigCache>,
+) -> rusqlite::Result<String> {
     // Drop reclaimable rows that already used their attempt budget so
     // they cannot be claimed again (and so they don't clog the claim
     // index forever). Same outer SQL statement / connection, so this
     // shares the caller's transaction with the claim UPDATE below.
-    dead_letter_exhausted_claimable(conn, queue)?;
+    dead_letter_exhausted_claimable(conn, queue, cache)?;
 
     let mut stmt = conn.prepare_cached(
         "UPDATE _honker_live
@@ -762,6 +864,10 @@ pub fn claim_batch(
         ))
     })?;
     let mut out = Vec::new();
+    // Three states distinguish "no claimed rows yet" from "rows exist but
+    // events are disabled". That keeps empty worker polls free of config
+    // reads while loading configuration only once for a non-empty batch.
+    let mut emitter: Option<Option<QueueEventEmitter<'_>>> = None;
     for row in rows {
         let (
             id,
@@ -777,9 +883,11 @@ pub fn claim_batch(
             created_at,
             expires_at,
         ) = row?;
-        emit_queue_event(
-            conn,
-            QueueEventRecord {
+        if emitter.is_none() {
+            emitter = Some(queue_event_emitter(conn, cache)?);
+        }
+        if let Some(Some(emitter)) = emitter.as_mut() {
+            emitter.emit(QueueEventRecord {
                 event_type: "claimed",
                 job_id: id,
                 queue: &q,
@@ -788,8 +896,8 @@ pub fn claim_batch(
                 worker_id: Some(&w),
                 run_at: Some(run_at),
                 error: None,
-            },
-        )?;
+            })?;
+        }
         // payload stays a JSON string (double-encoded on the wire) so
         // every binding's existing parse path keeps working.
         out.push(json!({
@@ -807,10 +915,34 @@ pub fn claim_batch(
             "expires_at": expires_at,
         }));
     }
+    if let Some(Some(emitter)) = emitter {
+        emitter.finish()?;
+    }
     Ok(Value::Array(out).to_string())
 }
 
-pub fn ack_batch(conn: &Connection, ids_json: &str, worker_id: &str) -> rusqlite::Result<i64> {
+#[cfg(test)]
+fn ack_batch(conn: &Connection, ids_json: &str, worker_id: &str) -> rusqlite::Result<i64> {
+    ack_batch_with_cache(conn, ids_json, worker_id, None)
+}
+
+fn ack_batch_with_cache(
+    conn: &Connection,
+    ids_json: &str,
+    worker_id: &str,
+    cache: Option<&QueueEventConfigCache>,
+) -> rusqlite::Result<i64> {
+    let Some(mut emitter) = queue_event_emitter(conn, cache)? else {
+        let deleted = conn.execute(
+            "DELETE FROM _honker_live
+             WHERE id IN (SELECT value FROM json_each(?1))
+               AND worker_id = ?2
+               AND claim_expires_at >= unixepoch()",
+            rusqlite::params![ids_json, worker_id],
+        )?;
+        return Ok(deleted as i64);
+    };
+
     #[allow(clippy::type_complexity)]
     let jobs: Vec<(i64, String, String, i64, i64, String)> = {
         let mut stmt = conn.prepare_cached(
@@ -834,20 +966,18 @@ pub fn ack_batch(conn: &Connection, ids_json: &str, worker_id: &str) -> rusqlite
     };
     let count = jobs.len() as i64;
     for (id, queue, payload, attempts, run_at, worker_id) in jobs {
-        emit_queue_event(
-            conn,
-            QueueEventRecord {
-                event_type: "completed",
-                job_id: id,
-                queue: &queue,
-                payload: &payload,
-                attempts,
-                worker_id: Some(&worker_id),
-                run_at: Some(run_at),
-                error: None,
-            },
-        )?;
+        emitter.emit(QueueEventRecord {
+            event_type: "completed",
+            job_id: id,
+            queue: &queue,
+            payload: &payload,
+            attempts,
+            worker_id: Some(&worker_id),
+            run_at: Some(run_at),
+            error: None,
+        })?;
     }
+    emitter.finish()?;
     Ok(count)
 }
 
@@ -899,7 +1029,8 @@ pub fn queue_next_claim_at(conn: &Connection, queue: &str) -> rusqlite::Result<i
 ///   - delay set            → `unixepoch() + delay` (wins over run_at)
 ///
 /// Expiration: NULL = never; `Some(s)` = `unixepoch() + s`.
-pub fn enqueue(
+#[cfg(test)]
+fn enqueue(
     conn: &Connection,
     queue: &str,
     payload: &str,
@@ -908,6 +1039,31 @@ pub fn enqueue(
     priority: i64,
     max_attempts: i64,
     expires: Option<i64>,
+) -> rusqlite::Result<i64> {
+    enqueue_with_cache(
+        conn,
+        queue,
+        payload,
+        run_at,
+        delay,
+        priority,
+        max_attempts,
+        expires,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn enqueue_with_cache(
+    conn: &Connection,
+    queue: &str,
+    payload: &str,
+    run_at: Option<i64>,
+    delay: Option<i64>,
+    priority: i64,
+    max_attempts: i64,
+    expires: Option<i64>,
+    cache: Option<&QueueEventConfigCache>,
 ) -> rusqlite::Result<i64> {
     let now: i64 = conn.query_row("SELECT unixepoch()", [], |r| r.get(0))?;
     let run_at_val: i64 = match (delay, run_at) {
@@ -939,6 +1095,7 @@ pub fn enqueue(
     )?;
     emit_queue_event(
         conn,
+        cache,
         QueueEventRecord {
             event_type: "enqueued",
             job_id: id,
@@ -956,7 +1113,27 @@ pub fn enqueue(
 /// Single-job ack. DELETEs the row if the caller's claim is still
 /// valid. Returns 1 on success, 0 if the claim expired or the row
 /// isn't ours.
-pub fn ack(conn: &Connection, job_id: i64, worker_id: &str) -> rusqlite::Result<i64> {
+#[cfg(test)]
+fn ack(conn: &Connection, job_id: i64, worker_id: &str) -> rusqlite::Result<i64> {
+    ack_with_cache(conn, job_id, worker_id, None)
+}
+
+fn ack_with_cache(
+    conn: &Connection,
+    job_id: i64,
+    worker_id: &str,
+    cache: Option<&QueueEventConfigCache>,
+) -> rusqlite::Result<i64> {
+    let Some(mut emitter) = queue_event_emitter(conn, cache)? else {
+        let deleted = conn.execute(
+            "DELETE FROM _honker_live
+             WHERE id = ?1 AND worker_id = ?2
+               AND claim_expires_at >= unixepoch()",
+            rusqlite::params![job_id, worker_id],
+        )?;
+        return Ok(deleted as i64);
+    };
+
     let row: Option<(String, String, i64, i64, String)> = match conn.query_row(
         "DELETE FROM _honker_live
          WHERE id = ?1 AND worker_id = ?2 AND claim_expires_at >= unixepoch()
@@ -971,19 +1148,17 @@ pub fn ack(conn: &Connection, job_id: i64, worker_id: &str) -> rusqlite::Result<
     let Some((queue, payload, attempts, run_at, worker_id)) = row else {
         return Ok(0);
     };
-    emit_queue_event(
-        conn,
-        QueueEventRecord {
-            event_type: "completed",
-            job_id,
-            queue: &queue,
-            payload: &payload,
-            attempts,
-            worker_id: Some(&worker_id),
-            run_at: Some(run_at),
-            error: None,
-        },
-    )?;
+    emitter.emit(QueueEventRecord {
+        event_type: "completed",
+        job_id,
+        queue: &queue,
+        payload: &payload,
+        attempts,
+        worker_id: Some(&worker_id),
+        run_at: Some(run_at),
+        error: None,
+    })?;
+    emitter.finish()?;
     Ok(1)
 }
 
@@ -995,12 +1170,24 @@ pub fn ack(conn: &Connection, job_id: i64, worker_id: &str) -> rusqlite::Result<
 ///
 /// Returns 1 if either branch ran, 0 if the claim is no longer valid
 /// (expired / not our worker / row moved on).
-pub fn retry(
+#[cfg(test)]
+fn retry(
     conn: &Connection,
     job_id: i64,
     worker_id: &str,
     delay_s: i64,
     error: &str,
+) -> rusqlite::Result<i64> {
+    retry_with_cache(conn, job_id, worker_id, delay_s, error, None)
+}
+
+fn retry_with_cache(
+    conn: &Connection,
+    job_id: i64,
+    worker_id: &str,
+    delay_s: i64,
+    error: &str,
+    cache: Option<&QueueEventConfigCache>,
 ) -> rusqlite::Result<i64> {
     #[allow(clippy::type_complexity)]
     let row: Option<(i64, String, String, i64, i64, i64, i64, i64)> = conn
@@ -1071,6 +1258,7 @@ pub fn retry(
     };
     emit_queue_event(
         conn,
+        cache,
         QueueEventRecord {
             event_type,
             job_id: id,
@@ -1087,7 +1275,13 @@ pub fn retry(
 
 /// Unconditionally move the claim to `_honker_dead` with the given
 /// error. Returns 1 if moved, 0 if not our claim.
-pub fn fail(conn: &Connection, job_id: i64, worker_id: &str, error: &str) -> rusqlite::Result<i64> {
+fn fail_with_cache(
+    conn: &Connection,
+    job_id: i64,
+    worker_id: &str,
+    error: &str,
+    cache: Option<&QueueEventConfigCache>,
+) -> rusqlite::Result<i64> {
     #[allow(clippy::type_complexity)]
     let row: Option<(i64, String, String, i64, i64, i64, i64, i64)> = conn
         .query_row(
@@ -1134,6 +1328,7 @@ pub fn fail(conn: &Connection, job_id: i64, worker_id: &str, error: &str) -> rus
     )?;
     emit_queue_event(
         conn,
+        cache,
         QueueEventRecord {
             event_type: "dead_lettered",
             job_id: id,
@@ -1157,7 +1352,25 @@ pub fn fail(conn: &Connection, job_id: i64, worker_id: &str, error: &str) -> rus
 /// changed their mind). Note that for a `state='processing'` row,
 /// the worker holding the claim will see `ack()` return 0 on its
 /// next call — same shape as a claim that simply expired.
-pub fn cancel(conn: &Connection, job_id: i64) -> rusqlite::Result<i64> {
+#[cfg(test)]
+fn cancel(conn: &Connection, job_id: i64) -> rusqlite::Result<i64> {
+    cancel_with_cache(conn, job_id, None)
+}
+
+fn cancel_with_cache(
+    conn: &Connection,
+    job_id: i64,
+    cache: Option<&QueueEventConfigCache>,
+) -> rusqlite::Result<i64> {
+    let Some(mut emitter) = queue_event_emitter(conn, cache)? else {
+        let deleted = conn.execute(
+            "DELETE FROM _honker_live
+             WHERE id = ?1 AND state IN ('pending', 'processing')",
+            rusqlite::params![job_id],
+        )?;
+        return Ok(deleted as i64);
+    };
+
     let row: Option<(String, String, i64, i64, Option<String>)> = match conn.query_row(
         "DELETE FROM _honker_live
          WHERE id = ?1 AND state IN ('pending', 'processing')
@@ -1172,19 +1385,17 @@ pub fn cancel(conn: &Connection, job_id: i64) -> rusqlite::Result<i64> {
     let Some((queue, payload, attempts, run_at, worker_id)) = row else {
         return Ok(0);
     };
-    emit_queue_event(
-        conn,
-        QueueEventRecord {
-            event_type: "cancelled",
-            job_id,
-            queue: &queue,
-            payload: &payload,
-            attempts,
-            worker_id: worker_id.as_deref(),
-            run_at: Some(run_at),
-            error: None,
-        },
-    )?;
+    emitter.emit(QueueEventRecord {
+        event_type: "cancelled",
+        job_id,
+        queue: &queue,
+        payload: &payload,
+        attempts,
+        worker_id: worker_id.as_deref(),
+        run_at: Some(run_at),
+        error: None,
+    })?;
+    emitter.finish()?;
     Ok(1)
 }
 
@@ -1291,7 +1502,16 @@ pub fn heartbeat(
 
 /// Move expired-pending rows from `_honker_live` to `_honker_dead`
 /// with `last_error='expired'`. Returns count moved.
-pub fn sweep_expired(conn: &Connection, queue: &str) -> rusqlite::Result<i64> {
+#[cfg(test)]
+fn sweep_expired(conn: &Connection, queue: &str) -> rusqlite::Result<i64> {
+    sweep_expired_with_cache(conn, queue, None)
+}
+
+fn sweep_expired_with_cache(
+    conn: &Connection,
+    queue: &str,
+    cache: Option<&QueueEventConfigCache>,
+) -> rusqlite::Result<i64> {
     let mut select = conn.prepare_cached(
         "DELETE FROM _honker_live
          WHERE queue = ?1
@@ -1326,6 +1546,7 @@ pub fn sweep_expired(conn: &Connection, queue: &str) -> rusqlite::Result<i64> {
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'expired', ?8)",
     )?;
     let count = rows.len() as i64;
+    let mut emitter = queue_event_emitter(conn, cache)?;
     for (id, queue, payload, priority, run_at, max_attempts, attempts, created_at) in rows {
         insert.execute(rusqlite::params![
             id,
@@ -1337,9 +1558,8 @@ pub fn sweep_expired(conn: &Connection, queue: &str) -> rusqlite::Result<i64> {
             attempts,
             created_at
         ])?;
-        emit_queue_event(
-            conn,
-            QueueEventRecord {
+        if let Some(emitter) = emitter.as_mut() {
+            emitter.emit(QueueEventRecord {
                 event_type: "dead_lettered",
                 job_id: id,
                 queue: &queue,
@@ -1348,8 +1568,11 @@ pub fn sweep_expired(conn: &Connection, queue: &str) -> rusqlite::Result<i64> {
                 worker_id: None,
                 run_at: Some(run_at),
                 error: Some("expired"),
-            },
-        )?;
+            })?;
+        }
+    }
+    if let Some(emitter) = emitter {
+        emitter.finish()?;
     }
     Ok(count)
 }
@@ -1554,7 +1777,11 @@ pub const SCHEDULER_MAX_CATCHUP_FIRES: i64 = 64;
 /// boundaries remain in the past (catches up after a scheduler
 /// outage), up to [`SCHEDULER_MAX_CATCHUP_FIRES`] per task.
 /// Returns a JSON array of `{name, queue, fire_at, job_id}` fires.
-pub fn scheduler_tick(conn: &Connection, now_unix: i64) -> rusqlite::Result<String> {
+fn scheduler_tick_with_cache(
+    conn: &Connection,
+    now_unix: i64,
+    cache: Option<&QueueEventConfigCache>,
+) -> rusqlite::Result<String> {
     #[allow(clippy::type_complexity)]
     let tasks: Vec<(String, String, String, String, i64, Option<i64>, i64, i64)> = {
         let mut stmt = conn.prepare_cached(
@@ -1596,7 +1823,7 @@ pub fn scheduler_tick(conn: &Connection, now_unix: i64) -> rusqlite::Result<Stri
             // Enqueue at this boundary. `run_at` is NULL (claimable
             // immediately); `expires` is the task's expires_s if set.
             // max_attempts comes from the schedule row, not a constant.
-            let job_id = enqueue(
+            let job_id = enqueue_with_cache(
                 conn,
                 &queue,
                 &payload,
@@ -1605,6 +1832,7 @@ pub fn scheduler_tick(conn: &Connection, now_unix: i64) -> rusqlite::Result<Stri
                 priority,
                 max_attempts,
                 expires_s,
+                cache,
             )?;
             out.push(json!({
                 "name": name,
@@ -1901,14 +2129,21 @@ pub fn queue_events_configure(
     Ok(1)
 }
 
-fn queue_event_config(conn: &Connection) -> rusqlite::Result<Option<(i64, bool)>> {
-    match conn.query_row(
-        "SELECT max_events, include_payload
-         FROM _honker_queue_event_config
-         WHERE singleton = 1 AND enabled = 1",
-        [],
-        |r| Ok((r.get(0)?, r.get::<_, i64>(1)? != 0)),
-    ) {
+fn load_queue_event_config(conn: &Connection) -> rusqlite::Result<Option<QueueEventConfig>> {
+    let result = (|| {
+        let mut stmt = conn.prepare_cached(
+            "SELECT max_events, include_payload
+             FROM _honker_queue_event_config
+             WHERE singleton = 1 AND enabled = 1",
+        )?;
+        stmt.query_row([], |r| {
+            Ok(QueueEventConfig {
+                max_events: r.get(0)?,
+                include_payload: r.get::<_, i64>(1)? != 0,
+            })
+        })
+    })();
+    match result {
         Ok(config) => Ok(Some(config)),
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
         Err(error) => {
@@ -1933,53 +2168,156 @@ fn queue_event_config(conn: &Connection) -> rusqlite::Result<Option<(i64, bool)>
     }
 }
 
-fn emit_queue_event(
-    conn: &Connection,
-    event: QueueEventRecord<'_>,
-) -> rusqlite::Result<Option<i64>> {
-    let Some((max_events, include_payload)) = queue_event_config(conn)? else {
+impl QueueEventConfigCache {
+    fn get(&self, conn: &Connection) -> rusqlite::Result<Option<QueueEventConfig>> {
+        if self.bypass_until_autocommit.load(Ordering::Acquire) {
+            if conn.is_autocommit() {
+                self.bypass_until_autocommit.store(false, Ordering::Release);
+                self.invalidate();
+            } else {
+                return load_queue_event_config(conn);
+            }
+        }
+
+        let now_ms = queue_event_cache_millis();
+        if now_ms < self.expires_at_ms.load(Ordering::Acquire) {
+            let encoded = self.encoded.load(Ordering::Relaxed);
+            return Ok(decode_queue_event_config(encoded));
+        }
+
+        let config = load_queue_event_config(conn)?;
+        self.encoded
+            .store(encode_queue_event_config(config), Ordering::Relaxed);
+        self.expires_at_ms.store(
+            now_ms + QUEUE_EVENT_CONFIG_CACHE_TTL.as_millis() as u64,
+            Ordering::Release,
+        );
+        Ok(config)
+    }
+
+    fn invalidate_after_configure(&self, conn: &Connection) {
+        self.invalidate();
+        // A configure call inside an explicit transaction may still roll
+        // back. Do not cache its uncommitted value until autocommit resumes.
+        self.bypass_until_autocommit
+            .store(!conn.is_autocommit(), Ordering::Release);
+    }
+
+    fn invalidate(&self) {
+        self.expires_at_ms.store(0, Ordering::Release);
+        self.encoded.store(0, Ordering::Relaxed);
+    }
+}
+
+fn queue_event_cache_millis() -> u64 {
+    static START: OnceLock<Instant> = OnceLock::new();
+    START
+        .get_or_init(Instant::now)
+        .elapsed()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+fn encode_queue_event_config(config: Option<QueueEventConfig>) -> u64 {
+    match config {
+        None => 0,
+        Some(config) => {
+            let payload_bit = u64::from(config.include_payload) << 63;
+            payload_bit | config.max_events as u64
+        }
+    }
+}
+
+fn decode_queue_event_config(encoded: u64) -> Option<QueueEventConfig> {
+    if encoded == 0 {
+        return None;
+    }
+    Some(QueueEventConfig {
+        max_events: (encoded & i64::MAX as u64) as i64,
+        include_payload: encoded >> 63 == 1,
+    })
+}
+
+fn queue_event_emitter<'a>(
+    conn: &'a Connection,
+    cache: Option<&QueueEventConfigCache>,
+) -> rusqlite::Result<Option<QueueEventEmitter<'a>>> {
+    let config = match cache {
+        Some(cache) => cache.get(conn)?,
+        None => load_queue_event_config(conn)?,
+    };
+    let Some(config) = config else {
         return Ok(None);
     };
-    let occurred_at = now_unix(conn)?;
-    let mut body = json!({
-        "version": 1,
-        "type": event.event_type,
-        "job_id": event.job_id,
-        "queue": event.queue,
-        "occurred_at": occurred_at,
-        "attempts": event.attempts,
-        "worker_id": event.worker_id,
-        "run_at": event.run_at,
-        "error": event.error,
-    });
-    if include_payload {
-        let payload = serde_json::from_str(event.payload)
-            .unwrap_or_else(|_| Value::String(event.payload.to_string()));
-        body.as_object_mut()
-            .expect("queue event body is always an object")
-            .insert("payload".to_string(), payload);
-    }
-
-    let offset = stream_publish(
+    Ok(Some(QueueEventEmitter {
         conn,
-        QUEUE_EVENTS_TOPIC,
-        Some(event.queue),
-        &body.to_string(),
-    )?;
+        config,
+        occurred_at: now_unix(conn)?,
+        last_offset: None,
+    }))
+}
 
-    // `_honker_stream.offset` is global across topics. Using its distance
-    // as the trim bound may retain fewer than max_events when application
-    // streams are very busy, but it can never retain more. That keeps the
-    // queue feed strictly bounded without a COUNT/OFFSET scan on every
-    // queue transition.
-    let trim_through = offset.saturating_sub(max_events);
-    if trim_through > 0 {
-        conn.execute(
-            "DELETE FROM _honker_stream WHERE topic = ?1 AND offset <= ?2",
-            rusqlite::params![QUEUE_EVENTS_TOPIC, trim_through],
-        )?;
+fn emit_queue_event(
+    conn: &Connection,
+    cache: Option<&QueueEventConfigCache>,
+    event: QueueEventRecord<'_>,
+) -> rusqlite::Result<()> {
+    let Some(mut emitter) = queue_event_emitter(conn, cache)? else {
+        return Ok(());
+    };
+    emitter.emit(event)?;
+    emitter.finish()
+}
+
+impl QueueEventEmitter<'_> {
+    fn emit(&mut self, event: QueueEventRecord<'_>) -> rusqlite::Result<()> {
+        let mut body = json!({
+            "version": 1,
+            "type": event.event_type,
+            "job_id": event.job_id,
+            "queue": event.queue,
+            "occurred_at": self.occurred_at,
+            "attempts": event.attempts,
+            "worker_id": event.worker_id,
+            "run_at": event.run_at,
+            "error": event.error,
+        });
+        if self.config.include_payload {
+            let payload = serde_json::from_str(event.payload)
+                .unwrap_or_else(|_| Value::String(event.payload.to_string()));
+            body.as_object_mut()
+                .expect("queue event body is always an object")
+                .insert("payload".to_string(), payload);
+        }
+
+        self.last_offset = Some(stream_publish_internal(
+            self.conn,
+            QUEUE_EVENTS_TOPIC,
+            Some(event.queue),
+            &body.to_string(),
+        )?);
+        Ok(())
     }
-    Ok(Some(offset))
+
+    fn finish(self) -> rusqlite::Result<()> {
+        let Some(last_offset) = self.last_offset else {
+            return Ok(());
+        };
+
+        // `_honker_stream.offset` is global across topics. Using its distance
+        // as the trim bound may retain fewer than max_events when application
+        // streams are very busy, but it can never retain more. Batch callers
+        // trim once after their final event, avoiding one DELETE per job.
+        let trim_through = last_offset.saturating_sub(self.config.max_events);
+        if trim_through > 0 {
+            let mut stmt = self
+                .conn
+                .prepare_cached("DELETE FROM _honker_stream WHERE topic = ?1 AND offset <= ?2")?;
+            stmt.execute(rusqlite::params![QUEUE_EVENTS_TOPIC, trim_through])?;
+        }
+        Ok(())
+    }
 }
 
 pub fn queue_events_read_since(
@@ -2030,15 +2368,27 @@ pub fn stream_publish(
     key: Option<&str>,
     payload: &str,
 ) -> rusqlite::Result<i64> {
+    if topic == QUEUE_EVENTS_TOPIC {
+        return Err(to_sql_err(
+            "honker: topic '_honker:queue-events:v1' is reserved for queue lifecycle events",
+        ));
+    }
+    stream_publish_internal(conn, topic, key, payload)
+}
+
+fn stream_publish_internal(
+    conn: &Connection,
+    topic: &str,
+    key: Option<&str>,
+    payload: &str,
+) -> rusqlite::Result<i64> {
     // Stream row INSERT advances data_version on commit — same wake
     // path as enqueue. No synthetic notification row (see enqueue).
-    let offset: i64 = conn.query_row(
+    let mut stmt = conn.prepare_cached(
         "INSERT INTO _honker_stream (topic, key, payload)
-         VALUES (?1, ?2, ?3)
-         RETURNING offset",
-        rusqlite::params![topic, key, payload],
-        |r| r.get(0),
+         VALUES (?1, ?2, ?3) RETURNING offset",
     )?;
+    let offset: i64 = stmt.query_row(rusqlite::params![topic, key, payload], |r| r.get(0))?;
     Ok(offset)
 }
 
@@ -2315,6 +2665,8 @@ mod real_arg_tests {
 mod queue_event_tests {
     use super::*;
     use crate::{attach_honker_functions, bootstrap_honker_schema};
+    use rusqlite::OpenFlags;
+    use std::thread;
 
     fn db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
@@ -2325,6 +2677,15 @@ mod queue_event_tests {
 
     fn events(conn: &Connection, queue: Option<&str>) -> Vec<Value> {
         serde_json::from_str(&queue_events_read_since(conn, 0, queue, 10_000).unwrap()).unwrap()
+    }
+
+    fn sql_enqueue(conn: &Connection, queue: &str) -> i64 {
+        conn.query_row(
+            "SELECT honker_enqueue(?1, '{}', NULL, NULL, 0, 3, NULL)",
+            [queue],
+            |r| r.get(0),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -2343,6 +2704,102 @@ mod queue_event_tests {
         let id = enqueue(&conn, "emails", "{}", None, None, 0, 3, None).unwrap();
         claim_batch(&conn, "emails", "legacy-worker", 1, 300).unwrap();
         assert_eq!(ack(&conn, id, "legacy-worker").unwrap(), 1);
+    }
+
+    #[test]
+    fn queue_event_config_cache_refreshes_across_connections() {
+        let uri = format!(
+            "file:honker-queue-event-cache-{}?mode=memory&cache=shared",
+            std::process::id()
+        );
+        let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_CREATE
+            | OpenFlags::SQLITE_OPEN_URI;
+        let first = Connection::open_with_flags(&uri, flags).unwrap();
+        let second = Connection::open_with_flags(&uri, flags).unwrap();
+        attach_honker_functions(&first).unwrap();
+        attach_honker_functions(&second).unwrap();
+        bootstrap_honker_schema(&first).unwrap();
+
+        sql_enqueue(&first, "before-enable");
+        second
+            .query_row("SELECT honker_queue_events_configure(1, 100, 0)", [], |r| {
+                r.get::<_, i64>(0)
+            })
+            .unwrap();
+        thread::sleep(QUEUE_EVENT_CONFIG_CACHE_TTL + Duration::from_millis(25));
+        let enabled_id = sql_enqueue(&first, "after-enable");
+        assert!(
+            events(&first, None)
+                .iter()
+                .any(|event| { event["job_id"] == enabled_id && event["type"] == "enqueued" })
+        );
+
+        second
+            .query_row("SELECT honker_queue_events_configure(0, 100, 0)", [], |r| {
+                r.get::<_, i64>(0)
+            })
+            .unwrap();
+        thread::sleep(QUEUE_EVENT_CONFIG_CACHE_TTL + Duration::from_millis(25));
+        let last_offset = events(&first, None).last().unwrap()["offset"]
+            .as_i64()
+            .unwrap();
+        sql_enqueue(&first, "after-disable");
+        assert!(
+            serde_json::from_str::<Vec<Value>>(
+                &queue_events_read_since(&first, last_offset, None, 100).unwrap()
+            )
+            .unwrap()
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn queue_event_config_cache_encodes_the_largest_retention() {
+        for include_payload in [false, true] {
+            let config = QueueEventConfig {
+                max_events: i64::MAX,
+                include_payload,
+            };
+            let decoded = decode_queue_event_config(encode_queue_event_config(Some(config)))
+                .expect("enabled configuration should round-trip");
+            assert_eq!(decoded.max_events, i64::MAX);
+            assert_eq!(decoded.include_payload, include_payload);
+        }
+        assert!(decode_queue_event_config(encode_queue_event_config(None)).is_none());
+    }
+
+    #[test]
+    fn rolled_back_configuration_does_not_poison_connection_cache() {
+        let conn = db();
+        conn.execute_batch("BEGIN IMMEDIATE").unwrap();
+        conn.query_row("SELECT honker_queue_events_configure(1, 100, 0)", [], |r| {
+            r.get::<_, i64>(0)
+        })
+        .unwrap();
+        sql_enqueue(&conn, "rolled-back-config");
+        conn.execute_batch("ROLLBACK").unwrap();
+
+        let id = sql_enqueue(&conn, "still-disabled");
+        assert!(
+            events(&conn, None)
+                .iter()
+                .all(|event| event["job_id"] != id)
+        );
+    }
+
+    #[test]
+    fn queue_event_topic_rejects_public_stream_writes() {
+        let conn = db();
+        assert!(stream_publish(&conn, QUEUE_EVENTS_TOPIC, None, "{}").is_err());
+
+        queue_events_configure(&conn, true, 100, false).unwrap();
+        let id = enqueue(&conn, "internal", "{}", None, None, 0, 3, None).unwrap();
+        assert!(
+            events(&conn, None)
+                .iter()
+                .any(|event| { event["job_id"] == id && event["type"] == "enqueued" })
+        );
     }
 
     #[test]
@@ -2489,6 +2946,38 @@ mod queue_event_tests {
                 && event["type"] == "dead_lettered"
                 && event["error"] == "max attempts exceeded"
         }));
+    }
+
+    #[test]
+    fn scheduler_enqueues_emit_through_the_cached_core_path() {
+        let conn = db();
+        queue_events_configure(&conn, true, 100, false).unwrap();
+        conn.query_row(
+            "SELECT honker_scheduler_register(
+               'scheduled-event', 'scheduled', '* * * * *', '{}', 0, NULL
+             )",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap();
+        let next_fire: i64 = conn
+            .query_row(
+                "SELECT next_fire_at FROM _honker_scheduler_tasks
+                 WHERE name = 'scheduled-event'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        conn.query_row("SELECT honker_scheduler_tick(?1)", [next_fire], |r| {
+            r.get::<_, String>(0)
+        })
+        .unwrap();
+
+        assert!(
+            events(&conn, Some("scheduled"))
+                .iter()
+                .any(|event| { event["type"] == "enqueued" && event["queue"] == "scheduled" })
+        );
     }
 
     #[test]

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -2137,6 +2137,7 @@ pub fn queue_events_configure(
             "honker: queue event retention_target must be between 1 and 1000000",
         ));
     }
+    super::bootstrap_honker_schema(conn).map_err(to_sql_err)?;
     conn.execute(
         "INSERT INTO _honker_queue_event_config
            (singleton, enabled, retention_target, include_payload, events_since_trim)

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -23,6 +23,19 @@ use rusqlite::functions::{Context, FunctionFlags};
 use rusqlite::types::ValueRef;
 use serde_json::{Value, json};
 
+const QUEUE_EVENTS_TOPIC: &str = "_honker:queue-events:v1";
+
+struct QueueEventRecord<'a> {
+    event_type: &'a str,
+    job_id: i64,
+    queue: &'a str,
+    payload: &'a str,
+    attempts: i64,
+    worker_id: Option<&'a str>,
+    run_at: Option<i64>,
+    error: Option<&'a str>,
+}
+
 /// Read an integer argument, accepting the REAL that dynamically typed
 /// clients send for whole numbers.
 ///
@@ -587,6 +600,33 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
         },
     )?;
 
+    // Queue lifecycle events are an opt-in, bounded stream maintained
+    // transactionally by the queue mutation functions below.
+    conn.create_scalar_function(
+        "honker_queue_events_configure",
+        3,
+        FunctionFlags::SQLITE_UTF8,
+        |ctx| {
+            let enabled = arg_i64(ctx, 0)? != 0;
+            let max_events = arg_i64(ctx, 1)?;
+            let include_payload = arg_i64(ctx, 2)? != 0;
+            let db = unsafe { ctx.get_connection() }?;
+            queue_events_configure(&db, enabled, max_events, include_payload).map_err(to_sql_err)
+        },
+    )?;
+    conn.create_scalar_function(
+        "honker_queue_events_read_since",
+        3,
+        FunctionFlags::SQLITE_UTF8,
+        |ctx| {
+            let offset = arg_i64(ctx, 0)?;
+            let queue: Option<String> = ctx.get(1)?;
+            let limit = arg_i64(ctx, 2)?;
+            let db = unsafe { ctx.get_connection() }?;
+            queue_events_read_since(&db, offset, queue.as_deref(), limit).map_err(to_sql_err)
+        },
+    )?;
+
     Ok(())
 }
 
@@ -642,8 +682,30 @@ fn dead_letter_exhausted_claimable(conn: &Connection, queue: &str) -> rusqlite::
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'max attempts exceeded', ?8)",
     )?;
     let count = rows.len() as i64;
-    for r in rows {
-        insert.execute(rusqlite::params![r.0, r.1, r.2, r.3, r.4, r.5, r.6, r.7])?;
+    for (id, queue, payload, priority, run_at, max_attempts, attempts, created_at) in rows {
+        insert.execute(rusqlite::params![
+            id,
+            queue,
+            payload,
+            priority,
+            run_at,
+            max_attempts,
+            attempts,
+            created_at
+        ])?;
+        emit_queue_event(
+            conn,
+            QueueEventRecord {
+                event_type: "dead_lettered",
+                job_id: id,
+                queue: &queue,
+                payload: &payload,
+                attempts,
+                worker_id: None,
+                run_at: Some(run_at),
+                error: Some("max attempts exceeded"),
+            },
+        )?;
     }
     Ok(count)
 }
@@ -715,6 +777,19 @@ pub fn claim_batch(
             created_at,
             expires_at,
         ) = row?;
+        emit_queue_event(
+            conn,
+            QueueEventRecord {
+                event_type: "claimed",
+                job_id: id,
+                queue: &q,
+                payload: &payload,
+                attempts,
+                worker_id: Some(&w),
+                run_at: Some(run_at),
+                error: None,
+            },
+        )?;
         // payload stays a JSON string (double-encoded on the wire) so
         // every binding's existing parse path keeps working.
         out.push(json!({
@@ -736,17 +811,42 @@ pub fn claim_batch(
 }
 
 pub fn ack_batch(conn: &Connection, ids_json: &str, worker_id: &str) -> rusqlite::Result<i64> {
-    let mut stmt = conn.prepare_cached(
-        "DELETE FROM _honker_live
-         WHERE id IN (SELECT value FROM json_each(?1))
-           AND worker_id = ?2
-           AND claim_expires_at >= unixepoch()
-         RETURNING id",
-    )?;
-    let mut rows = stmt.query(rusqlite::params![ids_json, worker_id])?;
-    let mut count = 0;
-    while rows.next()?.is_some() {
-        count += 1;
+    #[allow(clippy::type_complexity)]
+    let jobs: Vec<(i64, String, String, i64, i64, String)> = {
+        let mut stmt = conn.prepare_cached(
+            "DELETE FROM _honker_live
+             WHERE id IN (SELECT value FROM json_each(?1))
+               AND worker_id = ?2
+               AND claim_expires_at >= unixepoch()
+             RETURNING id, queue, payload, attempts, run_at, worker_id",
+        )?;
+        stmt.query_map(rusqlite::params![ids_json, worker_id], |r| {
+            Ok((
+                r.get(0)?,
+                r.get(1)?,
+                r.get(2)?,
+                r.get(3)?,
+                r.get(4)?,
+                r.get(5)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?
+    };
+    let count = jobs.len() as i64;
+    for (id, queue, payload, attempts, run_at, worker_id) in jobs {
+        emit_queue_event(
+            conn,
+            QueueEventRecord {
+                event_type: "completed",
+                job_id: id,
+                queue: &queue,
+                payload: &payload,
+                attempts,
+                worker_id: Some(&worker_id),
+                run_at: Some(run_at),
+                error: None,
+            },
+        )?;
     }
     Ok(count)
 }
@@ -837,6 +937,19 @@ pub fn enqueue(
         ],
         |r| r.get(0),
     )?;
+    emit_queue_event(
+        conn,
+        QueueEventRecord {
+            event_type: "enqueued",
+            job_id: id,
+            queue,
+            payload,
+            attempts: 0,
+            worker_id: None,
+            run_at: Some(run_at_val),
+            error: None,
+        },
+    )?;
     Ok(id)
 }
 
@@ -844,12 +957,34 @@ pub fn enqueue(
 /// valid. Returns 1 on success, 0 if the claim expired or the row
 /// isn't ours.
 pub fn ack(conn: &Connection, job_id: i64, worker_id: &str) -> rusqlite::Result<i64> {
-    let deleted = conn.execute(
+    let row: Option<(String, String, i64, i64, String)> = match conn.query_row(
         "DELETE FROM _honker_live
-         WHERE id = ?1 AND worker_id = ?2 AND claim_expires_at >= unixepoch()",
+         WHERE id = ?1 AND worker_id = ?2 AND claim_expires_at >= unixepoch()
+         RETURNING queue, payload, attempts, run_at, worker_id",
         rusqlite::params![job_id, worker_id],
+        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+    ) {
+        Ok(row) => Some(row),
+        Err(rusqlite::Error::QueryReturnedNoRows) => None,
+        Err(error) => return Err(error),
+    };
+    let Some((queue, payload, attempts, run_at, worker_id)) = row else {
+        return Ok(0);
+    };
+    emit_queue_event(
+        conn,
+        QueueEventRecord {
+            event_type: "completed",
+            job_id,
+            queue: &queue,
+            payload: &payload,
+            attempts,
+            worker_id: Some(&worker_id),
+            run_at: Some(run_at),
+            error: None,
+        },
     )?;
-    Ok(deleted as i64)
+    Ok(1)
 }
 
 /// Retry or fail based on `attempts` vs `max_attempts`. If another
@@ -895,7 +1030,7 @@ pub fn retry(
     else {
         return Ok(0);
     };
-    if attempts >= max_attempts {
+    let (event_type, event_run_at) = if attempts >= max_attempts {
         conn.execute(
             "DELETE FROM _honker_live WHERE id = ?1",
             rusqlite::params![id],
@@ -917,19 +1052,36 @@ pub fn retry(
                 created_at
             ],
         )?;
+        ("dead_lettered", run_at)
     } else {
-        conn.execute(
+        let retry_run_at = conn.query_row(
             "UPDATE _honker_live
              SET state = 'pending',
                  run_at = unixepoch() + ?2,
                  worker_id = NULL,
                  claim_expires_at = NULL
-             WHERE id = ?1",
+             WHERE id = ?1
+             RETURNING run_at",
             rusqlite::params![id, delay_s],
+            |r| r.get(0),
         )?;
         // Wake comes from the live-table UPDATE + commit (data_version).
         // No synthetic notification row — see enqueue() for rationale.
-    }
+        ("retry_scheduled", retry_run_at)
+    };
+    emit_queue_event(
+        conn,
+        QueueEventRecord {
+            event_type,
+            job_id: id,
+            queue: &queue,
+            payload: &payload,
+            attempts,
+            worker_id: Some(worker_id),
+            run_at: Some(event_run_at),
+            error: Some(error),
+        },
+    )?;
     Ok(1)
 }
 
@@ -980,6 +1132,19 @@ pub fn fail(conn: &Connection, job_id: i64, worker_id: &str, error: &str) -> rus
             created_at
         ],
     )?;
+    emit_queue_event(
+        conn,
+        QueueEventRecord {
+            event_type: "dead_lettered",
+            job_id: id,
+            queue: &queue,
+            payload: &payload,
+            attempts,
+            worker_id: Some(worker_id),
+            run_at: Some(run_at),
+            error: Some(error),
+        },
+    )?;
     Ok(1)
 }
 
@@ -993,11 +1158,34 @@ pub fn fail(conn: &Connection, job_id: i64, worker_id: &str, error: &str) -> rus
 /// the worker holding the claim will see `ack()` return 0 on its
 /// next call — same shape as a claim that simply expired.
 pub fn cancel(conn: &Connection, job_id: i64) -> rusqlite::Result<i64> {
-    let n = conn.execute(
-        "DELETE FROM _honker_live WHERE id = ?1 AND state IN ('pending', 'processing')",
+    let row: Option<(String, String, i64, i64, Option<String>)> = match conn.query_row(
+        "DELETE FROM _honker_live
+         WHERE id = ?1 AND state IN ('pending', 'processing')
+         RETURNING queue, payload, attempts, run_at, worker_id",
         rusqlite::params![job_id],
+        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+    ) {
+        Ok(row) => Some(row),
+        Err(rusqlite::Error::QueryReturnedNoRows) => None,
+        Err(error) => return Err(error),
+    };
+    let Some((queue, payload, attempts, run_at, worker_id)) = row else {
+        return Ok(0);
+    };
+    emit_queue_event(
+        conn,
+        QueueEventRecord {
+            event_type: "cancelled",
+            job_id,
+            queue: &queue,
+            payload: &payload,
+            attempts,
+            worker_id: worker_id.as_deref(),
+            run_at: Some(run_at),
+            error: None,
+        },
     )?;
-    Ok(n as i64)
+    Ok(1)
 }
 
 /// Read a single job row by id. Returns a JSON object on success or
@@ -1138,8 +1326,30 @@ pub fn sweep_expired(conn: &Connection, queue: &str) -> rusqlite::Result<i64> {
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'expired', ?8)",
     )?;
     let count = rows.len() as i64;
-    for r in rows {
-        insert.execute(rusqlite::params![r.0, r.1, r.2, r.3, r.4, r.5, r.6, r.7])?;
+    for (id, queue, payload, priority, run_at, max_attempts, attempts, created_at) in rows {
+        insert.execute(rusqlite::params![
+            id,
+            queue,
+            payload,
+            priority,
+            run_at,
+            max_attempts,
+            attempts,
+            created_at
+        ])?;
+        emit_queue_event(
+            conn,
+            QueueEventRecord {
+                event_type: "dead_lettered",
+                job_id: id,
+                queue: &queue,
+                payload: &payload,
+                attempts,
+                worker_id: None,
+                run_at: Some(run_at),
+                error: Some("expired"),
+            },
+        )?;
     }
     Ok(count)
 }
@@ -1667,6 +1877,153 @@ pub fn result_sweep(conn: &Connection) -> rusqlite::Result<i64> {
 // Streams
 // ---------------------------------------------------------------------
 
+pub fn queue_events_configure(
+    conn: &Connection,
+    enabled: bool,
+    max_events: i64,
+    include_payload: bool,
+) -> rusqlite::Result<i64> {
+    if !(1..=1_000_000).contains(&max_events) {
+        return Err(to_sql_err(
+            "honker: queue event max_events must be between 1 and 1000000",
+        ));
+    }
+    conn.execute(
+        "INSERT INTO _honker_queue_event_config
+           (singleton, enabled, max_events, include_payload)
+         VALUES (1, ?1, ?2, ?3)
+         ON CONFLICT(singleton) DO UPDATE SET
+           enabled = excluded.enabled,
+           max_events = excluded.max_events,
+           include_payload = excluded.include_payload",
+        rusqlite::params![enabled as i64, max_events, include_payload as i64],
+    )?;
+    Ok(1)
+}
+
+fn queue_event_config(conn: &Connection) -> rusqlite::Result<Option<(i64, bool)>> {
+    match conn.query_row(
+        "SELECT max_events, include_payload
+         FROM _honker_queue_event_config
+         WHERE singleton = 1 AND enabled = 1",
+        [],
+        |r| Ok((r.get(0)?, r.get::<_, i64>(1)? != 0)),
+    ) {
+        Ok(config) => Ok(Some(config)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(error) => {
+            // A newer core can share a database with an older binding that
+            // has not created the opt-in config table yet. Queue mutations
+            // must remain backwards-compatible in that mixed-version case;
+            // the absence of configuration means events are disabled.
+            let table_exists: i64 = conn.query_row(
+                "SELECT EXISTS(
+                   SELECT 1 FROM sqlite_schema
+                   WHERE type = 'table' AND name = '_honker_queue_event_config'
+                 )",
+                [],
+                |r| r.get(0),
+            )?;
+            if table_exists == 0 {
+                Ok(None)
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+
+fn emit_queue_event(
+    conn: &Connection,
+    event: QueueEventRecord<'_>,
+) -> rusqlite::Result<Option<i64>> {
+    let Some((max_events, include_payload)) = queue_event_config(conn)? else {
+        return Ok(None);
+    };
+    let occurred_at = now_unix(conn)?;
+    let mut body = json!({
+        "version": 1,
+        "type": event.event_type,
+        "job_id": event.job_id,
+        "queue": event.queue,
+        "occurred_at": occurred_at,
+        "attempts": event.attempts,
+        "worker_id": event.worker_id,
+        "run_at": event.run_at,
+        "error": event.error,
+    });
+    if include_payload {
+        let payload = serde_json::from_str(event.payload)
+            .unwrap_or_else(|_| Value::String(event.payload.to_string()));
+        body.as_object_mut()
+            .expect("queue event body is always an object")
+            .insert("payload".to_string(), payload);
+    }
+
+    let offset = stream_publish(
+        conn,
+        QUEUE_EVENTS_TOPIC,
+        Some(event.queue),
+        &body.to_string(),
+    )?;
+
+    // `_honker_stream.offset` is global across topics. Using its distance
+    // as the trim bound may retain fewer than max_events when application
+    // streams are very busy, but it can never retain more. That keeps the
+    // queue feed strictly bounded without a COUNT/OFFSET scan on every
+    // queue transition.
+    let trim_through = offset.saturating_sub(max_events);
+    if trim_through > 0 {
+        conn.execute(
+            "DELETE FROM _honker_stream WHERE topic = ?1 AND offset <= ?2",
+            rusqlite::params![QUEUE_EVENTS_TOPIC, trim_through],
+        )?;
+    }
+    Ok(Some(offset))
+}
+
+pub fn queue_events_read_since(
+    conn: &Connection,
+    offset: i64,
+    queue: Option<&str>,
+    limit: i64,
+) -> rusqlite::Result<String> {
+    if offset < 0 {
+        return Err(to_sql_err(
+            "honker: queue event offset must be greater than or equal to zero",
+        ));
+    }
+    if !(1..=10_000).contains(&limit) {
+        return Err(to_sql_err(
+            "honker: queue event read limit must be between 1 and 10000",
+        ));
+    }
+
+    let mut stmt = conn.prepare_cached(
+        "SELECT offset, payload
+         FROM _honker_stream
+         WHERE topic = ?1 AND offset > ?2
+           AND (?3 IS NULL OR key = ?3)
+         ORDER BY offset ASC
+         LIMIT ?4",
+    )?;
+    let rows = stmt.query_map(
+        rusqlite::params![QUEUE_EVENTS_TOPIC, offset, queue, limit],
+        |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)),
+    )?;
+    let mut out = Vec::new();
+    for row in rows {
+        let (event_offset, payload) = row?;
+        let mut event: Value = serde_json::from_str(&payload).map_err(to_sql_err)?;
+        event
+            .as_object_mut()
+            .ok_or_else(|| to_sql_err("honker: stored queue event is not an object"))?
+            .insert("offset".to_string(), json!(event_offset));
+        out.push(event);
+    }
+    Ok(Value::Array(out).to_string())
+}
+
 pub fn stream_publish(
     conn: &Connection,
     topic: &str,
@@ -1951,5 +2308,216 @@ mod real_arg_tests {
         assert!(probe(f64::NAN).is_err(), "NaN must reject");
         // Negative zero is whole and must coerce to 0, not error.
         assert!(probe(-0.0).is_ok(), "-0.0 must pass");
+    }
+}
+
+#[cfg(test)]
+mod queue_event_tests {
+    use super::*;
+    use crate::{attach_honker_functions, bootstrap_honker_schema};
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        attach_honker_functions(&conn).unwrap();
+        bootstrap_honker_schema(&conn).unwrap();
+        conn
+    }
+
+    fn events(conn: &Connection, queue: Option<&str>) -> Vec<Value> {
+        serde_json::from_str(&queue_events_read_since(conn, 0, queue, 10_000).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn queue_events_are_disabled_by_default() {
+        let conn = db();
+        enqueue(&conn, "emails", "{}", None, None, 0, 3, None).unwrap();
+        assert!(events(&conn, None).is_empty());
+    }
+
+    #[test]
+    fn queue_mutations_remain_compatible_with_pre_event_schema() {
+        let conn = db();
+        conn.execute("DROP TABLE _honker_queue_event_config", [])
+            .unwrap();
+
+        let id = enqueue(&conn, "emails", "{}", None, None, 0, 3, None).unwrap();
+        claim_batch(&conn, "emails", "legacy-worker", 1, 300).unwrap();
+        assert_eq!(ack(&conn, id, "legacy-worker").unwrap(), 1);
+    }
+
+    #[test]
+    fn queue_events_follow_committed_lifecycle_transitions() {
+        let conn = db();
+        queue_events_configure(&conn, true, 100, false).unwrap();
+
+        conn.execute_batch("BEGIN IMMEDIATE").unwrap();
+        let rolled_back = enqueue(
+            &conn,
+            "emails",
+            "{\"rolled_back\":true}",
+            None,
+            None,
+            0,
+            3,
+            None,
+        )
+        .unwrap();
+        conn.execute_batch("ROLLBACK").unwrap();
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM _honker_live WHERE id = ?1",
+                [rolled_back],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap(),
+            0
+        );
+        assert!(events(&conn, None).is_empty());
+
+        let id = enqueue(
+            &conn,
+            "emails",
+            "{\"to\":\"alice@example.com\"}",
+            None,
+            None,
+            7,
+            3,
+            None,
+        )
+        .unwrap();
+        claim_batch(&conn, "emails", "worker-1", 1, 300).unwrap();
+        assert_eq!(ack(&conn, id, "not-the-owner").unwrap(), 0);
+        retry(&conn, id, "worker-1", 0, "temporary").unwrap();
+        claim_batch(&conn, "emails", "worker-2", 1, 300).unwrap();
+        ack(&conn, id, "worker-2").unwrap();
+
+        let retained = events(&conn, None);
+        let types: Vec<&str> = retained
+            .iter()
+            .map(|event| event["type"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            types,
+            vec![
+                "enqueued",
+                "claimed",
+                "retry_scheduled",
+                "claimed",
+                "completed"
+            ]
+        );
+        assert!(retained.iter().all(|event| event.get("payload").is_none()));
+        assert!(
+            retained
+                .windows(2)
+                .all(|pair| pair[0]["offset"].as_i64() < pair[1]["offset"].as_i64())
+        );
+    }
+
+    #[test]
+    fn queue_events_cover_terminal_and_batch_transitions() {
+        let conn = db();
+        queue_events_configure(&conn, true, 100, false).unwrap();
+
+        let dead_id = enqueue(&conn, "jobs", "{}", None, None, 0, 1, None).unwrap();
+        claim_batch(&conn, "jobs", "worker-1", 1, 300).unwrap();
+        retry(&conn, dead_id, "worker-1", 0, "permanent").unwrap();
+
+        let cancel_id = enqueue(&conn, "jobs", "{}", None, None, 0, 3, None).unwrap();
+        cancel(&conn, cancel_id).unwrap();
+
+        let batch_a = enqueue(&conn, "batch", "{}", None, None, 0, 3, None).unwrap();
+        let batch_b = enqueue(&conn, "batch", "{}", None, None, 0, 3, None).unwrap();
+        claim_batch(&conn, "batch", "worker-batch", 2, 300).unwrap();
+        assert_eq!(
+            ack_batch(
+                &conn,
+                &json!([batch_a, batch_b]).to_string(),
+                "worker-batch"
+            )
+            .unwrap(),
+            2
+        );
+
+        let retained = events(&conn, None);
+        assert!(
+            retained
+                .iter()
+                .any(|event| { event["job_id"] == dead_id && event["type"] == "dead_lettered" })
+        );
+        assert!(
+            retained
+                .iter()
+                .any(|event| { event["job_id"] == cancel_id && event["type"] == "cancelled" })
+        );
+        assert_eq!(
+            retained
+                .iter()
+                .filter(|event| event["type"] == "completed")
+                .count(),
+            2
+        );
+
+        let expired_id = enqueue(&conn, "jobs", "{}", None, None, 0, 3, Some(0)).unwrap();
+        assert_eq!(sweep_expired(&conn, "jobs").unwrap(), 1);
+
+        let abandoned_id = enqueue(&conn, "jobs", "{}", None, None, 0, 1, None).unwrap();
+        claim_batch(&conn, "jobs", "abandoned-worker", 1, 300).unwrap();
+        conn.execute(
+            "UPDATE _honker_live
+             SET claim_expires_at = unixepoch() - 1
+             WHERE id = ?1",
+            [abandoned_id],
+        )
+        .unwrap();
+        assert!(
+            serde_json::from_str::<Vec<Value>>(
+                &claim_batch(&conn, "jobs", "next-worker", 1, 300).unwrap()
+            )
+            .unwrap()
+            .is_empty()
+        );
+
+        let terminal = events(&conn, None);
+        assert!(terminal.iter().any(|event| {
+            event["job_id"] == expired_id
+                && event["type"] == "dead_lettered"
+                && event["error"] == "expired"
+        }));
+        assert!(terminal.iter().any(|event| {
+            event["job_id"] == abandoned_id
+                && event["type"] == "dead_lettered"
+                && event["error"] == "max attempts exceeded"
+        }));
+    }
+
+    #[test]
+    fn queue_events_are_bounded_filterable_and_optionally_include_payloads() {
+        let conn = db();
+        queue_events_configure(&conn, true, 3, true).unwrap();
+
+        for i in 0..5 {
+            let queue = if i % 2 == 0 { "alpha" } else { "beta" };
+            enqueue(
+                &conn,
+                queue,
+                &json!({ "sequence": i }).to_string(),
+                None,
+                None,
+                0,
+                3,
+                None,
+            )
+            .unwrap();
+        }
+
+        let retained = events(&conn, None);
+        assert_eq!(retained.len(), 3);
+        assert_eq!(retained[0]["payload"]["sequence"], 2);
+        assert_eq!(retained[2]["payload"]["sequence"], 4);
+
+        let alpha = events(&conn, Some("alpha"));
+        assert_eq!(alpha.len(), 2);
+        assert!(alpha.iter().all(|event| event["queue"] == "alpha"));
     }
 }

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -37,12 +37,13 @@ struct QueueEventRecord<'a> {
     attempts: i64,
     worker_id: Option<&'a str>,
     run_at: Option<i64>,
+    reason: Option<&'a str>,
     error: Option<&'a str>,
 }
 
 #[derive(Clone, Copy)]
 struct QueueEventConfig {
-    max_events: i64,
+    retention_target: i64,
     include_payload: bool,
 }
 
@@ -50,6 +51,7 @@ struct QueueEventConfigCache {
     encoded: AtomicU64,
     expires_at_ms: AtomicU64,
     bypass_until_autocommit: AtomicBool,
+    events_since_trim: AtomicU64,
 }
 
 impl Default for QueueEventConfigCache {
@@ -58,6 +60,7 @@ impl Default for QueueEventConfigCache {
             encoded: AtomicU64::new(0),
             expires_at_ms: AtomicU64::new(0),
             bypass_until_autocommit: AtomicBool::new(false),
+            events_since_trim: AtomicU64::new(0),
         }
     }
 }
@@ -67,6 +70,8 @@ struct QueueEventEmitter<'a> {
     config: QueueEventConfig,
     occurred_at: i64,
     last_offset: Option<i64>,
+    emitted_events: u64,
+    cache: Option<&'a QueueEventConfigCache>,
 }
 
 /// Read an integer argument, accepting the REAL that dynamically typed
@@ -688,11 +693,12 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
         FunctionFlags::SQLITE_UTF8,
         move |ctx| {
             let enabled = arg_i64(ctx, 0)? != 0;
-            let max_events = arg_i64(ctx, 1)?;
+            let retention_target = arg_i64(ctx, 1)?;
             let include_payload = arg_i64(ctx, 2)? != 0;
             let db = unsafe { ctx.get_connection() }?;
-            let configured = queue_events_configure(&db, enabled, max_events, include_payload)
-                .map_err(to_sql_err)?;
+            let configured =
+                queue_events_configure(&db, enabled, retention_target, include_payload)
+                    .map_err(to_sql_err)?;
             configure_event_cache.invalidate_after_configure(&db);
             Ok(configured)
         },
@@ -707,6 +713,15 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
             let limit = arg_i64(ctx, 2)?;
             let db = unsafe { ctx.get_connection() }?;
             queue_events_read_since(&db, offset, queue.as_deref(), limit).map_err(to_sql_err)
+        },
+    )?;
+    conn.create_scalar_function(
+        "honker_queue_events_status",
+        0,
+        FunctionFlags::SQLITE_UTF8,
+        |ctx| {
+            let db = unsafe { ctx.get_connection() }?;
+            queue_events_status(&db).map_err(to_sql_err)
         },
     )?;
 
@@ -790,6 +805,7 @@ fn dead_letter_exhausted_claimable(
                 attempts,
                 worker_id: None,
                 run_at: Some(run_at),
+                reason: Some("attempts_exhausted"),
                 error: Some("max attempts exceeded"),
             })?;
         }
@@ -895,6 +911,7 @@ fn claim_batch_with_cache(
                 attempts,
                 worker_id: Some(&w),
                 run_at: Some(run_at),
+                reason: None,
                 error: None,
             })?;
         }
@@ -974,6 +991,7 @@ fn ack_batch_with_cache(
             attempts,
             worker_id: Some(&worker_id),
             run_at: Some(run_at),
+            reason: None,
             error: None,
         })?;
     }
@@ -1104,6 +1122,7 @@ fn enqueue_with_cache(
             attempts: 0,
             worker_id: None,
             run_at: Some(run_at_val),
+            reason: None,
             error: None,
         },
     )?;
@@ -1156,6 +1175,7 @@ fn ack_with_cache(
         attempts,
         worker_id: Some(&worker_id),
         run_at: Some(run_at),
+        reason: None,
         error: None,
     })?;
     emitter.finish()?;
@@ -1267,6 +1287,7 @@ fn retry_with_cache(
             attempts,
             worker_id: Some(worker_id),
             run_at: Some(event_run_at),
+            reason: (event_type == "dead_lettered").then_some("attempts_exhausted"),
             error: Some(error),
         },
     )?;
@@ -1337,6 +1358,7 @@ fn fail_with_cache(
             attempts,
             worker_id: Some(worker_id),
             run_at: Some(run_at),
+            reason: Some("explicit_failure"),
             error: Some(error),
         },
     )?;
@@ -1393,6 +1415,7 @@ fn cancel_with_cache(
         attempts,
         worker_id: worker_id.as_deref(),
         run_at: Some(run_at),
+        reason: None,
         error: None,
     })?;
     emitter.finish()?;
@@ -1567,6 +1590,7 @@ fn sweep_expired_with_cache(
                 attempts,
                 worker_id: None,
                 run_at: Some(run_at),
+                reason: Some("job_expired"),
                 error: Some("expired"),
             })?;
         }
@@ -2108,37 +2132,86 @@ pub fn result_sweep(conn: &Connection) -> rusqlite::Result<i64> {
 pub fn queue_events_configure(
     conn: &Connection,
     enabled: bool,
-    max_events: i64,
+    retention_target: i64,
     include_payload: bool,
 ) -> rusqlite::Result<i64> {
-    if !(1..=1_000_000).contains(&max_events) {
+    if !(1..=1_000_000).contains(&retention_target) {
         return Err(to_sql_err(
-            "honker: queue event max_events must be between 1 and 1000000",
+            "honker: queue event retention_target must be between 1 and 1000000",
         ));
     }
     conn.execute(
         "INSERT INTO _honker_queue_event_config
-           (singleton, enabled, max_events, include_payload)
+           (singleton, enabled, retention_target, include_payload)
          VALUES (1, ?1, ?2, ?3)
          ON CONFLICT(singleton) DO UPDATE SET
            enabled = excluded.enabled,
-           max_events = excluded.max_events,
+           retention_target = excluded.retention_target,
            include_payload = excluded.include_payload",
-        rusqlite::params![enabled as i64, max_events, include_payload as i64],
+        rusqlite::params![enabled as i64, retention_target, include_payload as i64],
     )?;
     Ok(1)
+}
+
+pub fn queue_events_status(conn: &Connection) -> rusqlite::Result<String> {
+    let config = match conn.query_row(
+        "SELECT enabled, retention_target, include_payload, trimmed_through_offset
+             FROM _honker_queue_event_config WHERE singleton = 1",
+        [],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)? != 0,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)? != 0,
+                row.get::<_, i64>(3)?,
+            ))
+        },
+    ) {
+        Ok(config) => Some(config),
+        Err(rusqlite::Error::QueryReturnedNoRows) => None,
+        Err(error) => return Err(error),
+    };
+    let (enabled, retention_target, include_payload, trimmed_through_offset) =
+        config.unwrap_or((false, 10_000, false, 0));
+    let (oldest_offset, latest_offset): (Option<i64>, Option<i64>) = conn.query_row(
+        "SELECT MIN(offset), MAX(offset) FROM _honker_stream WHERE topic = ?1",
+        [QUEUE_EVENTS_TOPIC],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    Ok(json!({
+        "enabled": enabled,
+        "retention_target": retention_target,
+        "include_payload": include_payload,
+        "trimmed_through_offset": trimmed_through_offset,
+        "oldest_offset": oldest_offset,
+        "latest_offset": latest_offset,
+    })
+    .to_string())
+}
+
+fn queue_events_trimmed_through(conn: &Connection) -> rusqlite::Result<i64> {
+    match conn.query_row(
+        "SELECT trimmed_through_offset
+         FROM _honker_queue_event_config WHERE singleton = 1",
+        [],
+        |row| row.get(0),
+    ) {
+        Ok(offset) => Ok(offset),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(0),
+        Err(error) => Err(error),
+    }
 }
 
 fn load_queue_event_config(conn: &Connection) -> rusqlite::Result<Option<QueueEventConfig>> {
     let result = (|| {
         let mut stmt = conn.prepare_cached(
-            "SELECT max_events, include_payload
+            "SELECT retention_target, include_payload
              FROM _honker_queue_event_config
              WHERE singleton = 1 AND enabled = 1",
         )?;
         stmt.query_row([], |r| {
             Ok(QueueEventConfig {
-                max_events: r.get(0)?,
+                retention_target: r.get(0)?,
                 include_payload: r.get::<_, i64>(1)? != 0,
             })
         })
@@ -2206,7 +2279,25 @@ impl QueueEventConfigCache {
     fn invalidate(&self) {
         self.expires_at_ms.store(0, Ordering::Release);
         self.encoded.store(0, Ordering::Relaxed);
+        self.events_since_trim.store(0, Ordering::Relaxed);
     }
+
+    fn should_trim(&self, emitted_events: u64, interval: u64) -> bool {
+        let previous = self
+            .events_since_trim
+            .fetch_add(emitted_events, Ordering::Relaxed);
+        let total = previous.saturating_add(emitted_events);
+        if total < interval {
+            return false;
+        }
+        self.events_since_trim
+            .store(total % interval, Ordering::Relaxed);
+        true
+    }
+}
+
+fn queue_event_trim_interval(retention_target: i64) -> u64 {
+    ((retention_target as u64) / 10).clamp(1, 1_000)
 }
 
 fn queue_event_cache_millis() -> u64 {
@@ -2224,7 +2315,7 @@ fn encode_queue_event_config(config: Option<QueueEventConfig>) -> u64 {
         None => 0,
         Some(config) => {
             let payload_bit = u64::from(config.include_payload) << 63;
-            payload_bit | config.max_events as u64
+            payload_bit | config.retention_target as u64
         }
     }
 }
@@ -2234,14 +2325,14 @@ fn decode_queue_event_config(encoded: u64) -> Option<QueueEventConfig> {
         return None;
     }
     Some(QueueEventConfig {
-        max_events: (encoded & i64::MAX as u64) as i64,
+        retention_target: (encoded & i64::MAX as u64) as i64,
         include_payload: encoded >> 63 == 1,
     })
 }
 
 fn queue_event_emitter<'a>(
     conn: &'a Connection,
-    cache: Option<&QueueEventConfigCache>,
+    cache: Option<&'a QueueEventConfigCache>,
 ) -> rusqlite::Result<Option<QueueEventEmitter<'a>>> {
     let config = match cache {
         Some(cache) => cache.get(conn)?,
@@ -2255,6 +2346,8 @@ fn queue_event_emitter<'a>(
         config,
         occurred_at: now_unix(conn)?,
         last_offset: None,
+        emitted_events: 0,
+        cache,
     }))
 }
 
@@ -2281,6 +2374,7 @@ impl QueueEventEmitter<'_> {
             "attempts": event.attempts,
             "worker_id": event.worker_id,
             "run_at": event.run_at,
+            "reason": event.reason,
             "error": event.error,
         });
         if self.config.include_payload {
@@ -2297,24 +2391,53 @@ impl QueueEventEmitter<'_> {
             Some(event.queue),
             &body.to_string(),
         )?);
+        self.emitted_events += 1;
         Ok(())
     }
 
     fn finish(self) -> rusqlite::Result<()> {
-        let Some(last_offset) = self.last_offset else {
+        if self.last_offset.is_none() {
             return Ok(());
-        };
+        }
 
-        // `_honker_stream.offset` is global across topics. Using its distance
-        // as the trim bound may retain fewer than max_events when application
-        // streams are very busy, but it can never retain more. Batch callers
-        // trim once after their final event, avoiding one DELETE per job.
-        let trim_through = last_offset.saturating_sub(self.config.max_events);
-        if trim_through > 0 {
-            let mut stmt = self
+        let interval = queue_event_trim_interval(self.config.retention_target);
+        if let Some(cache) = self.cache
+            && !cache.should_trim(self.emitted_events, interval)
+        {
+            return Ok(());
+        }
+
+        // Find the (retention_target + 1)-th newest queue event, then delete it and
+        // everything older on this topic. Generic stream traffic uses the
+        // same global offset sequence but must never consume queue-event
+        // retention. Batch callers still trim once after their final event.
+        let trim_through = {
+            let mut stmt = self.conn.prepare_cached(
+                "SELECT offset FROM _honker_stream
+                 WHERE topic = ?1
+                 ORDER BY offset DESC
+                 LIMIT 1 OFFSET ?2",
+            )?;
+            match stmt.query_row(
+                rusqlite::params![QUEUE_EVENTS_TOPIC, self.config.retention_target],
+                |row| row.get::<_, i64>(0),
+            ) {
+                Ok(offset) => Some(offset),
+                Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                Err(error) => return Err(error),
+            }
+        };
+        if let Some(trim_through) = trim_through {
+            let mut delete = self
                 .conn
                 .prepare_cached("DELETE FROM _honker_stream WHERE topic = ?1 AND offset <= ?2")?;
-            stmt.execute(rusqlite::params![QUEUE_EVENTS_TOPIC, trim_through])?;
+            delete.execute(rusqlite::params![QUEUE_EVENTS_TOPIC, trim_through])?;
+            self.conn.execute(
+                "UPDATE _honker_queue_event_config
+                 SET trimmed_through_offset = MAX(trimmed_through_offset, ?1)
+                 WHERE singleton = 1",
+                [trim_through],
+            )?;
         }
         Ok(())
     }
@@ -2335,6 +2458,14 @@ pub fn queue_events_read_since(
         return Err(to_sql_err(
             "honker: queue event read limit must be between 1 and 10000",
         ));
+    }
+
+    let trimmed_through = queue_events_trimmed_through(conn)?;
+    if offset < trimmed_through {
+        return Err(to_sql_err(format!(
+            "HONKER_QUEUE_EVENT_OFFSET_EXPIRED: requested offset {offset} is older than \
+             trimmed-through offset {trimmed_through}"
+        )));
     }
 
     let mut stmt = conn.prepare_cached(
@@ -2679,6 +2810,10 @@ mod queue_event_tests {
         serde_json::from_str(&queue_events_read_since(conn, 0, queue, 10_000).unwrap()).unwrap()
     }
 
+    fn event_status(conn: &Connection) -> Value {
+        serde_json::from_str(&queue_events_status(conn).unwrap()).unwrap()
+    }
+
     fn sql_enqueue(conn: &Connection, queue: &str) -> i64 {
         conn.query_row(
             "SELECT honker_enqueue(?1, '{}', NULL, NULL, 0, 3, NULL)",
@@ -2758,12 +2893,12 @@ mod queue_event_tests {
     fn queue_event_config_cache_encodes_the_largest_retention() {
         for include_payload in [false, true] {
             let config = QueueEventConfig {
-                max_events: i64::MAX,
+                retention_target: i64::MAX,
                 include_payload,
             };
             let decoded = decode_queue_event_config(encode_queue_event_config(Some(config)))
                 .expect("enabled configuration should round-trip");
-            assert_eq!(decoded.max_events, i64::MAX);
+            assert_eq!(decoded.retention_target, i64::MAX);
             assert_eq!(decoded.include_payload, include_payload);
         }
         assert!(decode_queue_event_config(encode_queue_event_config(None)).is_none());
@@ -2897,11 +3032,11 @@ mod queue_event_tests {
         );
 
         let retained = events(&conn, None);
-        assert!(
-            retained
-                .iter()
-                .any(|event| { event["job_id"] == dead_id && event["type"] == "dead_lettered" })
-        );
+        assert!(retained.iter().any(|event| {
+            event["job_id"] == dead_id
+                && event["type"] == "dead_lettered"
+                && event["reason"] == "attempts_exhausted"
+        }));
         assert!(
             retained
                 .iter()
@@ -2939,11 +3074,13 @@ mod queue_event_tests {
         assert!(terminal.iter().any(|event| {
             event["job_id"] == expired_id
                 && event["type"] == "dead_lettered"
+                && event["reason"] == "job_expired"
                 && event["error"] == "expired"
         }));
         assert!(terminal.iter().any(|event| {
             event["job_id"] == abandoned_id
                 && event["type"] == "dead_lettered"
+                && event["reason"] == "attempts_exhausted"
                 && event["error"] == "max attempts exceeded"
         }));
     }
@@ -2998,15 +3135,67 @@ mod queue_event_tests {
                 None,
             )
             .unwrap();
+            stream_publish(
+                &conn,
+                "application-events",
+                None,
+                &json!({ "i": i }).to_string(),
+            )
+            .unwrap();
         }
 
-        let retained = events(&conn, None);
+        let status = event_status(&conn);
+        let trimmed_through = status["trimmed_through_offset"].as_i64().unwrap();
+        assert!(trimmed_through > 0);
+        assert!(queue_events_read_since(&conn, 0, None, 10_000).is_err());
+        let retained: Vec<Value> = serde_json::from_str(
+            &queue_events_read_since(&conn, trimmed_through, None, 10_000).unwrap(),
+        )
+        .unwrap();
         assert_eq!(retained.len(), 3);
         assert_eq!(retained[0]["payload"]["sequence"], 2);
         assert_eq!(retained[2]["payload"]["sequence"], 4);
 
-        let alpha = events(&conn, Some("alpha"));
+        let alpha: Vec<Value> = serde_json::from_str(
+            &queue_events_read_since(&conn, trimmed_through, Some("alpha"), 10_000).unwrap(),
+        )
+        .unwrap();
         assert_eq!(alpha.len(), 2);
         assert!(alpha.iter().all(|event| event["queue"] == "alpha"));
+    }
+
+    #[test]
+    fn production_retention_trims_in_bounded_chunks() {
+        let conn = db();
+        conn.query_row("SELECT honker_queue_events_configure(1, 100, 0)", [], |r| {
+            r.get::<_, i64>(0)
+        })
+        .unwrap();
+
+        for _ in 0..105 {
+            sql_enqueue(&conn, "chunked");
+        }
+        let before_trim: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM _honker_stream WHERE topic = ?1",
+                [QUEUE_EVENTS_TOPIC],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(before_trim, 105);
+
+        for _ in 0..5 {
+            sql_enqueue(&conn, "chunked");
+        }
+        let status = event_status(&conn);
+        let after_trim: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM _honker_stream WHERE topic = ?1",
+                [QUEUE_EVENTS_TOPIC],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(after_trim, 100);
+        assert!(status["trimmed_through_offset"].as_i64().unwrap() > 0);
     }
 }

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -428,6 +428,12 @@ pub const BOOTSTRAP_HONKER_SQL: &str = "
       offset INTEGER NOT NULL DEFAULT 0,
       PRIMARY KEY (name, topic)
     );
+    CREATE TABLE IF NOT EXISTS _honker_queue_event_config (
+      singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+      enabled INTEGER NOT NULL CHECK (enabled IN (0, 1)),
+      max_events INTEGER NOT NULL CHECK (max_events > 0),
+      include_payload INTEGER NOT NULL CHECK (include_payload IN (0, 1))
+    );
 ";
 
 /// Install the honker queue schema on `conn`. Idempotent. See
@@ -2425,6 +2431,18 @@ while True:
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert_eq!(sc_cols, vec!["name", "topic", "offset"]);
+
+        let queue_event_config_cols: Vec<String> = conn
+            .prepare("SELECT name FROM pragma_table_info('_honker_queue_event_config')")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            queue_event_config_cols,
+            vec!["singleton", "enabled", "max_events", "include_payload"]
+        );
     }
 
     // -----------------------------------------------------------------

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -431,8 +431,10 @@ pub const BOOTSTRAP_HONKER_SQL: &str = "
     CREATE TABLE IF NOT EXISTS _honker_queue_event_config (
       singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
       enabled INTEGER NOT NULL CHECK (enabled IN (0, 1)),
-      max_events INTEGER NOT NULL CHECK (max_events > 0),
-      include_payload INTEGER NOT NULL CHECK (include_payload IN (0, 1))
+      retention_target INTEGER NOT NULL CHECK (retention_target > 0),
+      include_payload INTEGER NOT NULL CHECK (include_payload IN (0, 1)),
+      trimmed_through_offset INTEGER NOT NULL DEFAULT 0
+        CHECK (trimmed_through_offset >= 0)
     );
 ";
 
@@ -481,6 +483,54 @@ pub fn bootstrap_honker_schema(conn: &Connection) -> Result<(), Error> {
     if !has_max_attempts {
         match conn.execute(
             "ALTER TABLE _honker_scheduler_tasks ADD COLUMN max_attempts INTEGER NOT NULL DEFAULT 3",
+            [],
+        ) {
+            Ok(_) => {}
+            Err(e) if e.to_string().to_lowercase().contains("duplicate column") => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+    // Migration: the first queue-event draft called an exact cap
+    // `max_events`. Retention is intentionally chunked and approximate, so
+    // rename the internal field before the API ships with misleading terms.
+    let queue_event_config_columns: Vec<String> = conn
+        .prepare("SELECT name FROM pragma_table_info('_honker_queue_event_config')")?
+        .query_map([], |r| r.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    if queue_event_config_columns
+        .iter()
+        .any(|name| name == "max_events")
+        && !queue_event_config_columns
+            .iter()
+            .any(|name| name == "retention_target")
+    {
+        match conn.execute(
+            "ALTER TABLE _honker_queue_event_config \
+             RENAME COLUMN max_events TO retention_target",
+            [],
+        ) {
+            Ok(_) => {}
+            Err(e)
+                if e.to_string().to_lowercase().contains("duplicate column")
+                    || e.to_string().to_lowercase().contains("no such column") => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+    // Migration: queue-event consumers need a durable watermark to
+    // distinguish a fresh reader from a checkpoint that fell behind
+    // retention. Older draft schemas predate this column.
+    let has_queue_event_watermark: bool = {
+        let mut stmt = conn.prepare(
+            "SELECT 1 FROM pragma_table_info('_honker_queue_event_config') \
+             WHERE name='trimmed_through_offset'",
+        )?;
+        stmt.query_row([], |_| Ok(true)).unwrap_or(false)
+    };
+    if !has_queue_event_watermark {
+        match conn.execute(
+            "ALTER TABLE _honker_queue_event_config \
+             ADD COLUMN trimmed_through_offset INTEGER NOT NULL DEFAULT 0 \
+             CHECK (trimmed_through_offset >= 0)",
             [],
         ) {
             Ok(_) => {}
@@ -2311,6 +2361,35 @@ while True:
     }
 
     #[test]
+    fn bootstrap_draft_queue_event_config_gets_trim_watermark() {
+        let conn = mem();
+        conn.execute_batch(
+            "CREATE TABLE _honker_queue_event_config (
+               singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+               enabled INTEGER NOT NULL CHECK (enabled IN (0, 1)),
+               max_events INTEGER NOT NULL CHECK (max_events > 0),
+               include_payload INTEGER NOT NULL CHECK (include_payload IN (0, 1))
+             );
+             INSERT INTO _honker_queue_event_config
+               (singleton, enabled, max_events, include_payload)
+             VALUES (1, 1, 321, 1);",
+        )
+        .unwrap();
+
+        bootstrap_honker_schema(&conn).unwrap();
+        let row: (i64, i64, i64) = conn
+            .query_row(
+                "SELECT retention_target, include_payload, trimmed_through_offset
+                 FROM _honker_queue_event_config WHERE singleton = 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(row, (321, 1, 0));
+        bootstrap_honker_schema(&conn).unwrap();
+    }
+
+    #[test]
     fn bootstrap_honker_schema_creates_tables_and_index() {
         let conn = mem();
         bootstrap_honker_schema(&conn).unwrap();
@@ -2441,7 +2520,13 @@ while True:
             .unwrap();
         assert_eq!(
             queue_event_config_cols,
-            vec!["singleton", "enabled", "max_events", "include_payload"]
+            vec![
+                "singleton",
+                "enabled",
+                "retention_target",
+                "include_payload",
+                "trimmed_through_offset"
+            ]
         );
     }
 

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -434,7 +434,9 @@ pub const BOOTSTRAP_HONKER_SQL: &str = "
       retention_target INTEGER NOT NULL CHECK (retention_target > 0),
       include_payload INTEGER NOT NULL CHECK (include_payload IN (0, 1)),
       trimmed_through_offset INTEGER NOT NULL DEFAULT 0
-        CHECK (trimmed_through_offset >= 0)
+        CHECK (trimmed_through_offset >= 0),
+      events_since_trim INTEGER NOT NULL DEFAULT 0
+        CHECK (events_since_trim >= 0)
     );
 ";
 
@@ -531,6 +533,28 @@ pub fn bootstrap_honker_schema(conn: &Connection) -> Result<(), Error> {
             "ALTER TABLE _honker_queue_event_config \
              ADD COLUMN trimmed_through_offset INTEGER NOT NULL DEFAULT 0 \
              CHECK (trimmed_through_offset >= 0)",
+            [],
+        ) {
+            Ok(_) => {}
+            Err(e) if e.to_string().to_lowercase().contains("duplicate column") => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+    // Migration: retention scheduling must survive short-lived connections
+    // and coordinate across processes. Earlier drafts kept this counter in a
+    // per-connection cache, which could prevent trimming indefinitely.
+    let has_queue_event_trim_counter: bool = {
+        let mut stmt = conn.prepare(
+            "SELECT 1 FROM pragma_table_info('_honker_queue_event_config') \
+             WHERE name='events_since_trim'",
+        )?;
+        stmt.query_row([], |_| Ok(true)).unwrap_or(false)
+    };
+    if !has_queue_event_trim_counter {
+        match conn.execute(
+            "ALTER TABLE _honker_queue_event_config \
+             ADD COLUMN events_since_trim INTEGER NOT NULL DEFAULT 0 \
+             CHECK (events_since_trim >= 0)",
             [],
         ) {
             Ok(_) => {}
@@ -2361,7 +2385,7 @@ while True:
     }
 
     #[test]
-    fn bootstrap_draft_queue_event_config_gets_trim_watermark() {
+    fn bootstrap_draft_queue_event_config_gets_current_columns() {
         let conn = mem();
         conn.execute_batch(
             "CREATE TABLE _honker_queue_event_config (
@@ -2377,15 +2401,16 @@ while True:
         .unwrap();
 
         bootstrap_honker_schema(&conn).unwrap();
-        let row: (i64, i64, i64) = conn
+        let row: (i64, i64, i64, i64) = conn
             .query_row(
-                "SELECT retention_target, include_payload, trimmed_through_offset
+                "SELECT retention_target, include_payload, trimmed_through_offset,
+                        events_since_trim
                  FROM _honker_queue_event_config WHERE singleton = 1",
                 [],
-                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
             )
             .unwrap();
-        assert_eq!(row, (321, 1, 0));
+        assert_eq!(row, (321, 1, 0, 0));
         bootstrap_honker_schema(&conn).unwrap();
     }
 
@@ -2525,7 +2550,8 @@ while True:
                 "enabled",
                 "retention_target",
                 "include_payload",
-                "trimmed_through_offset"
+                "trimmed_through_offset",
+                "events_since_trim"
             ]
         );
     }

--- a/packages/honker-node/README.md
+++ b/packages/honker-node/README.md
@@ -86,7 +86,8 @@ not perform runtime schema validation.
 
 Queue lifecycle events are an opt-in, bounded observability feed. Configuration
 is stored in the database so producers and workers in other processes use the
-same behavior:
+same behavior. Existing connections refresh configuration within 100 ms; the
+connection that calls `configureQueueEvents()` sees it immediately:
 
 ```ts
 db.configureQueueEvents({ maxEvents: 10_000, includePayload: false });
@@ -100,7 +101,9 @@ for await (const event of events) {
 Events are appended in the same SQLite transaction as successful queue state
 transitions. They are intended for dashboards, metrics, and debugging—not as a
 permanent audit log or an exactly-once business event bus. Save the last offset
-to replay retained events after reconnecting.
+to replay retained events after reconnecting. The internal
+`_honker:queue-events:v1` stream topic is reserved and cannot be published via
+`db.stream()`.
 
 Recurring schedules use `schedule`:
 

--- a/packages/honker-node/README.md
+++ b/packages/honker-node/README.md
@@ -90,13 +90,37 @@ same behavior. Existing connections refresh configuration within 100 ms; the
 connection that calls `configureQueueEvents()` sees it immediately:
 
 ```ts
-db.configureQueueEvents({ maxEvents: 10_000, includePayload: false });
+db.configureQueueEvents({ retentionTarget: 10_000, includePayload: false });
 
-const events = db.queueEvents({ queue: "emails", fromOffset: 0 });
+const events = db.queueEvents({ queue: "emails" });
 for await (const event of events) {
   console.log(event.offset, event.type, event.jobId);
 }
 ```
+
+`retentionTarget` is approximate: Honker trims the queue-event topic in bounded
+chunks so normal job transactions do not run a retention delete on every state
+change. Constructing `queueEvents()` without `fromOffset` starts at the oldest
+retained event. An explicit checkpoint that fell behind retention throws
+`QueueEventOffsetExpiredError` instead of silently skipping activity.
+
+For familiar live `EventEmitter` ergonomics, use a listener backed by the same
+durable, cross-process feed. It starts at the latest event unless configured
+otherwise:
+
+```ts
+const listener = db.queueEventListener({ queue: "emails" });
+listener.on("enqueued", event => console.log(event.jobId));
+listener.on("completed", event => console.log(event.jobId));
+listener.on("error", error => console.error(error));
+
+// Later:
+listener.close();
+```
+
+Queue events remain disabled until `configureQueueEvents()` is called; creating
+a listener while disabled throws an actionable `QueueEventsDisabledError`.
+`includePayload` is feed-wide, so enabling it stores payloads for every queue.
 
 Events are appended in the same SQLite transaction as successful queue state
 transitions. They are intended for dashboards, metrics, and debugging—not as a

--- a/packages/honker-node/README.md
+++ b/packages/honker-node/README.md
@@ -84,6 +84,24 @@ if (job) {
 Payload generics describe the expected JSON shape at compile time; Honker does
 not perform runtime schema validation.
 
+Queue lifecycle events are an opt-in, bounded observability feed. Configuration
+is stored in the database so producers and workers in other processes use the
+same behavior:
+
+```ts
+db.configureQueueEvents({ maxEvents: 10_000, includePayload: false });
+
+const events = db.queueEvents({ queue: "emails", fromOffset: 0 });
+for await (const event of events) {
+  console.log(event.offset, event.type, event.jobId);
+}
+```
+
+Events are appended in the same SQLite transaction as successful queue state
+transitions. They are intended for dashboards, metrics, and debugging—not as a
+permanent audit log or an exactly-once business event bus. Save the last offset
+to replay retained events after reconnecting.
+
 Recurring schedules use `schedule`:
 
 ```js

--- a/packages/honker-node/README.md
+++ b/packages/honker-node/README.md
@@ -106,6 +106,15 @@ short-lived connections and multiple worker processes. Constructing
 explicit checkpoint that fell behind retention throws
 `QueueEventOffsetExpiredError` instead of silently skipping activity.
 
+Size the feed deliberately. `retentionTarget` counts events, not bytes, and
+there is no time-based expiry: a retained event stays until `retentionTarget`
+newer ones push it out, which on a quiet feed can be a long time. With
+`includePayload` on, every retained event carries a full copy of its job
+payload, so the feed costs roughly `retentionTarget` x payload size on top of
+the queue itself — and unlike the job row, that copy outlives the job. The
+maximum is 1,000,000, which with large payloads is gigabytes in the same SQLite
+file as your hot queue. The default of 10,000 without payloads is small.
+
 For familiar live `EventEmitter` ergonomics, use a listener backed by the same
 durable, cross-process feed. It starts at the latest event unless configured
 otherwise:

--- a/packages/honker-node/README.md
+++ b/packages/honker-node/README.md
@@ -100,8 +100,10 @@ for await (const event of events) {
 
 `retentionTarget` is approximate: Honker trims the queue-event topic in bounded
 chunks so normal job transactions do not run a retention delete on every state
-change. Constructing `queueEvents()` without `fromOffset` starts at the oldest
-retained event. An explicit checkpoint that fell behind retention throws
+change. Trim scheduling is stored in SQLite, so the bound also holds across
+short-lived connections and multiple worker processes. Constructing
+`queueEvents()` without `fromOffset` starts at the oldest retained event. An
+explicit checkpoint that fell behind retention throws
 `QueueEventOffsetExpiredError` instead of silently skipping activity.
 
 For familiar live `EventEmitter` ergonomics, use a listener backed by the same

--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -766,6 +766,86 @@ class Stream {
   }
 }
 
+class QueueEvent {
+  constructor(row) {
+    this.version = row.version;
+    this.offset = row.offset;
+    this.type = row.type;
+    this.queue = row.queue;
+    this.jobId = row.job_id;
+    this.occurredAt = row.occurred_at;
+    this.attempts = row.attempts;
+    this.workerId = row.worker_id ?? null;
+    this.runAt = row.run_at ?? null;
+    this.error = row.error ?? null;
+    if (Object.prototype.hasOwnProperty.call(row, 'payload')) {
+      this.payload = row.payload;
+    }
+  }
+}
+
+class QueueEvents {
+  constructor(
+    db,
+    { queue = null, fromOffset = 0, fallbackPollS = 1, signal = null } = {},
+  ) {
+    this._db = db;
+    this.queue = queue;
+    this._fallbackPollMs =
+      fallbackPollS == null ? null : Math.max(0, fallbackPollS * 1000);
+    this._signal = signal;
+    // Subscribe before the first read so a commit cannot land in the
+    // snapshot/listen gap and leave this iterator parked until fallback.
+    this._updates = db.updateEvents();
+    this._closed = false;
+    this._pending = [];
+    this._lastSeen = fromOffset;
+  }
+
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+
+  get lastOffset() {
+    return this._lastSeen;
+  }
+
+  readSince(offset, limit = 256) {
+    const rowsJson = this._db._callScalar(
+      'SELECT honker_queue_events_read_since(?, ?, ?)',
+      [offset, this.queue, limit],
+    );
+    return JSON.parse(rowsJson || '[]').map((row) => new QueueEvent(row));
+  }
+
+  _loadPending() {
+    this._pending.push(...this.readSince(this._lastSeen));
+  }
+
+  async next() {
+    while (!this._closed && !aborted(this._signal)) {
+      if (this._pending.length === 0) this._loadPending();
+      if (this._pending.length > 0) {
+        const event = this._pending.shift();
+        this._lastSeen = event.offset;
+        return { done: false, value: event };
+      }
+      await waitForUpdateOrTimeout(
+        this._updates,
+        this._signal,
+        this._fallbackPollMs,
+      );
+    }
+    return { done: true, value: undefined };
+  }
+
+  close() {
+    if (this._closed) return;
+    this._closed = true;
+    this._updates.close();
+  }
+}
+
 class Listener {
   constructor(db, channel, { fallbackPollS = 15 } = {}) {
     this._db = db;
@@ -990,6 +1070,20 @@ class Database {
     return unwrapTx(tx).notify(channel, payload);
   }
 
+  configureQueueEvents({ enabled = true, maxEvents = 10_000, includePayload = false } = {}) {
+    return (
+      this._callScalar('SELECT honker_queue_events_configure(?, ?, ?)', [
+        enabled ? 1 : 0,
+        maxEvents,
+        includePayload ? 1 : 0,
+      ]) === 1
+    );
+  }
+
+  queueEvents(opts = {}) {
+    return new QueueEvents(this, opts);
+  }
+
   queue(name, opts = {}) {
     return new Queue(this, name, opts);
   }
@@ -1075,6 +1169,8 @@ module.exports = function buildApi(nativeBinding) {
     Stream,
     StreamEvent,
     StreamSubscription,
+    QueueEvent,
+    QueueEvents,
     CheckpointMigrationError,
     Listener,
     Scheduler,

--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -823,19 +823,30 @@ class QueueEvents {
   }
 
   async next() {
-    while (!this._closed && !aborted(this._signal)) {
-      if (this._pending.length === 0) this._loadPending();
-      if (this._pending.length > 0) {
-        const event = this._pending.shift();
-        this._lastSeen = event.offset;
-        return { done: false, value: event };
+    try {
+      while (!this._closed && !aborted(this._signal)) {
+        if (this._pending.length === 0) this._loadPending();
+        if (this._pending.length > 0) {
+          const event = this._pending.shift();
+          this._lastSeen = event.offset;
+          return { done: false, value: event };
+        }
+        await waitForUpdateOrTimeout(
+          this._updates,
+          this._signal,
+          this._fallbackPollMs,
+        );
       }
-      await waitForUpdateOrTimeout(
-        this._updates,
-        this._signal,
-        this._fallbackPollMs,
-      );
+    } catch (error) {
+      this.close();
+      throw error;
     }
+    this.close();
+    return { done: true, value: undefined };
+  }
+
+  async return() {
+    this.close();
     return { done: true, value: undefined };
   }
 

--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { EventEmitter } = require('node:events');
 const { setTimeout: delay } = require('node:timers/promises');
 
 function scalar(rows) {
@@ -99,6 +100,31 @@ class CheckpointMigrationError extends Error {
     this.stream = stream;
     this.consumer = consumer;
     this.offset = offset;
+  }
+}
+
+class QueueEventOffsetExpiredError extends Error {
+  constructor(requestedOffset, trimmedThroughOffset, oldestAvailableOffset) {
+    super(
+      `Queue-event offset ${requestedOffset} is no longer retained; ` +
+        `events through offset ${trimmedThroughOffset} were trimmed. ` +
+        `Start without fromOffset to consume from the oldest retained event.`,
+    );
+    this.name = 'QueueEventOffsetExpiredError';
+    this.code = 'HONKER_QUEUE_EVENT_OFFSET_EXPIRED';
+    this.requestedOffset = requestedOffset;
+    this.trimmedThroughOffset = trimmedThroughOffset;
+    this.oldestAvailableOffset = oldestAvailableOffset;
+  }
+}
+
+class QueueEventsDisabledError extends Error {
+  constructor() {
+    super(
+      'Queue events are disabled; call configureQueueEvents({ enabled: true }) first.',
+    );
+    this.name = 'QueueEventsDisabledError';
+    this.code = 'HONKER_QUEUE_EVENTS_DISABLED';
   }
 }
 
@@ -777,6 +803,7 @@ class QueueEvent {
     this.attempts = row.attempts;
     this.workerId = row.worker_id ?? null;
     this.runAt = row.run_at ?? null;
+    this.reason = row.reason ?? null;
     this.error = row.error ?? null;
     if (Object.prototype.hasOwnProperty.call(row, 'payload')) {
       this.payload = row.payload;
@@ -785,10 +812,12 @@ class QueueEvent {
 }
 
 class QueueEvents {
-  constructor(
-    db,
-    { queue = null, fromOffset = 0, fallbackPollS = 1, signal = null } = {},
-  ) {
+  constructor(db, opts = {}) {
+    const {
+      queue = null,
+      fallbackPollS = 1,
+      signal = null,
+    } = opts;
     this._db = db;
     this.queue = queue;
     this._fallbackPollMs =
@@ -797,9 +826,18 @@ class QueueEvents {
     // Subscribe before the first read so a commit cannot land in the
     // snapshot/listen gap and leave this iterator parked until fallback.
     this._updates = db.updateEvents();
+    let status;
+    try {
+      status = db._queueEventsStatus();
+    } catch (error) {
+      this._updates.close();
+      throw error;
+    }
     this._closed = false;
     this._pending = [];
-    this._lastSeen = fromOffset;
+    this._lastSeen = Object.prototype.hasOwnProperty.call(opts, 'fromOffset')
+      ? opts.fromOffset
+      : status.trimmedThroughOffset;
   }
 
   [Symbol.asyncIterator]() {
@@ -811,10 +849,23 @@ class QueueEvents {
   }
 
   readSince(offset, limit = 256) {
-    const rowsJson = this._db._callScalar(
-      'SELECT honker_queue_events_read_since(?, ?, ?)',
-      [offset, this.queue, limit],
-    );
+    let rowsJson;
+    try {
+      rowsJson = this._db._callScalar(
+        'SELECT honker_queue_events_read_since(?, ?, ?)',
+        [offset, this.queue, limit],
+      );
+    } catch (error) {
+      if (!String(error?.message).includes('HONKER_QUEUE_EVENT_OFFSET_EXPIRED')) {
+        throw error;
+      }
+      const status = this._db._queueEventsStatus();
+      throw new QueueEventOffsetExpiredError(
+        offset,
+        status.trimmedThroughOffset,
+        status.oldestOffset,
+      );
+    }
     return JSON.parse(rowsJson || '[]').map((row) => new QueueEvent(row));
   }
 
@@ -854,6 +905,55 @@ class QueueEvents {
     if (this._closed) return;
     this._closed = true;
     this._updates.close();
+  }
+}
+
+class QueueEventListener extends EventEmitter {
+  constructor(db, opts = {}) {
+    super();
+    const status = db._queueEventsStatus();
+    if (!status.enabled) throw new QueueEventsDisabledError();
+    if (
+      Object.prototype.hasOwnProperty.call(opts, 'fromOffset') &&
+      Object.prototype.hasOwnProperty.call(opts, 'startAt')
+    ) {
+      throw new TypeError('Specify either fromOffset or startAt, not both');
+    }
+    const { startAt = 'latest', ...feedOpts } = opts;
+    if (!Object.prototype.hasOwnProperty.call(opts, 'fromOffset')) {
+      if (startAt === 'latest') {
+        feedOpts.fromOffset = status.latestOffset ?? status.trimmedThroughOffset;
+      } else if (startAt !== 'oldest') {
+        throw new TypeError("startAt must be 'latest' or 'oldest'");
+      }
+    }
+    this._feed = new QueueEvents(db, feedOpts);
+    this._closed = false;
+    queueMicrotask(() => this._pump());
+  }
+
+  get lastOffset() {
+    return this._feed.lastOffset;
+  }
+
+  async _pump() {
+    try {
+      for await (const event of this._feed) {
+        this.emit(event.type, event);
+        this.emit('event', event);
+      }
+    } catch (error) {
+      if (!this._closed) this.emit('error', error);
+    } finally {
+      this.close();
+    }
+  }
+
+  close() {
+    if (this._closed) return;
+    this._closed = true;
+    this._feed.close();
+    this.emit('close');
   }
 }
 
@@ -1081,18 +1181,35 @@ class Database {
     return unwrapTx(tx).notify(channel, payload);
   }
 
-  configureQueueEvents({ enabled = true, maxEvents = 10_000, includePayload = false } = {}) {
+  configureQueueEvents({ enabled = true, retentionTarget = 10_000, includePayload = false } = {}) {
     return (
       this._callScalar('SELECT honker_queue_events_configure(?, ?, ?)', [
         enabled ? 1 : 0,
-        maxEvents,
+        retentionTarget,
         includePayload ? 1 : 0,
       ]) === 1
     );
   }
 
+  _queueEventsStatus() {
+    const raw = this._callScalar('SELECT honker_queue_events_status()');
+    const row = JSON.parse(raw || '{}');
+    return {
+      enabled: Boolean(row.enabled),
+      retentionTarget: row.retention_target ?? 10_000,
+      includePayload: Boolean(row.include_payload),
+      trimmedThroughOffset: row.trimmed_through_offset ?? 0,
+      oldestOffset: row.oldest_offset ?? null,
+      latestOffset: row.latest_offset ?? null,
+    };
+  }
+
   queueEvents(opts = {}) {
     return new QueueEvents(this, opts);
+  }
+
+  queueEventListener(opts = {}) {
+    return new QueueEventListener(this, opts);
   }
 
   queue(name, opts = {}) {
@@ -1182,6 +1299,9 @@ module.exports = function buildApi(nativeBinding) {
     StreamSubscription,
     QueueEvent,
     QueueEvents,
+    QueueEventListener,
+    QueueEventOffsetExpiredError,
+    QueueEventsDisabledError,
     CheckpointMigrationError,
     Listener,
     Scheduler,

--- a/packages/honker-node/api.js
+++ b/packages/honker-node/api.js
@@ -829,6 +829,7 @@ class QueueEvents {
     let status;
     try {
       status = db._queueEventsStatus();
+      if (!status.schemaAvailable) throw new QueueEventsDisabledError();
     } catch (error) {
       this._updates.close();
       throw error;
@@ -1195,6 +1196,7 @@ class Database {
     const raw = this._callScalar('SELECT honker_queue_events_status()');
     const row = JSON.parse(raw || '{}');
     return {
+      schemaAvailable: Boolean(row.schema_available ?? true),
       enabled: Boolean(row.enabled),
       retentionTarget: row.retention_target ?? 10_000,
       includePayload: Boolean(row.include_payload),

--- a/packages/honker-node/package.json
+++ b/packages/honker-node/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "npm run test:types && node --test test/extension.js test/api.test.js test/basic.js test/parity.test.js test/cross_lang_python_to_node.js test/cross_lang_node_to_python.js test/cross_lang_supporting.js test/watcher_backends.js test/watcher_backends_e2e.js test/watcher_backends_queue_e2e.js test/phase_mantle.js test/typed_jobs_e2e.js",
+    "test": "npm run test:types && node --test test/extension.js test/api.test.js test/basic.js test/parity.test.js test/cross_lang_python_to_node.js test/cross_lang_node_to_python.js test/cross_lang_supporting.js test/watcher_backends.js test/watcher_backends_e2e.js test/watcher_backends_queue_e2e.js test/phase_mantle.js test/typed_jobs_e2e.js test/queue_events.test.js test/queue_events_e2e.js",
     "test:types": "tsc -p test/types/tsconfig.json"
   },
   "devDependencies": {

--- a/packages/honker-node/test/helpers.js
+++ b/packages/honker-node/test/helpers.js
@@ -55,6 +55,7 @@ function wrapDatabase(db, tracked) {
   wrapMethod(db, 'updateEvents', (resource) => trackCloseable(tracked, resource));
   wrapMethod(db, 'listen', (resource) => trackCloseable(tracked, resource));
   wrapMethod(db, 'queueEvents', (resource) => trackCloseable(tracked, resource));
+  wrapMethod(db, 'queueEventListener', (resource) => trackCloseable(tracked, resource));
   wrapMethod(db, 'stream', (stream) => {
     wrapMethod(stream, 'subscribe', (resource) => trackCloseable(tracked, resource));
     return stream;

--- a/packages/honker-node/test/helpers.js
+++ b/packages/honker-node/test/helpers.js
@@ -54,6 +54,7 @@ function wrapDatabase(db, tracked) {
 
   wrapMethod(db, 'updateEvents', (resource) => trackCloseable(tracked, resource));
   wrapMethod(db, 'listen', (resource) => trackCloseable(tracked, resource));
+  wrapMethod(db, 'queueEvents', (resource) => trackCloseable(tracked, resource));
   wrapMethod(db, 'stream', (stream) => {
     wrapMethod(stream, 'subscribe', (resource) => trackCloseable(tracked, resource));
     return stream;

--- a/packages/honker-node/test/queue_events.test.js
+++ b/packages/honker-node/test/queue_events.test.js
@@ -149,6 +149,43 @@ test('queue events cover retry, completion, cancellation, filtering, and retenti
   }
 });
 
+test('queue event retention remains bounded across short-lived connections', () => {
+  const { path, open, cleanup } = tmpdb();
+  let reader;
+  let feed;
+  try {
+    const configured = open(path);
+    configured.configureQueueEvents({ retentionTarget: 20 });
+    configured.close();
+
+    // Model request-scoped clients and separate worker processes. Each enqueue
+    // uses a fresh native database handle and a fresh Rust config cache.
+    for (let sequence = 0; sequence < 45; sequence++) {
+      const writer = open(path);
+      writer.queue('short-lived-writers').enqueue({ sequence });
+      writer.close();
+    }
+
+    reader = open(path);
+    feed = reader.queueEvents();
+    assert.ok(feed.lastOffset > 0);
+    const retained = feed.readSince(feed.lastOffset, 100);
+    assert.equal(retained.length, 21);
+    assert.deepEqual(
+      retained.map((event) => event.jobId),
+      [...retained.map((event) => event.jobId)].sort((a, b) => a - b),
+    );
+    assert.throws(
+      () => feed.readSince(0, 100),
+      (error) => error instanceof honker.QueueEventOffsetExpiredError &&
+        error.trimmedThroughOffset === feed.lastOffset,
+    );
+  } finally {
+    try { feed?.close(); } catch {}
+    cleanup();
+  }
+});
+
 test('queue event listener provides live EventEmitter ergonomics over the durable feed', async () => {
   const { path, open, cleanup } = tmpdb();
   let db;

--- a/packages/honker-node/test/queue_events.test.js
+++ b/packages/honker-node/test/queue_events.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const honker = require('..');
+const { createTempDb } = require('./helpers');
+
+function tmpdb() {
+  return createTempDb('honker-queue-events-', honker.open.bind(honker));
+}
+
+test('queue events are opt-in and follow successful committed transitions', async () => {
+  const { path, open, cleanup } = tmpdb();
+  let db;
+  let feed;
+  try {
+    db = open(path);
+    const queue = db.queue('emails', { maxAttempts: 3 });
+
+    queue.enqueue({ disabled: true });
+    feed = db.queueEvents({ fromOffset: 0 });
+    assert.deepEqual(feed.readSince(0), []);
+    feed.close();
+
+    assert.equal(
+      db.configureQueueEvents({ maxEvents: 100, includePayload: true }),
+      true,
+    );
+    feed = db.queueEvents({ fromOffset: 0 });
+
+    const rolledBack = db.transaction();
+    queue.enqueueTx(rolledBack, { rolledBack: true });
+    rolledBack.rollback();
+    assert.deepEqual(feed.readSince(0), []);
+
+    const first = feed.next();
+    const id = queue.enqueue({ to: 'alice@example.com' }, { priority: 7 });
+    const enqueued = await first;
+    assert.equal(enqueued.done, false);
+    assert.equal(enqueued.value.type, 'enqueued');
+    assert.equal(enqueued.value.jobId, id);
+    assert.deepEqual(enqueued.value.payload, { to: 'alice@example.com' });
+
+    const claimedOnce = queue.claimOne('worker-1');
+    assert.equal(claimedOnce.ack(), true);
+    assert.deepEqual(
+      feed.readSince(enqueued.value.offset).map((event) => event.type),
+      ['claimed', 'completed'],
+    );
+  } finally {
+    try { feed?.close(); } catch {}
+    cleanup();
+  }
+});
+
+test('queue events cover retry, completion, cancellation, filtering, and retention', () => {
+  const { path, open, cleanup } = tmpdb();
+  let db;
+  let globalFeed;
+  let alphaFeed;
+  try {
+    db = open(path);
+    db.configureQueueEvents({ maxEvents: 100, includePayload: false });
+
+    const queue = db.queue('jobs', { maxAttempts: 3 });
+    const id = queue.enqueue({ secret: 'not retained' });
+    const first = queue.claimOne('worker-1');
+    assert.equal(first.retry(0, 'temporary'), true);
+    const second = queue.claimOne('worker-2');
+    assert.equal(second.ack(), true);
+    assert.equal(second.ack(), false);
+
+    const cancelled = queue.enqueue({ cancel: true });
+    assert.equal(queue.cancel(cancelled), true);
+    assert.equal(queue.cancel(cancelled), false);
+
+    const failed = queue.enqueue({ fail: true });
+    const failedJob = queue.claimOne('worker-fail');
+    assert.equal(failedJob.fail('permanent'), true);
+
+    globalFeed = db.queueEvents({ fromOffset: 0 });
+    const lifecycle = globalFeed.readSince(0, 100);
+    assert.deepEqual(
+      lifecycle.filter((event) => event.jobId === id).map((event) => event.type),
+      ['enqueued', 'claimed', 'retry_scheduled', 'claimed', 'completed'],
+    );
+    assert.equal(
+      lifecycle.filter((event) => event.jobId === cancelled).at(-1).type,
+      'cancelled',
+    );
+    const failedEvent = lifecycle
+      .filter((event) => event.jobId === failed)
+      .at(-1);
+    assert.equal(failedEvent.type, 'dead_lettered');
+    assert.equal(failedEvent.error, 'permanent');
+    assert.equal(failedEvent.workerId, 'worker-fail');
+    assert.equal(failedEvent.attempts, 1);
+    assert.ok(lifecycle.every((event) => event.payload === undefined));
+
+    db.configureQueueEvents({ maxEvents: 3, includePayload: true });
+    const alpha = db.queue('alpha');
+    const beta = db.queue('beta');
+    alpha.enqueue({ sequence: 1 });
+    beta.enqueue({ sequence: 2 });
+    alpha.enqueue({ sequence: 3 });
+    beta.enqueue({ sequence: 4 });
+    alpha.enqueue({ sequence: 5 });
+
+    globalFeed.close();
+    globalFeed = db.queueEvents({ fromOffset: 0 });
+    const retained = globalFeed.readSince(0, 100);
+    assert.equal(retained.length, 3);
+    assert.deepEqual(retained.map((event) => event.payload.sequence), [3, 4, 5]);
+
+    alphaFeed = db.queueEvents({ queue: 'alpha', fromOffset: 0 });
+    assert.deepEqual(
+      alphaFeed.readSince(0, 100).map((event) => event.payload.sequence),
+      [3, 5],
+    );
+
+    const finalOffset = retained.at(-1).offset;
+    db.configureQueueEvents({ enabled: false, maxEvents: 3 });
+    alpha.enqueue({ sequence: 6 });
+    assert.deepEqual(globalFeed.readSince(finalOffset, 100), []);
+  } finally {
+    try { alphaFeed?.close(); } catch {}
+    try { globalFeed?.close(); } catch {}
+    cleanup();
+  }
+});

--- a/packages/honker-node/test/queue_events.test.js
+++ b/packages/honker-node/test/queue_events.test.js
@@ -129,3 +129,73 @@ test('queue events cover retry, completion, cancellation, filtering, and retenti
     cleanup();
   }
 });
+
+test('queue event iterators close on abort, early return, and pending close', async () => {
+  const { path, open, cleanup } = tmpdb();
+  let db;
+  let abortedFeed;
+  let breakFeed;
+  let closedFeed;
+  let errorFeed;
+  try {
+    db = open(path);
+    db.configureQueueEvents();
+
+    const controller = new AbortController();
+    abortedFeed = db.queueEvents({ signal: controller.signal, fallbackPollS: null });
+    const abortedNext = abortedFeed.next();
+    controller.abort();
+    assert.deepEqual(await abortedNext, { done: true, value: undefined });
+    assert.equal(abortedFeed._updates._closed, true);
+
+    breakFeed = db.queueEvents();
+    db.queue('iterator-cleanup').enqueue({ sequence: 1 });
+    for await (const event of breakFeed) {
+      assert.equal(event.type, 'enqueued');
+      break;
+    }
+    assert.equal(breakFeed._updates._closed, true);
+
+    closedFeed = db.queueEvents({
+      fromOffset: breakFeed.lastOffset,
+      fallbackPollS: null,
+    });
+    const closedNext = closedFeed.next();
+    closedFeed.close();
+    assert.deepEqual(await closedNext, { done: true, value: undefined });
+    assert.equal(closedFeed._updates._closed, true);
+
+    errorFeed = db.queueEvents({ fromOffset: breakFeed.lastOffset });
+    const dropStream = db.transaction();
+    dropStream.execute('DROP TABLE _honker_stream');
+    dropStream.commit();
+    await assert.rejects(errorFeed.next(), /no such table: _honker_stream/);
+    assert.equal(errorFeed._updates._closed, true);
+  } finally {
+    try { errorFeed?.close(); } catch {}
+    try { closedFeed?.close(); } catch {}
+    try { breakFeed?.close(); } catch {}
+    try { abortedFeed?.close(); } catch {}
+    cleanup();
+  }
+});
+
+test('the internal queue event stream topic is reserved', () => {
+  const { path, open, cleanup } = tmpdb();
+  let db;
+  try {
+    db = open(path);
+    assert.throws(
+      () => db.stream('_honker:queue-events:v1').publish({ forged: true }),
+      /reserved for queue lifecycle events/,
+    );
+
+    db.configureQueueEvents({ includePayload: true });
+    const id = db.queue('reserved-topic').enqueue({ legitimate: true });
+    const [event] = db.queueEvents({ queue: 'reserved-topic' }).readSince(0);
+    assert.equal(event.jobId, id);
+    assert.deepEqual(event.payload, { legitimate: true });
+  } finally {
+    cleanup();
+  }
+});

--- a/packages/honker-node/test/queue_events.test.js
+++ b/packages/honker-node/test/queue_events.test.js
@@ -54,6 +54,34 @@ test('queue events are opt-in and follow successful committed transitions', asyn
   }
 });
 
+test('pre-event schemas fail feed construction with the typed disabled error', () => {
+  const { path, open, cleanup } = tmpdb();
+  let db;
+  try {
+    db = open(path);
+    const legacySchema = db.transaction();
+    legacySchema.execute('DROP TABLE _honker_queue_event_config');
+    legacySchema.commit();
+
+    assert.throws(
+      () => db.queueEvents(),
+      (error) => error instanceof honker.QueueEventsDisabledError &&
+        error.code === 'HONKER_QUEUE_EVENTS_DISABLED',
+    );
+    assert.throws(
+      () => db.queueEventListener(),
+      (error) => error instanceof honker.QueueEventsDisabledError &&
+        error.code === 'HONKER_QUEUE_EVENTS_DISABLED',
+    );
+
+    // Compatibility remains symmetric: queue mutations still work without
+    // the opt-in event schema.
+    assert.ok(db.queue('legacy').enqueue({ compatible: true }) > 0);
+  } finally {
+    cleanup();
+  }
+});
+
 test('queue events cover retry, completion, cancellation, filtering, and retention', () => {
   const { path, open, cleanup } = tmpdb();
   let db;

--- a/packages/honker-node/test/queue_events.test.js
+++ b/packages/honker-node/test/queue_events.test.js
@@ -24,7 +24,7 @@ test('queue events are opt-in and follow successful committed transitions', asyn
     feed.close();
 
     assert.equal(
-      db.configureQueueEvents({ maxEvents: 100, includePayload: true }),
+      db.configureQueueEvents({ retentionTarget: 100, includePayload: true }),
       true,
     );
     feed = db.queueEvents({ fromOffset: 0 });
@@ -61,7 +61,7 @@ test('queue events cover retry, completion, cancellation, filtering, and retenti
   let alphaFeed;
   try {
     db = open(path);
-    db.configureQueueEvents({ maxEvents: 100, includePayload: false });
+    db.configureQueueEvents({ retentionTarget: 100, includePayload: false });
 
     const queue = db.queue('jobs', { maxAttempts: 3 });
     const id = queue.enqueue({ secret: 'not retained' });
@@ -93,39 +93,125 @@ test('queue events cover retry, completion, cancellation, filtering, and retenti
       .filter((event) => event.jobId === failed)
       .at(-1);
     assert.equal(failedEvent.type, 'dead_lettered');
+    assert.equal(failedEvent.reason, 'explicit_failure');
     assert.equal(failedEvent.error, 'permanent');
     assert.equal(failedEvent.workerId, 'worker-fail');
     assert.equal(failedEvent.attempts, 1);
     assert.ok(lifecycle.every((event) => event.payload === undefined));
 
-    db.configureQueueEvents({ maxEvents: 3, includePayload: true });
+    db.configureQueueEvents({ retentionTarget: 3, includePayload: true });
     const alpha = db.queue('alpha');
     const beta = db.queue('beta');
     alpha.enqueue({ sequence: 1 });
+    db.stream('app').publish({ unrelated: 1 });
     beta.enqueue({ sequence: 2 });
+    db.stream('app').publish({ unrelated: 2 });
     alpha.enqueue({ sequence: 3 });
+    db.stream('app').publish({ unrelated: 3 });
     beta.enqueue({ sequence: 4 });
+    db.stream('app').publish({ unrelated: 4 });
     alpha.enqueue({ sequence: 5 });
 
     globalFeed.close();
-    globalFeed = db.queueEvents({ fromOffset: 0 });
-    const retained = globalFeed.readSince(0, 100);
+    globalFeed = db.queueEvents();
+    const retained = globalFeed.readSince(globalFeed.lastOffset, 100);
     assert.equal(retained.length, 3);
     assert.deepEqual(retained.map((event) => event.payload.sequence), [3, 4, 5]);
 
-    alphaFeed = db.queueEvents({ queue: 'alpha', fromOffset: 0 });
+    const staleFeed = db.queueEvents({ fromOffset: 0 });
+    assert.throws(
+      () => staleFeed.readSince(0, 100),
+      (error) => {
+        assert.ok(error instanceof honker.QueueEventOffsetExpiredError);
+        assert.equal(error.code, 'HONKER_QUEUE_EVENT_OFFSET_EXPIRED');
+        assert.equal(error.requestedOffset, 0);
+        assert.ok(error.trimmedThroughOffset > 0);
+        assert.equal(error.oldestAvailableOffset, retained[0].offset);
+        return true;
+      },
+    );
+    staleFeed.close();
+
+    alphaFeed = db.queueEvents({ queue: 'alpha' });
     assert.deepEqual(
-      alphaFeed.readSince(0, 100).map((event) => event.payload.sequence),
+      alphaFeed.readSince(alphaFeed.lastOffset, 100).map((event) => event.payload.sequence),
       [3, 5],
     );
 
     const finalOffset = retained.at(-1).offset;
-    db.configureQueueEvents({ enabled: false, maxEvents: 3 });
+    db.configureQueueEvents({ enabled: false, retentionTarget: 3 });
     alpha.enqueue({ sequence: 6 });
     assert.deepEqual(globalFeed.readSince(finalOffset, 100), []);
   } finally {
     try { alphaFeed?.close(); } catch {}
     try { globalFeed?.close(); } catch {}
+    cleanup();
+  }
+});
+
+test('queue event listener provides live EventEmitter ergonomics over the durable feed', async () => {
+  const { path, open, cleanup } = tmpdb();
+  let db;
+  let listener;
+  let replayListener;
+  let gapListener;
+  try {
+    db = open(path);
+    assert.throws(
+      () => db.queueEventListener(),
+      (error) => error instanceof honker.QueueEventsDisabledError &&
+        error.code === 'HONKER_QUEUE_EVENTS_DISABLED',
+    );
+
+    db.configureQueueEvents({ includePayload: true });
+    db.queue('listener').enqueue({ sequence: 1 });
+    assert.throws(
+      () => db.queueEventListener({ startAt: 'middle' }),
+      /startAt must be 'latest' or 'oldest'/,
+    );
+    assert.throws(
+      () => db.queueEventListener({ fromOffset: 0, startAt: 'oldest' }),
+      /Specify either fromOffset or startAt/,
+    );
+
+    listener = db.queueEventListener({ queue: 'listener' });
+    const allLiveEvents = [];
+    listener.on('event', (item) => allLiveEvents.push(item));
+    const live = new Promise((resolve, reject) => {
+      listener.once('enqueued', resolve);
+      listener.once('error', reject);
+    });
+    const liveId = db.queue('listener').enqueue({ sequence: 2 });
+    const event = await live;
+    assert.equal(event.jobId, liveId);
+    assert.equal(event.payload.sequence, 2);
+    assert.deepEqual(allLiveEvents, [event]);
+
+    replayListener = db.queueEventListener({ queue: 'listener', startAt: 'oldest' });
+    const replayed = new Promise((resolve, reject) => {
+      replayListener.once('enqueued', resolve);
+      replayListener.once('error', reject);
+    });
+    assert.equal((await replayed).payload.sequence, 1);
+
+    let closeCount = 0;
+    listener.on('close', () => closeCount++);
+    listener.close();
+    listener.close();
+    assert.equal(closeCount, 1);
+    replayListener.close();
+    db.configureQueueEvents({ retentionTarget: 1, includePayload: false });
+    db.queue('listener-gap').enqueue({ sequence: 3 });
+    db.queue('listener-gap').enqueue({ sequence: 4 });
+    gapListener = db.queueEventListener({ fromOffset: 0 });
+    const gap = new Promise((resolve) => gapListener.once('error', resolve));
+    const gapError = await gap;
+    assert.ok(gapError instanceof honker.QueueEventOffsetExpiredError);
+    assert.equal(gapError.requestedOffset, 0);
+  } finally {
+    try { gapListener?.close(); } catch {}
+    try { replayListener?.close(); } catch {}
+    try { listener?.close(); } catch {}
     cleanup();
   }
 });

--- a/packages/honker-node/test/queue_events.test.js
+++ b/packages/honker-node/test/queue_events.test.js
@@ -57,6 +57,7 @@ test('queue events are opt-in and follow successful committed transitions', asyn
 test('pre-event schemas fail feed construction with the typed disabled error', () => {
   const { path, open, cleanup } = tmpdb();
   let db;
+  let feed;
   try {
     db = open(path);
     const legacySchema = db.transaction();
@@ -77,7 +78,18 @@ test('pre-event schemas fail feed construction with the typed disabled error', (
     // Compatibility remains symmetric: queue mutations still work without
     // the opt-in event schema.
     assert.ok(db.queue('legacy').enqueue({ compatible: true }) > 0);
+
+    // Follow the typed error's recovery instruction. Configuration restores
+    // the canonical schema, and subsequent lifecycle events are observable.
+    assert.equal(db.configureQueueEvents({ enabled: true }), true);
+    feed = db.queueEvents({ fromOffset: 0 });
+    const id = db.queue('legacy').enqueue({ emits: true });
+    assert.deepEqual(
+      feed.readSince(0).map((event) => [event.type, event.jobId]),
+      [['enqueued', id]],
+    );
   } finally {
+    try { feed?.close(); } catch {}
     cleanup();
   }
 });

--- a/packages/honker-node/test/queue_events_e2e.js
+++ b/packages/honker-node/test/queue_events_e2e.js
@@ -23,16 +23,24 @@ test('queue event feed observes a real producer and workers across processes', a
   const dbPath = path.join(dir, 'app.db');
   let db;
   let feed;
+  let listener;
   try {
     db = honker.open(dbPath);
-    db.configureQueueEvents({ maxEvents: 100, includePayload: true });
+    db.configureQueueEvents({ retentionTarget: 100, includePayload: true });
 
     const rolledBack = db.transaction();
     db.queue('emails').enqueueTx(rolledBack, { rolledBack: true });
     rolledBack.rollback();
 
-    feed = db.queueEvents({ queue: 'emails', fromOffset: 0, fallbackPollS: null });
-    const liveEvent = feed.next();
+    listener = db.queueEventListener({
+      queue: 'emails',
+      startAt: 'oldest',
+      fallbackPollS: null,
+    });
+    const liveEvent = new Promise((resolve, reject) => {
+      listener.once('enqueued', resolve);
+      listener.once('error', reject);
+    });
     const jobId = Number(runNode(`
       const honker = require('.');
       const db = honker.open(process.argv[1]);
@@ -45,10 +53,9 @@ test('queue event feed observes a real producer and workers across processes', a
     `, dbPath));
 
     const first = await liveEvent;
-    assert.equal(first.done, false);
-    assert.equal(first.value.type, 'enqueued');
-    assert.equal(first.value.jobId, jobId);
-    assert.deepEqual(first.value.payload, {
+    assert.equal(first.type, 'enqueued');
+    assert.equal(first.jobId, jobId);
+    assert.deepEqual(first.payload, {
       recipient: 'alice@example.com',
       template: 'welcome',
     });
@@ -68,16 +75,18 @@ test('queue event feed observes a real producer and workers across processes', a
       db.close();
     `, dbPath);
 
-    const replayed = feed.readSince(first.value.offset, 100);
+    feed = db.queueEvents({ queue: 'emails', fromOffset: first.offset });
+    const replayed = feed.readSince(first.offset, 100);
     assert.deepEqual(
       replayed.filter((event) => event.jobId === jobId).map((event) => event.type),
       ['claimed', 'retry_scheduled', 'claimed', 'completed'],
     );
-    assert.ok(replayed.every((event) => event.offset > first.value.offset));
+    assert.ok(replayed.every((event) => event.offset > first.offset));
     assert.ok(
-      [first.value, ...replayed].every((event) => event.payload?.rolledBack !== true),
+      [first, ...replayed].every((event) => event.payload?.rolledBack !== true),
     );
   } finally {
+    try { listener?.close(); } catch {}
     try { feed?.close(); } catch {}
     try { db?.close(); } catch {}
     fs.rmSync(dir, { recursive: true, force: true });

--- a/packages/honker-node/test/queue_events_e2e.js
+++ b/packages/honker-node/test/queue_events_e2e.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const honker = require('..');
+
+function runNode(script, dbPath) {
+  const result = spawnSync(process.execPath, ['-e', script, dbPath], {
+    cwd: path.join(__dirname, '..'),
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result.stdout.trim();
+}
+
+test('queue event feed observes a real producer and workers across processes', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'honker-queue-events-e2e-'));
+  const dbPath = path.join(dir, 'app.db');
+  let db;
+  let feed;
+  try {
+    db = honker.open(dbPath);
+    db.configureQueueEvents({ maxEvents: 100, includePayload: true });
+
+    const rolledBack = db.transaction();
+    db.queue('emails').enqueueTx(rolledBack, { rolledBack: true });
+    rolledBack.rollback();
+
+    feed = db.queueEvents({ queue: 'emails', fromOffset: 0, fallbackPollS: null });
+    const liveEvent = feed.next();
+    const jobId = Number(runNode(`
+      const honker = require('.');
+      const db = honker.open(process.argv[1]);
+      const id = db.queue('emails', { maxAttempts: 3 }).enqueue({
+        recipient: 'alice@example.com',
+        template: 'welcome',
+      });
+      console.log(id);
+      db.close();
+    `, dbPath));
+
+    const first = await liveEvent;
+    assert.equal(first.done, false);
+    assert.equal(first.value.type, 'enqueued');
+    assert.equal(first.value.jobId, jobId);
+    assert.deepEqual(first.value.payload, {
+      recipient: 'alice@example.com',
+      template: 'welcome',
+    });
+
+    runNode(`
+      const honker = require('.');
+      const db = honker.open(process.argv[1]);
+      const job = db.queue('emails', { maxAttempts: 3 }).claimOne('worker-1');
+      if (!job || !job.retry(0, 'temporary')) process.exit(2);
+      db.close();
+    `, dbPath);
+    runNode(`
+      const honker = require('.');
+      const db = honker.open(process.argv[1]);
+      const job = db.queue('emails', { maxAttempts: 3 }).claimOne('worker-2');
+      if (!job || !job.ack()) process.exit(2);
+      db.close();
+    `, dbPath);
+
+    const replayed = feed.readSince(first.value.offset, 100);
+    assert.deepEqual(
+      replayed.filter((event) => event.jobId === jobId).map((event) => event.type),
+      ['claimed', 'retry_scheduled', 'claimed', 'completed'],
+    );
+    assert.ok(replayed.every((event) => event.offset > first.value.offset));
+    assert.ok(
+      [first.value, ...replayed].every((event) => event.payload?.rolledBack !== true),
+    );
+  } finally {
+    try { feed?.close(); } catch {}
+    try { db?.close(); } catch {}
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/honker-node/test/types/typed-jobs.ts
+++ b/packages/honker-node/test/types/typed-jobs.ts
@@ -62,5 +62,6 @@ for (const event of retained) {
 queue.enqueue({ template: 'welcome', variables: {} })
 
 waker.close()
+void queueEvents.return()
 queueEvents.close()
 db.close()

--- a/packages/honker-node/test/types/typed-jobs.ts
+++ b/packages/honker-node/test/types/typed-jobs.ts
@@ -43,8 +43,24 @@ outbox.enqueue({
   variables: {},
 })
 
+db.configureQueueEvents({ maxEvents: 10_000, includePayload: true })
+const queueEvents = db.queueEvents<EmailPayload>({ queue: 'emails', fromOffset: 0 })
+const retained = queueEvents.readSince(0)
+for (const event of retained) {
+  event.type satisfies
+    | 'enqueued'
+    | 'claimed'
+    | 'completed'
+    | 'retry_scheduled'
+    | 'dead_lettered'
+    | 'cancelled'
+  event.payload?.recipient.toUpperCase()
+  event.offset.toFixed(0)
+}
+
 // @ts-expect-error recipient is required by the queue payload contract
 queue.enqueue({ template: 'welcome', variables: {} })
 
 waker.close()
+queueEvents.close()
 db.close()

--- a/packages/honker-node/test/types/typed-jobs.ts
+++ b/packages/honker-node/test/types/typed-jobs.ts
@@ -1,4 +1,4 @@
-import { open, type Job, type JobSnapshot } from '../..'
+import { open, type Job, type JobSnapshot, type QueueEventReason } from '../..'
 
 interface EmailPayload {
   recipient: string
@@ -43,8 +43,16 @@ outbox.enqueue({
   variables: {},
 })
 
-db.configureQueueEvents({ maxEvents: 10_000, includePayload: true })
+db.configureQueueEvents({ retentionTarget: 10_000, includePayload: true })
 const queueEvents = db.queueEvents<EmailPayload>({ queue: 'emails', fromOffset: 0 })
+const queueEventListener = db.queueEventListener<EmailPayload>({
+  queue: 'emails',
+  startAt: 'latest',
+})
+queueEventListener.on('enqueued', (event) => {
+  event.payload?.recipient.toUpperCase()
+  event.reason satisfies QueueEventReason | null
+})
 const retained = queueEvents.readSince(0)
 for (const event of retained) {
   event.type satisfies
@@ -64,4 +72,5 @@ queue.enqueue({ template: 'welcome', variables: {} })
 waker.close()
 void queueEvents.return()
 queueEvents.close()
+queueEventListener.close()
 db.close()

--- a/packages/honker-node/wrapper.d.ts
+++ b/packages/honker-node/wrapper.d.ts
@@ -35,6 +35,11 @@ export interface StreamEvent {
   createdAt: number | null
 }
 
+/**
+ * Queue lifecycle event names. `error` and `close` are reserved by
+ * QueueEventListener's EventEmitter contract and must not become lifecycle
+ * event types.
+ */
 export type QueueEventType =
   | 'enqueued'
   | 'claimed'

--- a/packages/honker-node/wrapper.d.ts
+++ b/packages/honker-node/wrapper.d.ts
@@ -77,7 +77,19 @@ export interface QueueEventsOptions {
 
 export interface QueueEventsConfig {
   enabled?: boolean
+  /**
+   * Approximate number of events to retain. Counts events, not bytes, and has
+   * no time-based expiry: an event stays until `retentionTarget` newer ones
+   * push it out. Budget for it — with `includePayload` on, the feed costs
+   * roughly `retentionTarget` x payload size on top of the queue, in the same
+   * SQLite file. 1 to 1,000,000; defaults to 10,000.
+   */
   retentionTarget?: number
+  /**
+   * Store a copy of each job's payload on its events. Feed-wide: enabling it
+   * to inspect one queue captures payloads for every queue. The copy outlives
+   * the job row, which is deleted on completion. Defaults to false.
+   */
   includePayload?: boolean
 }
 

--- a/packages/honker-node/wrapper.d.ts
+++ b/packages/honker-node/wrapper.d.ts
@@ -43,6 +43,11 @@ export type QueueEventType =
   | 'dead_lettered'
   | 'cancelled'
 
+export type QueueEventReason =
+  | 'explicit_failure'
+  | 'attempts_exhausted'
+  | 'job_expired'
+
 export class QueueEvent<TPayload = JsonValue> {
   readonly version: 1
   readonly offset: number
@@ -53,6 +58,7 @@ export class QueueEvent<TPayload = JsonValue> {
   readonly attempts: number
   readonly workerId: string | null
   readonly runAt: number | null
+  readonly reason: QueueEventReason | null
   readonly error: string | null
   readonly payload?: TPayload
 }
@@ -66,8 +72,24 @@ export interface QueueEventsOptions {
 
 export interface QueueEventsConfig {
   enabled?: boolean
-  maxEvents?: number
+  retentionTarget?: number
   includePayload?: boolean
+}
+
+export interface QueueEventListenerOptions extends Omit<QueueEventsOptions, 'fromOffset'> {
+  fromOffset?: number
+  startAt?: 'latest' | 'oldest'
+}
+
+export class QueueEventOffsetExpiredError extends Error {
+  readonly code: 'HONKER_QUEUE_EVENT_OFFSET_EXPIRED'
+  readonly requestedOffset: number
+  readonly trimmedThroughOffset: number
+  readonly oldestAvailableOffset: number | null
+}
+
+export class QueueEventsDisabledError extends Error {
+  readonly code: 'HONKER_QUEUE_EVENTS_DISABLED'
 }
 
 export class CheckpointMigrationError extends Error {
@@ -195,6 +217,23 @@ export class QueueEvents<TPayload = JsonValue>
   close(): void
 }
 
+export class QueueEventListener<TPayload = JsonValue> {
+  readonly lastOffset: number
+  on(type: QueueEventType, listener: (event: QueueEvent<TPayload>) => void): this
+  on(type: 'event', listener: (event: QueueEvent<TPayload>) => void): this
+  on(type: 'error', listener: (error: Error) => void): this
+  on(type: 'close', listener: () => void): this
+  once(type: QueueEventType, listener: (event: QueueEvent<TPayload>) => void): this
+  once(type: 'event', listener: (event: QueueEvent<TPayload>) => void): this
+  once(type: 'error', listener: (error: Error) => void): this
+  once(type: 'close', listener: () => void): this
+  off(type: QueueEventType, listener: (event: QueueEvent<TPayload>) => void): this
+  off(type: 'event', listener: (event: QueueEvent<TPayload>) => void): this
+  off(type: 'error', listener: (error: Error) => void): this
+  off(type: 'close', listener: () => void): this
+  close(): void
+}
+
 export class Stream {
   publish(payload: JsonValue): number
   publishWithKey(key: string, payload: JsonValue): number
@@ -271,6 +310,7 @@ export class Database {
   notifyTx(tx: Transaction | any, channel: string, payload: JsonValue): number
   configureQueueEvents(opts?: QueueEventsConfig): boolean
   queueEvents<TPayload = JsonValue>(opts?: QueueEventsOptions): QueueEvents<TPayload>
+  queueEventListener<TPayload = JsonValue>(opts?: QueueEventListenerOptions): QueueEventListener<TPayload>
   queue<TPayload = JsonValue>(name: string, opts?: QueueOptions): Queue<TPayload>
   outbox<TPayload = JsonValue>(name: string, delivery: (payload: TPayload, job: Job<TPayload>) => any | Promise<any>, opts?: OutboxOptions): Outbox<TPayload>
   stream(name: string): Stream

--- a/packages/honker-node/wrapper.d.ts
+++ b/packages/honker-node/wrapper.d.ts
@@ -190,6 +190,7 @@ export class QueueEvents<TPayload = JsonValue>
   readonly lastOffset: number
   readSince(offset: number, limit?: number): QueueEvent<TPayload>[]
   next(): Promise<IteratorResult<QueueEvent<TPayload>>>
+  return(): Promise<IteratorResult<QueueEvent<TPayload>>>
   [Symbol.asyncIterator](): AsyncIterableIterator<QueueEvent<TPayload>>
   close(): void
 }

--- a/packages/honker-node/wrapper.d.ts
+++ b/packages/honker-node/wrapper.d.ts
@@ -35,6 +35,41 @@ export interface StreamEvent {
   createdAt: number | null
 }
 
+export type QueueEventType =
+  | 'enqueued'
+  | 'claimed'
+  | 'completed'
+  | 'retry_scheduled'
+  | 'dead_lettered'
+  | 'cancelled'
+
+export class QueueEvent<TPayload = JsonValue> {
+  readonly version: 1
+  readonly offset: number
+  readonly type: QueueEventType
+  readonly queue: string
+  readonly jobId: number
+  readonly occurredAt: number
+  readonly attempts: number
+  readonly workerId: string | null
+  readonly runAt: number | null
+  readonly error: string | null
+  readonly payload?: TPayload
+}
+
+export interface QueueEventsOptions {
+  queue?: string | null
+  fromOffset?: number
+  fallbackPollS?: number | null
+  signal?: AbortSignal | null
+}
+
+export interface QueueEventsConfig {
+  enabled?: boolean
+  maxEvents?: number
+  includePayload?: boolean
+}
+
 export class CheckpointMigrationError extends Error {
   readonly code: 'HONKER_CHECKPOINT_MIGRATION_UNVERIFIABLE'
   readonly stream: string
@@ -149,6 +184,16 @@ export class StreamSubscription implements AsyncIterableIterator<StreamEvent> {
   close(): void
 }
 
+export class QueueEvents<TPayload = JsonValue>
+  implements AsyncIterableIterator<QueueEvent<TPayload>> {
+  readonly queue: string | null
+  readonly lastOffset: number
+  readSince(offset: number, limit?: number): QueueEvent<TPayload>[]
+  next(): Promise<IteratorResult<QueueEvent<TPayload>>>
+  [Symbol.asyncIterator](): AsyncIterableIterator<QueueEvent<TPayload>>
+  close(): void
+}
+
 export class Stream {
   publish(payload: JsonValue): number
   publishWithKey(key: string, payload: JsonValue): number
@@ -223,6 +268,8 @@ export class Database {
   pruneNotifications(olderThanS?: number | null, maxKeep?: number | null): number
   notify(channel: string, payload: JsonValue): number
   notifyTx(tx: Transaction | any, channel: string, payload: JsonValue): number
+  configureQueueEvents(opts?: QueueEventsConfig): boolean
+  queueEvents<TPayload = JsonValue>(opts?: QueueEventsOptions): QueueEvents<TPayload>
   queue<TPayload = JsonValue>(name: string, opts?: QueueOptions): Queue<TPayload>
   outbox<TPayload = JsonValue>(name: string, delivery: (payload: TPayload, job: Job<TPayload>) => any | Promise<any>, opts?: OutboxOptions): Outbox<TPayload>
   stream(name: string): Stream

--- a/tests/test_extension_interop.py
+++ b/tests/test_extension_interop.py
@@ -652,6 +652,74 @@ def test_extension_enqueue_returns_id_without_wake_row(ext_db_path):
 
 
 @pytest.mark.skipif(_SKIP, reason=_SKIP_REASON)
+def test_extension_queue_events_are_transactional_bounded_and_gap_aware(ext_db_path):
+    """Exercise queue events entirely through the shipped loadable extension.
+
+    This covers the user-facing SQL ABI, transaction rollback, unrelated stream
+    traffic, topic-specific retention, payloads, stale checkpoints, and the
+    reserved-topic guard without relying on either language binding.
+    """
+    conn = _open_ext(ext_db_path)
+    assert conn.execute(
+        "SELECT honker_queue_events_configure(1, 3, 1)"
+    ).fetchone()[0] == 1
+    conn.commit()
+
+    conn.execute("BEGIN IMMEDIATE")
+    conn.execute(
+        "SELECT honker_enqueue('events', '{\"sequence\":0}', NULL, NULL, 0, 3, NULL)"
+    )
+    conn.rollback()
+    assert (
+        json.loads(
+            conn.execute(
+                "SELECT honker_queue_events_read_since(0, NULL, 100)"
+            ).fetchone()[0]
+        )
+        == []
+    )
+
+    for sequence in range(1, 6):
+        conn.execute(
+            "SELECT honker_enqueue('events', ?, NULL, NULL, 0, 3, NULL)",
+            [json.dumps({"sequence": sequence})],
+        )
+        conn.execute(
+            "SELECT honker_stream_publish('application', NULL, ?)",
+            [json.dumps({"sequence": sequence})],
+        )
+        conn.commit()
+
+    status = json.loads(
+        conn.execute("SELECT honker_queue_events_status()").fetchone()[0]
+    )
+    assert status["trimmed_through_offset"] > 0
+    with pytest.raises(sqlite3.OperationalError):
+        conn.execute(
+            "SELECT honker_queue_events_read_since(0, NULL, 100)"
+        ).fetchone()
+
+    retained = json.loads(
+        conn.execute(
+            "SELECT honker_queue_events_read_since(?, NULL, 100)",
+            [status["trimmed_through_offset"]],
+        ).fetchone()[0]
+    )
+    assert [event["type"] for event in retained] == ["enqueued"] * 3
+    assert [event["payload"]["sequence"] for event in retained] == [3, 4, 5]
+    assert all(event["queue"] == "events" for event in retained)
+    assert conn.execute(
+        "SELECT COUNT(*) FROM _honker_stream WHERE topic = 'application'"
+    ).fetchone()[0] == 5
+
+    with pytest.raises(sqlite3.OperationalError):
+        conn.execute(
+            "SELECT honker_stream_publish('_honker:queue-events:v1', NULL, '{}')"
+        ).fetchone()
+    conn.close()
+
+
+@pytest.mark.skipif(_SKIP, reason=_SKIP_REASON)
 def test_extension_enqueue_delay_overrides_run_at(ext_db_path):
     """Delay wins over run_at per the documented precedence."""
     conn = _open_ext(ext_db_path)

--- a/tests/test_performance_floors.py
+++ b/tests/test_performance_floors.py
@@ -129,6 +129,50 @@ def test_disabled_queue_events_do_not_multiply_ack_batch_cost(db_path):
     )
 
 
+def test_enabled_queue_events_stay_amortized_at_retention_target(db_path):
+    """Reaching retention must not add a trim query/delete per event.
+
+    Compare equal transactional enqueue batches immediately before and after
+    the feed reaches its target. This specifically exercises the steady-state
+    path that a benchmark against an empty event feed misses.
+    """
+    retention_target = 2_000
+    db = honker.open(db_path)
+    with db.transaction() as tx:
+        tx.query(
+            "SELECT honker_queue_events_configure(1, ?, 0)",
+            [retention_target],
+        )
+    # Reopen so the timed writer starts with a normal committed config cache.
+    db.close()
+    db = honker.open(db_path)
+    queue = db.queue("perf-retention")
+
+    t0 = time.perf_counter()
+    with db.transaction() as tx:
+        for i in range(retention_target):
+            queue.enqueue({"phase": "fill", "i": i}, tx=tx)
+    fill_seconds = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    with db.transaction() as tx:
+        for i in range(retention_target):
+            queue.enqueue({"phase": "steady", "i": i}, tx=tx)
+    steady_seconds = time.perf_counter() - t0
+
+    assert steady_seconds < fill_seconds * 2.0 + 0.050, (
+        f"queue events took {steady_seconds:.4f}s at the retention target "
+        f"versus {fill_seconds:.4f}s while filling it. Likely trimming on "
+        "every lifecycle event instead of in bounded chunks."
+    )
+    retained = db.query(
+        "SELECT COUNT(*) AS c FROM _honker_stream "
+        "WHERE topic = '_honker:queue-events:v1'"
+    )[0]["c"]
+    trim_interval = min(1_000, max(1, retention_target // 10))
+    assert retention_target <= retained < retention_target + trim_interval
+
+
 async def test_notify_listener_receive_floor(db_path):
     """100 notifies delivered to a listener must be observed within
     1 second end-to-end. Measured ~4ms on M-series. A 250x slowdown

--- a/tests/test_performance_floors.py
+++ b/tests/test_performance_floors.py
@@ -18,6 +18,8 @@ for that. These catch order-of-magnitude regressions only.
 """
 
 import asyncio
+import json
+import statistics
 import time
 
 import pytest
@@ -71,6 +73,59 @@ def test_claim_batch_throughput_floor(db_path):
         f"claim_batch 10k took {elapsed:.3f}s (floor: 3.0s). "
         f"Likely regression in the _honker_live_claim partial index "
         f"or honker_claim_batch."
+    )
+
+
+def test_disabled_queue_events_do_not_multiply_ack_batch_cost(db_path):
+    """The disabled event path must stay close to the lean DELETE.
+
+    Queue events originally materialized every job payload and queried
+    configuration once per ack even while disabled, making a 5k ack batch
+    roughly 6x slower. Compare the public UDF with its underlying DELETE so
+    that regression trips independently of runner speed.
+    """
+    db = honker.open(db_path)
+    direct_times = []
+    udf_times = []
+
+    for round_number in range(3):
+        direct_q = db.queue(f"perf-ack-direct-{round_number}")
+        udf_q = db.queue(f"perf-ack-udf-{round_number}")
+        with db.transaction() as tx:
+            for i in range(5_000):
+                direct_q.enqueue({"i": i}, tx=tx)
+                udf_q.enqueue({"i": i}, tx=tx)
+
+        direct_jobs = direct_q.claim_batch("direct-worker", 5_000)
+        udf_jobs = udf_q.claim_batch("udf-worker", 5_000)
+        direct_ids = [job.id for job in direct_jobs]
+        udf_ids = [job.id for job in udf_jobs]
+
+        t0 = time.perf_counter()
+        with db.transaction() as tx:
+            tx.execute(
+                "DELETE FROM _honker_live "
+                "WHERE id IN (SELECT value FROM json_each(?)) "
+                "AND worker_id = ? AND claim_expires_at >= unixepoch()",
+                [json.dumps(direct_ids), "direct-worker"],
+            )
+        direct_times.append(time.perf_counter() - t0)
+        assert db.query(
+            "SELECT COUNT(*) AS c FROM _honker_live WHERE queue = ?",
+            [direct_q.name],
+        )[0]["c"] == 0
+
+        t0 = time.perf_counter()
+        assert udf_q.ack_batch(udf_ids, "udf-worker") == 5_000
+        udf_times.append(time.perf_counter() - t0)
+
+    direct_median = statistics.median(direct_times)
+    udf_median = statistics.median(udf_times)
+    bound = direct_median * 2.0 + 0.010
+    assert udf_median < bound, (
+        f"disabled queue-event ack_batch took {udf_median:.4f}s versus "
+        f"{direct_median:.4f}s for the lean DELETE (bound: {bound:.4f}s). "
+        "Likely repeated config reads or payload materialization."
     )
 
 


### PR DESCRIPTION
## Summary

- add an opt-in Rust-core queue lifecycle feed backed by Honker streams
- append `enqueued`, `claimed`, `completed`, `retry_scheduled`, `dead_lettered`, and `cancelled` events in the same SQLite transaction as each successful state change
- expose both a typed Node async iterator and an EventEmitter-style listener over the same durable cross-process feed
- make retention topic-specific and globally coordinated, detect stale replay checkpoints, and attach stable typed reasons to terminal events
- keep the public binding in this draft TypeScript/Node only; the implementation and SQL ABI live in `honker-core`

This PR is stacked on #124 so the typed job API is reviewed first. Refs #123.

## Deliberate scope

This is a bounded observability feed for dashboards, metrics, and debugging—not a permanent audit log or exactly-once business event bus. It does not add named consumers, delivery acknowledgements, progress events, worker telemetry, lease-expiry polling, per-queue configuration, or bindings beyond Node.

Configuration is persisted once per database. Queue events are opt-in and payload capture is off by default. `includePayload` is feed-wide, which is documented explicitly.

## Retention and replay

The public option is `retentionTarget`, not `maxEvents`, because cleanup is intentionally amortized. The Rust core counts only the reserved queue-event topic, trims periodically in bounded chunks, and never lets unrelated `db.stream()` traffic consume queue-event retention.

Trim scheduling is persisted in the singleton configuration row and updated in the same queue transaction, so short-lived connections and multiple processes share one rollback-safe counter. Actual threshold scans and deletes remain periodic; they do not run on every queue state change. Lowering the target trims existing events immediately.

The core persists `trimmed_through_offset`. An explicit stale `fromOffset` throws `QueueEventOffsetExpiredError` with the requested offset, trim watermark, and oldest available offset. Omitting `fromOffset` starts at the oldest retained event. The EventEmitter adapter defaults to the latest offset for familiar live-listener behavior and throws `QueueEventsDisabledError` when the feed has not been enabled.

Terminal events separate stable machine-readable `reason` values (`explicit_failure`, `attempts_exhausted`, and `job_expired`) from human-readable error text.

## Performance

- disabled producers retain the original lean SQL paths and do not serialize event JSON, parse/copy payloads, insert stream rows, or update retention accounting
- enabled producers add one small transactional counter update per successful queue mutation; batch transitions update it once for the batch
- configuration is cached per connection for 100 ms; payload JSON is parsed only when `includePayload` is enabled
- a steady-state performance floor fills the feed to its target before measuring, specifically guarding against per-event cleanup regressions
- local 10,000-job transactional measurement: disabled ~40.8k enqueues/s, enabled fill ~17.3k/s, and enabled at target ~16.8k/s; reaching retention does not produce a cleanup cliff

## Verification

- `cargo test -p honker-core --release` — 71 passed, 1 intentional soak test ignored
- feature-enabled bundled-SQLite Rust suite — 84 passed, 6 intentional watcher/soak ignores
- `make lint` — rustfmt and Clippy pass with default and watcher feature sets
- `npm test` — 97 passed, 18 feature-gated skips
- `.venv/bin/pytest -q` — 300 passed, 19 platform/feature skips on macOS
- queue-event performance floors — 2 passed; 10,000-job benchmark run recorded above
- TypeScript declaration compile test for payloads, reasons, iterators, and listeners
- Node integration coverage for rollback, topic-specific retention amid unrelated stream traffic, replay gaps, redaction, filtering, terminal reasons, disable persistence, listener validation/cleanup, reserved-topic protection, retention across fresh connections, and typed errors and configure-driven self-healing for pre-event schemas
- cross-process Node producer/worker E2E through the EventEmitter listener and durable replay iterator
- automated SQLite loadable-extension E2E for transaction rollback, topic-specific retention, stale-checkpoint detection, payloads, unrelated stream preservation, and reserved-topic rejection
- Rust coverage for schema migration, cross-connection refresh and retention churn, rollback-safe accounting, immediate reconfiguration trimming, pre-event schemas, scheduler enqueues, batch transitions, and chunked production retention
