### PR TITLE
release: bump the Node package to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
 
+## 2026-08-27 — Node 0.5.1
+
+- Node `@russellthehippo/honker-node`: 0.5.1, with the four
+  `honker-node-<platform>` packages moved to 0.5.1 alongside it. The fix
+  is JavaScript only and the Rust addon is unchanged, but the loader
+  pins the native package version exactly, so the natives release in
+  lockstep. `honker-ext-<platform>` is untouched and stays at 0.4.6.
+- `claimWaker().next()` no longer parks on `idlePollS` after a `runAt`
+  deadline it was waiting for has passed. `honker_queue_next_claim_at`
+  only reports deadlines still in the future, so it returns 0 the moment
+  one arrives; if the claim taken at that instant came back empty — a
+  writer holding the lock past the 5 s `busy_timeout`, or another worker
+  taking the row — the waker had nothing to park on and slept the whole
+  idle interval on a queue with claimable work. A worker using `runAt`
+  with a long `idlePollS` could stall well past its deadline under write
+  contention. The waker now retries briefly instead. A queue that was
+  never waiting on a deadline polls exactly as before.
+- Regression test claims a job at a deadline with one claim forced to
+  return empty: it fails on the unpatched `api.js` and passes on the fix.
+
 ## Unreleased — Node checkpoint interoperability (Phase Robinson)
 
 - Node stream checkpoint calls now use the shared SQL ABI's canonical

--- a/packages/honker-node/Cargo.toml
+++ b/packages/honker-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honker-node"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/packages/honker-node/index.js
+++ b/packages/honker-node/index.js
@@ -77,7 +77,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-android-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -93,7 +93,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-android-arm-eabi')
         const bindingPackageVersion = require('@russellthehippo/honker-node-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -114,7 +114,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-x64-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -130,7 +130,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-x64-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -147,7 +147,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-ia32-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -163,7 +163,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-win32-arm64-msvc')
         const bindingPackageVersion = require('@russellthehippo/honker-node-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -182,7 +182,7 @@ function requireNative() {
     try {
       const binding = require('@russellthehippo/honker-node-darwin-universal')
       const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+      if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
         throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
@@ -198,7 +198,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-darwin-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -214,7 +214,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-darwin-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -234,7 +234,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-freebsd-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -250,7 +250,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-freebsd-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -271,7 +271,7 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-x64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
@@ -287,7 +287,7 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-x64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
@@ -305,7 +305,7 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
@@ -321,7 +321,7 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
@@ -339,7 +339,7 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm-musleabihf')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
@@ -355,7 +355,7 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
@@ -373,7 +373,7 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-loong64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
@@ -389,7 +389,7 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-loong64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
@@ -407,7 +407,7 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-riscv64-musl')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
@@ -423,7 +423,7 @@ function requireNative() {
         try {
           const binding = require('@russellthehippo/honker-node-linux-riscv64-gnu')
           const bindingPackageVersion = require('@russellthehippo/honker-node-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
@@ -440,7 +440,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-linux-ppc64-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -456,7 +456,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-linux-s390x-gnu')
         const bindingPackageVersion = require('@russellthehippo/honker-node-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -476,7 +476,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-arm64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -492,7 +492,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-x64')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
@@ -508,7 +508,7 @@ function requireNative() {
       try {
         const binding = require('@russellthehippo/honker-node-openharmony-arm')
         const bindingPackageVersion = require('@russellthehippo/honker-node-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.5.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        if (bindingPackageVersion !== '0.5.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 0.5.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding

--- a/packages/honker-node/npm/darwin-arm64/package.json
+++ b/packages/honker-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-darwin-arm64",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "cpu": [
     "arm64"
   ],

--- a/packages/honker-node/npm/darwin-x64/package.json
+++ b/packages/honker-node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-darwin-x64",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "cpu": [
     "x64"
   ],

--- a/packages/honker-node/npm/linux-arm64-gnu/package.json
+++ b/packages/honker-node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-linux-arm64-gnu",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "cpu": [
     "arm64"
   ],

--- a/packages/honker-node/npm/linux-x64-gnu/package.json
+++ b/packages/honker-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node-linux-x64-gnu",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "cpu": [
     "x64"
   ],

--- a/packages/honker-node/package-lock.json
+++ b/packages/honker-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@russellthehippo/honker-node",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@russellthehippo/honker-node",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"
@@ -19,10 +19,10 @@
         "@russellthehippo/honker-ext-darwin-x64": "0.4.6",
         "@russellthehippo/honker-ext-linux-arm64-gnu": "0.4.6",
         "@russellthehippo/honker-ext-linux-x64-gnu": "0.4.6",
-        "@russellthehippo/honker-node-darwin-arm64": "0.5.0",
-        "@russellthehippo/honker-node-darwin-x64": "0.5.0",
-        "@russellthehippo/honker-node-linux-arm64-gnu": "0.5.0",
-        "@russellthehippo/honker-node-linux-x64-gnu": "0.5.0"
+        "@russellthehippo/honker-node-darwin-arm64": "0.5.1",
+        "@russellthehippo/honker-node-darwin-x64": "0.5.1",
+        "@russellthehippo/honker-node-linux-arm64-gnu": "0.5.1",
+        "@russellthehippo/honker-node-linux-x64-gnu": "0.5.1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1657,74 +1657,16 @@
       ]
     },
     "node_modules/@russellthehippo/honker-node-darwin-arm64": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-darwin-arm64/-/honker-node-darwin-arm64-0.5.0.tgz",
-      "integrity": "sha512-74MEi4yKbDtiw8NweqkHYa0Ou/TdtmgkflmxKLbNZdbyMwbacOtquVGThWXsU1d+TLjrH7PIhYL8mmx4W3Jdag==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@russellthehippo/honker-node-darwin-x64": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-darwin-x64/-/honker-node-darwin-x64-0.5.0.tgz",
-      "integrity": "sha512-WGV3Wp7Ari9s4PaQS78QdXdc1NBw3TfL5DW5ubtj0PYtgtfbwc/5r83hAU5EuD0RH6YTkTnd3nPKqIe0qE90qw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@russellthehippo/honker-node-linux-arm64-gnu": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-linux-arm64-gnu/-/honker-node-linux-arm64-gnu-0.5.0.tgz",
-      "integrity": "sha512-8Ljln6Lifeg2642LIpBjo3yTPds44kmxraijcFSGOyd4y9QcYEIVDiyKHuur0JpiZmALOqmmYZpDh4f2bl/Kuw==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@russellthehippo/honker-node-linux-x64-gnu": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-linux-x64-gnu/-/honker-node-linux-x64-gnu-0.5.0.tgz",
-      "integrity": "sha512-pyvvJz24uNq88HzZRZ6m9gu+bgT1SSdk6qPhaXEX41r3a8TSHCYspvXxpYHyXTCIlVZpVXtawS2p4qUU76dj8A==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",

--- a/packages/honker-node/package.json
+++ b/packages/honker-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@russellthehippo/honker-node",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Node binding for honker \u2014 durable queues, streams, pub/sub, and scheduler on SQLite.",
   "main": "wrapper.js",
   "types": "wrapper.d.ts",
@@ -58,10 +58,10 @@
     "url": "https://github.com/russellromney/honker"
   },
   "optionalDependencies": {
-    "@russellthehippo/honker-node-darwin-arm64": "0.5.0",
-    "@russellthehippo/honker-node-darwin-x64": "0.5.0",
-    "@russellthehippo/honker-node-linux-x64-gnu": "0.5.0",
-    "@russellthehippo/honker-node-linux-arm64-gnu": "0.5.0",
+    "@russellthehippo/honker-node-darwin-arm64": "0.5.1",
+    "@russellthehippo/honker-node-darwin-x64": "0.5.1",
+    "@russellthehippo/honker-node-linux-x64-gnu": "0.5.1",
+    "@russellthehippo/honker-node-linux-arm64-gnu": "0.5.1",
     "@russellthehippo/honker-ext-darwin-arm64": "0.4.6",
     "@russellthehippo/honker-ext-darwin-x64": "0.4.6",
     "@russellthehippo/honker-ext-linux-x64-gnu": "0.4.6",


### PR DESCRIPTION
## Summary

Bumps `@russellthehippo/honker-node` to 0.5.1 so the claim waker deadline
fix from #122 reaches npm. 0.5.0 is the newest published version and the
bug is in it.

The fix is JavaScript only, but honker-node versions in lockstep. The
generated `index.js` loader pins each native package version exactly, and
`check-node-version-alignment.py` enforces that `Cargo.toml`, the four
`npm/<platform>/package.json` manifests, the `optionalDependencies` pins,
the lockfile, and the loader all carry the same version. So the four
`honker-node-<platform>` packages move to 0.5.1 alongside it, rebuilt from
unchanged Rust source. `honker-ext-<platform>` is a separate alignment
group and stays at 0.4.6.

## The bug being released

`honker_queue_next_claim_at` only reports deadlines still in the future,
so it returns 0 the moment one arrives. If the claim taken at that
instant came back empty — a writer holding the lock past the 5 s
`busy_timeout`, or another worker taking the row — `claimWaker().next()`
had nothing to park on and slept the whole `idlePollS` interval on a
queue with claimable work.

## Verification

- `check-node-version-alignment.py` — ok: 0.5.1 (4 platform packages, 26 loader checks)
- `check-ext-version-alignment.py` — ok: 8 pins at 0.4.6
- `node --test test/api.test.js test/basic.js test/parity.test.js test/phase_mantle.js` — 71 passed, 0 failed
- lockfile regenerated in the same commit as the bump

## After merge

Tag `node-v0.5.1` to build the natives, publish the four platform
packages and then `honker-node@0.5.1`, and regenerate `package-lock.json`
and `bun.lock` in the same pass — publishing pinned optional deps makes
both lockfiles stale and reds CI otherwise.