### PR TITLE
fix(ci): refresh the node lockfile after publishing the 0.5.1 natives

### DIFF
--- a/packages/honker-node/package-lock.json
+++ b/packages/honker-node/package-lock.json
@@ -1657,16 +1657,74 @@
       ]
     },
     "node_modules/@russellthehippo/honker-node-darwin-arm64": {
-      "optional": true
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-darwin-arm64/-/honker-node-darwin-arm64-0.5.1.tgz",
+      "integrity": "sha512-s87nEcQh5/5ifwX/+c7eaQQslM6T0gHed7s1sd4p1l1Mv+PJcELOQKj6s+S2L/dck7u9FdmgNgbZ3lnH7UlXew==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@russellthehippo/honker-node-darwin-x64": {
-      "optional": true
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-darwin-x64/-/honker-node-darwin-x64-0.5.1.tgz",
+      "integrity": "sha512-ua8UeON4koctANlEiEJzrII/IWRjz6xFLfatzErfhtksOJhvqUSw+Gg3yMLmWRnd5dHmWctgTbcot6x/c8b23g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@russellthehippo/honker-node-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-linux-arm64-gnu/-/honker-node-linux-arm64-gnu-0.5.1.tgz",
+      "integrity": "sha512-LGB67rNLG8mNiOzuE79I3nYk4UmgBWioLBnUAd/47PjoKCnt5YrB7R+t+gGCUncW+PqEsdxET6uPHACMvs1S6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@russellthehippo/honker-node-linux-x64-gnu": {
-      "optional": true
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@russellthehippo/honker-node-linux-x64-gnu/-/honker-node-linux-x64-gnu-0.5.1.tgz",
+      "integrity": "sha512-IGo/hSI7bqJdrjAQXkvzhmuJ+UPMj/D4w+afKW7Ro9Hfj5AEUKPAf7184FlnNWlRyLIw0H6ZmXTAwxKOcOfb/A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",


### PR DESCRIPTION
`main` is red without this. Publishing the four `honker-node-<platform>`
packages at 0.5.1 made their lockfile entries resolvable, and the entries
recorded while they were unpublished carry no `version` and no `resolved`:

```
npm error Invalid: lock file's @russellthehippo/honker-node-darwin-arm64@
  does not satisfy @russellthehippo/honker-node-darwin-arm64@0.5.1
```

Nothing in the repo changed. The lockfile is stale only relative to a
registry that moved underneath it, which is the same failure #118 fixed
after the 0.5.0 natives.

`bun.lock` only pins `honker-ext` at 0.4.6, which did not move, so it
needs no refresh.

## Verification

- `npm ci` against the pre-refresh lockfile and the live registry — fails with the four Invalid lines above
- `npm ci` against the refreshed lockfile — installs clean