### PR TITLE
feat(go): expose every claimed-job field and typed payload decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@
 - Regression test claims a job at a deadline with one claim forced to
   return empty: it fails on the unpatched `api.js` and passes on the fix.
 
+## Unreleased — full job details in the Go binding
+
+- Go `Job` now carries every field `honker_claim_batch` returns: `State`,
+  `Priority`, `RunAt`, `ClaimExpiresAt`, `MaxAttempts`, `CreatedAt`, and
+  `ExpiresAt` join the existing `ID`, `Queue`, `Payload`, `WorkerID`, and
+  `Attempts`. A claimed `Job` and a `GetJob` snapshot (`JobRow`) now describe
+  the same twelve columns; `Job` keeps `Ack` / `Retry` / `Fail` / `Heartbeat`
+  and `JobRow` stays data only. Purely additive — no existing field changed
+  name, type, or meaning.
+- New `honker.DecodePayload[T]` unmarshals a payload into a caller-owned type,
+  plus `JobRow.PayloadBytes()` so a snapshot decodes through the same path as
+  a claimed job. The type parameter is a compile-time contract; Honker still
+  does not validate payload shape in the database.
+- `TestClaimedJobAndSnapshotCarryEveryField` enqueues with a priority, TTL, and
+  max-attempts, asserts each of the twelve fields on the pending snapshot, the
+  claimed job, and a second `Database` handle's processing snapshot, then
+  asserts the reader gets nothing after ack.
+  `TestDelayedJobReportsItsRunAt` asserts a delayed job's `RunAt` and that it
+  is not claimable early.
+
 ## Unreleased — typed Node jobs
 
 - Node `Queue`, `Job`, `JobSnapshot`, `ClaimWaker`, and `Outbox` APIs now carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,33 @@
 - `DecodePayload` now returns an error on an empty payload instead of the zero
   value with a nil error. The core never emits an empty payload, so empty means
   the bytes never arrived, and a caller could not tell that apart from a clean
-  decode.
+  decode. That error is the exported sentinel `honker.ErrEmptyPayload`, wrapped
+  with `%w`, so a caller can tell "the bytes never arrived" from "the bytes did
+  not match `T`" with `errors.Is` instead of matching message text.
+- Documented the claim-time snapshot semantics of `Job`: `Ack` / `Retry` /
+  `Fail` / `Heartbeat` change the row in the database and do not write back to
+  the struct, so `job.ClaimExpiresAt` stays at its claim-time value after a
+  heartbeat. Also documented that `Queue.GetJob` is not queue-scoped, which
+  matters now that the README points it at `DecodePayload`: another queue's
+  payload decodes into your type with zero-valued fields and no error.
+- Go README: the quick start, the delayed-job example, and the scheduler
+  example did not compile (`db.Queue("emails")`, `q.Enqueue(payload)`,
+  `honker.RunAt(...)` — which does not exist — and the old positional
+  `Scheduler.Add`). Rewritten against the real signatures. The new typed-payload
+  example also called `row.PayloadBytes()` on the result of `q.GetJob(id)`
+  without checking for `nil`, which panics on a miss; it now checks the error
+  and the nil row.
+- `TestClaimBatchKeepsEachRowsOwnFields` claims two jobs in one `ClaimBatch`
+  call and pins each returned `Job` to its own row — id, priority, payload,
+  `ExpiresAt` set vs nil — then acks each job through its own handle. Every
+  other test claims a single job, so a mapping that reads the same element for
+  every job was invisible: `ClaimBatch` could hand every job in a batch the
+  first row's fields and the whole suite stayed green.
+- `TestClaimedJobReportsBackDatedRunAt` and `TestClaimBatchKeepsEachRowsOwnFields`
+  assert `ExpiresAt` is `nil`, not `0`, on a job enqueued without a TTL — on
+  both the claimed `Job` and the `JobRow`. No test covered the null case before,
+  so decoding `expires_at: null` as `0` (a job that "expired in 1970") passed
+  the whole suite.
 - `TestClaimedJobAndSnapshotCarryEveryField` enqueues with a priority, TTL, and
   max-attempts, asserts each of the twelve fields on the pending snapshot, the
   claimed job, and a second `Database` handle's processing snapshot, then
@@ -47,7 +73,9 @@
   `RunAt` (`now - 100`) so the job stays claimable while `RunAt` and `CreatedAt`
   differ, then pins both on the claimed job. Without it the two `json:` tags in
   the claim decode can be transposed and the suite stays green.
-  `TestDecodePayloadRejectsEmptyInput` covers the empty-payload error.
+  `TestDecodePayloadRejectsEmptyInput` covers the empty-payload error, checks
+  it with `errors.Is(err, ErrEmptyPayload)`, and checks that a shape mismatch
+  does *not* match the sentinel.
 
 ## Unreleased — typed Node jobs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,17 @@
   plus `JobRow.PayloadBytes()` so a snapshot decodes through the same path as
   a claimed job. The type parameter is a compile-time contract; Honker still
   does not validate payload shape in the database.
+- `DecodePayload` now returns an error on an empty payload instead of the zero
+  value with a nil error. The core never emits an empty payload, so empty means
+  the bytes never arrived, and a caller could not tell that apart from a clean
+  decode.
 - `TestClaimedJobAndSnapshotCarryEveryField` enqueues with a priority, TTL, and
   max-attempts, asserts each of the twelve fields on the pending snapshot, the
   claimed job, and a second `Database` handle's processing snapshot, then
   asserts the reader gets nothing after ack.
   `TestDelayedJobReportsItsRunAt` asserts a delayed job's `RunAt` and that it
   is not claimable early.
+  `TestDecodePayloadRejectsEmptyInput` covers the empty-payload error.
 
 ## Unreleased — typed Node jobs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
   asserts the reader gets nothing after ack.
   `TestDelayedJobReportsItsRunAt` asserts a delayed job's `RunAt` and that it
   is not claimable early.
+  `TestClaimedJobReportsBackDatedRunAt` enqueues with a back-dated absolute
+  `RunAt` (`now - 100`) so the job stays claimable while `RunAt` and `CreatedAt`
+  differ, then pins both on the claimed job. Without it the two `json:` tags in
+  the claim decode can be transposed and the suite stays green.
   `TestDecodePayloadRejectsEmptyInput` covers the empty-payload error.
 
 ## Unreleased — typed Node jobs

--- a/packages/honker-go/README.md
+++ b/packages/honker-go/README.md
@@ -29,10 +29,11 @@ db, err := honker.Open("app.db", "./libhonker_ext.dylib")
 if err != nil {
     panic(err)
 }
+defer db.Close()
 
-q := db.Queue("emails")
+q := db.Queue("emails", honker.QueueOptions{})
 
-if _, err := q.Enqueue(map[string]any{"to": "alice@example.com"}); err != nil {
+if _, err := q.Enqueue(map[string]any{"to": "alice@example.com"}, honker.EnqueueOptions{}); err != nil {
     panic(err)
 }
 
@@ -42,7 +43,7 @@ if err != nil {
 }
 if job != nil {
     sendEmail(job.Payload)
-    _ = job.Ack()
+    _, _ = job.Ack()
 }
 ```
 
@@ -54,6 +55,15 @@ shape: `ID`, `Queue`, `Payload`, `State`, `Priority`, `RunAt`, `WorkerID`,
 A `Job` also has the claim methods (`Ack`, `Retry`, `Fail`, `Heartbeat`);
 a `JobRow` is data only.
 
+`ExpiresAt` is `*int64` on both types and is `nil` — never `0` — when the job
+was enqueued without a TTL. On a `JobRow`, `WorkerID` and `ClaimExpiresAt` are
+`nil` until a worker claims the job. On a claimed `Job` both are always set,
+so they are plain values.
+
+Every field on a `Job` is a snapshot taken at claim time. `Heartbeat` extends
+the claim in the database but does not refresh `job.ClaimExpiresAt`; re-read
+with `GetJob` if you need the new deadline.
+
 Payloads stay raw JSON. `DecodePayload[T]` unmarshals one into your own type:
 
 ```go
@@ -62,38 +72,66 @@ type Email struct {
     Template string `json:"template"`
 }
 
-job, _ := q.ClaimOne("worker-1")
+job, err := q.ClaimOne("worker-1")
+if err != nil {
+    return err
+}
 if job != nil {
     email, err := honker.DecodePayload[Email](job.Payload)
     if err != nil {
         _, _ = job.Fail(err.Error())
     } else {
         send(email)
-        _ = job.Ack()
+        _, _ = job.Ack()
     }
     fmt.Println(job.State, job.Priority, job.RunAt, job.CreatedAt)
 }
+```
 
-row, _ := q.GetJob(id)
+A `JobRow` decodes through the same helper via `PayloadBytes`. `GetJob`
+returns `(nil, nil)` when the job is gone, so check the row before using it:
+
+```go
+row, err := q.GetJob(id)
+if err != nil {
+    return err
+}
+if row == nil {
+    return fmt.Errorf("job %d is gone", id)
+}
 email, err := honker.DecodePayload[Email](row.PayloadBytes())
 ```
+
+`GetJob` is not queue-scoped: job ids are globally unique and the lookup does
+not filter on the queue, so it can return a row from a different queue whose
+payload is not an `Email` at all. Pass only ids you know this queue owns.
 
 The type parameter is a compile-time contract only. Honker never validates
 payload shape in the database, so every app writing to a queue has to agree on
 the JSON shape itself. A mismatch shows up as an unmarshal error at decode
-time, not at enqueue time.
+time, not at enqueue time. An empty payload returns `honker.ErrEmptyPayload`,
+which you can match with `errors.Is`, rather than a zero-valued `Email`.
 
-Delayed jobs use `RunAt`:
+Delayed jobs use `Delay` (seconds from now) or `RunAt` (absolute unix epoch):
 
 ```go
-_, _ = q.Enqueue(map[string]any{"to": "later@example.com"}, honker.RunAt(time.Now().Unix()+10))
+delay := int64(10)
+_, _ = q.Enqueue(map[string]any{"to": "later@example.com"}, honker.EnqueueOptions{Delay: &delay})
+
+at := time.Now().Unix() + 10
+_, _ = q.Enqueue(map[string]any{"to": "later@example.com"}, honker.EnqueueOptions{RunAt: &at})
 ```
 
 Recurring schedules use `Schedule`:
 
 ```go
 s := db.Scheduler()
-_ = s.Add("fast", "emails", "@every 1s", map[string]any{"kind": "tick"})
+_ = s.Add(honker.ScheduledTask{
+    Name:     "fast",
+    Queue:    "emails",
+    Schedule: "@every 1s",
+    Payload:  map[string]any{"kind": "tick"},
+})
 ```
 
 Supported schedule forms:

--- a/packages/honker-go/README.md
+++ b/packages/honker-go/README.md
@@ -46,6 +46,43 @@ if job != nil {
 }
 ```
 
+### Job details and typed payloads
+
+A claimed `Job` and a `GetJob` snapshot (`JobRow`) both carry the full job
+shape: `ID`, `Queue`, `Payload`, `State`, `Priority`, `RunAt`, `WorkerID`,
+`ClaimExpiresAt`, `Attempts`, `MaxAttempts`, `CreatedAt`, and `ExpiresAt`.
+A `Job` also has the claim methods (`Ack`, `Retry`, `Fail`, `Heartbeat`);
+a `JobRow` is data only.
+
+Payloads stay raw JSON. `DecodePayload[T]` unmarshals one into your own type:
+
+```go
+type Email struct {
+    To       string `json:"to"`
+    Template string `json:"template"`
+}
+
+job, _ := q.ClaimOne("worker-1")
+if job != nil {
+    email, err := honker.DecodePayload[Email](job.Payload)
+    if err != nil {
+        _, _ = job.Fail(err.Error())
+    } else {
+        send(email)
+        _ = job.Ack()
+    }
+    fmt.Println(job.State, job.Priority, job.RunAt, job.CreatedAt)
+}
+
+row, _ := q.GetJob(id)
+email, err := honker.DecodePayload[Email](row.PayloadBytes())
+```
+
+The type parameter is a compile-time contract only. Honker never validates
+payload shape in the database, so every app writing to a queue has to agree on
+the JSON shape itself. A mismatch shows up as an unmarshal error at decode
+time, not at enqueue time.
+
 Delayed jobs use `RunAt`:
 
 ```go

--- a/packages/honker-go/honker.go
+++ b/packages/honker-go/honker.go
@@ -824,6 +824,11 @@ func (r *JobRow) PayloadBytes() []byte {
 	return []byte(r.Payload)
 }
 
+// ErrEmptyPayload is returned by DecodePayload when the payload has no
+// bytes. Match it with errors.Is to tell "the payload never arrived"
+// apart from "the payload did not match T".
+var ErrEmptyPayload = errors.New("empty payload")
+
 // DecodePayload unmarshals a job payload into T.
 //
 //	type Email struct {
@@ -841,14 +846,16 @@ func (r *JobRow) PayloadBytes() []byte {
 // agree on the JSON shape on its own. A payload that does not match T
 // surfaces here as an unmarshal error, not as an enqueue failure.
 //
-// An empty payload is an error, not a zero value. The core never emits
-// one, so empty means the bytes never arrived — a caller must not be
-// handed a zero-valued T that is indistinguishable from a successful
-// decode.
+// An empty payload is an error (ErrEmptyPayload), not a zero value. The
+// core never emits one, so empty means the bytes never arrived — a
+// caller must not be handed a zero-valued T that is indistinguishable
+// from a successful decode. A payload of JSON null is a different case:
+// it decodes to the zero value of T with a nil error, the same as
+// json.Unmarshal, because enqueueing nil is a legitimate choice.
 func DecodePayload[T any](payload []byte) (T, error) {
 	var out T
 	if len(payload) == 0 {
-		return out, errors.New("decode payload: empty payload")
+		return out, fmt.Errorf("decode payload: %w", ErrEmptyPayload)
 	}
 	if err := json.Unmarshal(payload, &out); err != nil {
 		return out, fmt.Errorf("decode payload: %w", err)

--- a/packages/honker-go/honker.go
+++ b/packages/honker-go/honker.go
@@ -84,6 +84,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -839,10 +840,15 @@ func (r *JobRow) PayloadBytes() []byte {
 // payload shape in the database, so every app writing to a queue has to
 // agree on the JSON shape on its own. A payload that does not match T
 // surfaces here as an unmarshal error, not as an enqueue failure.
+//
+// An empty payload is an error, not a zero value. The core never emits
+// one, so empty means the bytes never arrived — a caller must not be
+// handed a zero-valued T that is indistinguishable from a successful
+// decode.
 func DecodePayload[T any](payload []byte) (T, error) {
 	var out T
 	if len(payload) == 0 {
-		return out, nil
+		return out, errors.New("decode payload: empty payload")
 	}
 	if err := json.Unmarshal(payload, &out); err != nil {
 		return out, fmt.Errorf("decode payload: %w", err)

--- a/packages/honker-go/honker.go
+++ b/packages/honker-go/honker.go
@@ -653,14 +653,29 @@ func (q *Queue) EnqueueTx(tx *Transaction, payload any, opts EnqueueOptions) (in
 }
 
 // Job is a claimed unit of work. Payload is raw JSON bytes — unmarshal
-// into your own struct via json.Unmarshal(job.Payload, &dst).
+// into your own struct with json.Unmarshal(job.Payload, &dst), or with
+// the DecodePayload helper.
+//
+// A claimed Job carries the same twelve fields as a JobRow snapshot,
+// plus the claim methods (Ack, Retry, Fail, Heartbeat). WorkerID and
+// ClaimExpiresAt are always set: the claim UPDATE writes both. State is
+// "processing" by construction. ExpiresAt is nil when the job was
+// enqueued without EnqueueOptions.Expires.
 type Job struct {
-	q        *Queue
-	ID       int64
-	Queue    string
-	Payload  []byte
-	WorkerID string
-	Attempts int64
+	q *Queue
+
+	ID             int64
+	Queue          string
+	Payload        []byte
+	State          string
+	Priority       int64
+	RunAt          int64
+	WorkerID       string
+	ClaimExpiresAt int64
+	Attempts       int64
+	MaxAttempts    int64
+	CreatedAt      int64
+	ExpiresAt      *int64
 }
 
 // ClaimOne atomically claims one job or returns (nil, nil) on empty.
@@ -682,13 +697,22 @@ func (q *Queue) ClaimBatch(workerID string, n int) ([]*Job, error) {
 	if err != nil {
 		return nil, err
 	}
+	// honker_claim_batch returns the complete live-job snapshot, the
+	// same twelve columns honker_get_job returns. Keep every one of
+	// them; a claimed Job and a JobRow describe the same row.
 	var raw []struct {
 		ID             int64  `json:"id"`
 		Queue          string `json:"queue"`
 		Payload        string `json:"payload"`
+		State          string `json:"state"`
+		Priority       int64  `json:"priority"`
+		RunAt          int64  `json:"run_at"`
 		WorkerID       string `json:"worker_id"`
-		Attempts       int64  `json:"attempts"`
 		ClaimExpiresAt int64  `json:"claim_expires_at"`
+		Attempts       int64  `json:"attempts"`
+		MaxAttempts    int64  `json:"max_attempts"`
+		CreatedAt      int64  `json:"created_at"`
+		ExpiresAt      *int64 `json:"expires_at"`
 	}
 	if err := json.Unmarshal([]byte(rowsJSON), &raw); err != nil {
 		return nil, fmt.Errorf("unmarshal claim result: %w", err)
@@ -696,12 +720,19 @@ func (q *Queue) ClaimBatch(workerID string, n int) ([]*Job, error) {
 	jobs := make([]*Job, len(raw))
 	for i, r := range raw {
 		jobs[i] = &Job{
-			q:        q,
-			ID:       r.ID,
-			Queue:    r.Queue,
-			Payload:  []byte(r.Payload),
-			WorkerID: r.WorkerID,
-			Attempts: r.Attempts,
+			q:              q,
+			ID:             r.ID,
+			Queue:          r.Queue,
+			Payload:        []byte(r.Payload),
+			State:          r.State,
+			Priority:       r.Priority,
+			RunAt:          r.RunAt,
+			WorkerID:       r.WorkerID,
+			ClaimExpiresAt: r.ClaimExpiresAt,
+			Attempts:       r.Attempts,
+			MaxAttempts:    r.MaxAttempts,
+			CreatedAt:      r.CreatedAt,
+			ExpiresAt:      r.ExpiresAt,
 		}
 	}
 	return jobs, nil
@@ -764,7 +795,13 @@ func (q *Queue) AckBatch(ids []int64, workerID string) (int64, error) {
 }
 
 // JobRow is one job row read by Queue.GetJob. Pure data, no claim
-// semantics.
+// semantics — a JobRow has no Ack, Retry, Fail, or Heartbeat.
+//
+// It carries the same twelve fields as a claimed Job. Payload is the
+// raw JSON text of the job payload; use PayloadBytes with DecodePayload
+// to decode it. WorkerID and ClaimExpiresAt are nil while the job is
+// pending and set once a worker claims it. ExpiresAt is nil unless the
+// job was enqueued with EnqueueOptions.Expires.
 type JobRow struct {
 	ID             int64   `json:"id"`
 	Queue          string  `json:"queue"`
@@ -778,6 +815,39 @@ type JobRow struct {
 	MaxAttempts    int64   `json:"max_attempts"`
 	CreatedAt      int64   `json:"created_at"`
 	ExpiresAt      *int64  `json:"expires_at"`
+}
+
+// PayloadBytes returns the row's payload as raw JSON bytes, so a JobRow
+// decodes through the same path as a claimed Job.
+func (r *JobRow) PayloadBytes() []byte {
+	return []byte(r.Payload)
+}
+
+// DecodePayload unmarshals a job payload into T.
+//
+//	type Email struct {
+//	    To       string `json:"to"`
+//	    Template string `json:"template"`
+//	}
+//
+//	email, err := honker.DecodePayload[Email](job.Payload)
+//	row, _ := q.GetJob(id)
+//	email, err = honker.DecodePayload[Email](row.PayloadBytes())
+//
+// The type parameter is a compile-time contract between the producer
+// and the consumer, nothing more. Honker never inspects or validates
+// payload shape in the database, so every app writing to a queue has to
+// agree on the JSON shape on its own. A payload that does not match T
+// surfaces here as an unmarshal error, not as an enqueue failure.
+func DecodePayload[T any](payload []byte) (T, error) {
+	var out T
+	if len(payload) == 0 {
+		return out, nil
+	}
+	if err := json.Unmarshal(payload, &out); err != nil {
+		return out, fmt.Errorf("decode payload: %w", err)
+	}
+	return out, nil
 }
 
 // Cancel removes a pending or processing row by id. Returns true iff

--- a/packages/honker-go/honker.go
+++ b/packages/honker-go/honker.go
@@ -661,7 +661,14 @@ func (q *Queue) EnqueueTx(tx *Transaction, payload any, opts EnqueueOptions) (in
 // plus the claim methods (Ack, Retry, Fail, Heartbeat). WorkerID and
 // ClaimExpiresAt are always set: the claim UPDATE writes both. State is
 // "processing" by construction. ExpiresAt is nil when the job was
-// enqueued without EnqueueOptions.Expires.
+// enqueued without EnqueueOptions.Expires — never 0.
+//
+// Every field is a snapshot taken at claim time. Ack, Retry, Fail, and
+// Heartbeat change the row in the database; they do not write back to
+// this struct. In particular Heartbeat extends the claim in the
+// database but leaves ClaimExpiresAt at its claim-time value, so do not
+// compute remaining claim time from ClaimExpiresAt after a heartbeat —
+// track your own deadline, or re-read with Queue.GetJob.
 type Job struct {
 	q *Queue
 
@@ -771,6 +778,10 @@ func (j *Job) Fail(errMsg string) (bool, error) {
 
 // Heartbeat extends the claim's visibility timeout. Useful for
 // long-running jobs that might exceed the default visibility window.
+//
+// Heartbeat does not refresh j.ClaimExpiresAt — that field stays at its
+// claim-time value. Re-read the row with Queue.GetJob if you need the
+// new deadline.
 func (j *Job) Heartbeat(extendSec int64) (bool, error) {
 	var n int64
 	err := j.q.db.db.QueryRow(
@@ -799,10 +810,12 @@ func (q *Queue) AckBatch(ids []int64, workerID string) (int64, error) {
 // semantics — a JobRow has no Ack, Retry, Fail, or Heartbeat.
 //
 // It carries the same twelve fields as a claimed Job. Payload is the
-// raw JSON text of the job payload; use PayloadBytes with DecodePayload
-// to decode it. WorkerID and ClaimExpiresAt are nil while the job is
-// pending and set once a worker claims it. ExpiresAt is nil unless the
-// job was enqueued with EnqueueOptions.Expires.
+// raw JSON text of the job payload — a string rather than []byte
+// because encoding/json would base64 a []byte field; use PayloadBytes
+// with DecodePayload to decode it. WorkerID and ClaimExpiresAt are nil
+// while the job is pending and set once a worker claims it. ExpiresAt
+// is nil unless the job was enqueued with EnqueueOptions.Expires. All
+// three are nil, never 0 or "", when the column is NULL.
 type JobRow struct {
 	ID             int64   `json:"id"`
 	Queue          string  `json:"queue"`
@@ -819,7 +832,8 @@ type JobRow struct {
 }
 
 // PayloadBytes returns the row's payload as raw JSON bytes, so a JobRow
-// decodes through the same path as a claimed Job.
+// decodes through the same path as a claimed Job. Queue.GetJob returns
+// a nil row on a miss; check for nil before calling this.
 func (r *JobRow) PayloadBytes() []byte {
 	return []byte(r.Payload)
 }
@@ -837,7 +851,14 @@ var ErrEmptyPayload = errors.New("empty payload")
 //	}
 //
 //	email, err := honker.DecodePayload[Email](job.Payload)
-//	row, _ := q.GetJob(id)
+//
+//	row, err := q.GetJob(id)
+//	if err != nil {
+//	    return err
+//	}
+//	if row == nil {
+//	    return fmt.Errorf("job %d is gone", id)
+//	}
 //	email, err = honker.DecodePayload[Email](row.PayloadBytes())
 //
 // The type parameter is a compile-time contract between the producer
@@ -879,7 +900,15 @@ func (q *Queue) Cancel(jobID int64) (bool, error) {
 }
 
 // GetJob reads a single job row by id. Returns (*JobRow, nil) on hit
-// or (nil, nil) on miss (ack'd, dead'd, or never existed).
+// or (nil, nil) on miss (ack'd, dead'd, or never existed). Always check
+// the row for nil before using it — a miss is not an error.
+//
+// NOT queue-scoped: job ids are globally unique and this lookup does
+// not filter on the queue, so it can return a row belonging to another
+// queue. That matters for DecodePayload — another queue's payload will
+// happily decode into your type with zero-valued fields and no error.
+// Pass only ids you know this queue owns. Scoping the lookup in the
+// core is tracked separately.
 func (q *Queue) GetJob(jobID int64) (*JobRow, error) {
 	var raw string
 	err := q.db.db.QueryRow("SELECT honker_get_job(?)", jobID).Scan(&raw)

--- a/packages/honker-go/typed_jobs_test.go
+++ b/packages/honker-go/typed_jobs_test.go
@@ -1,6 +1,7 @@
 package honker
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -307,10 +308,24 @@ func TestDecodePayloadRejectsEmptyInput(t *testing.T) {
 			if err == nil {
 				t.Fatalf("DecodePayload(%s) = %+v, nil — want an error", tc.name, got)
 			}
+			// The caller has to be able to tell "the bytes never
+			// arrived" from "the bytes did not match T" without
+			// matching on the message text.
+			if !errors.Is(err, ErrEmptyPayload) {
+				t.Errorf("DecodePayload(%s) err = %v, want errors.Is(err, ErrEmptyPayload)", tc.name, err)
+			}
 			if got != (emailPayload{}) {
 				t.Errorf("DecodePayload(%s) value = %+v, want the zero value", tc.name, got)
 			}
 		})
+	}
+
+	// A shape mismatch is a different failure and must not match the
+	// sentinel, or errors.Is(err, ErrEmptyPayload) would be useless.
+	if _, err := DecodePayload[emailPayload]([]byte(`{"version":"not-a-number"}`)); err == nil {
+		t.Error("DecodePayload(wrong shape) = nil error, want an unmarshal error")
+	} else if errors.Is(err, ErrEmptyPayload) {
+		t.Errorf("DecodePayload(wrong shape) err = %v, want it NOT to match ErrEmptyPayload", err)
 	}
 
 	// A real payload still decodes.

--- a/packages/honker-go/typed_jobs_test.go
+++ b/packages/honker-go/typed_jobs_test.go
@@ -264,6 +264,12 @@ func TestClaimedJobReportsBackDatedRunAt(t *testing.T) {
 	if row.RunAt == row.CreatedAt {
 		t.Fatalf("row.RunAt == row.CreatedAt == %d, fixture no longer separates them", row.RunAt)
 	}
+	// No EnqueueOptions.Expires, so expires_at is SQL NULL. It has to
+	// arrive as nil, not as a pointer to 0 — a zero here reads as "this
+	// job expired in 1970".
+	if row.ExpiresAt != nil {
+		t.Errorf("row.ExpiresAt = %d, want nil (no TTL was set)", *row.ExpiresAt)
+	}
 
 	// ---- claimed job keeps the two apart -----------------------------
 	job, err := wq.ClaimOne("worker-backdated")
@@ -288,6 +294,119 @@ func TestClaimedJobReportsBackDatedRunAt(t *testing.T) {
 			"claimed gap CreatedAt-RunAt = %d, snapshot gap = %d, want equal",
 			job.CreatedAt-job.RunAt, row.CreatedAt-row.RunAt,
 		)
+	}
+	// Same NULL check on the claim path. The claim decode has its own
+	// struct, so a *int64 that became an int64 there would report 0 on
+	// every job enqueued without a TTL and nothing else would notice.
+	if job.ExpiresAt != nil {
+		t.Errorf("job.ExpiresAt = %d, want nil (no TTL was set)", *job.ExpiresAt)
+	}
+}
+
+// TestClaimBatchKeepsEachRowsOwnFields claims two jobs in one call and
+// pins each returned Job to its own row. ClaimBatch maps the twelve
+// fields in a loop; every other test in this file claims exactly one
+// job, so a mapping that reads the same element for every job — or a
+// per-row field taken from the wrong index — is invisible to them. The
+// user-visible damage is Ack: job.Ack() uses the Job's own ID, so a job
+// carrying its neighbour's id acks the wrong row and leaves its own
+// claim to expire.
+func TestClaimBatchKeepsEachRowsOwnFields(t *testing.T) {
+	worker, reader := openTypedJobs(t)
+	wq := worker.Queue("batchfields", QueueOptions{MaxAttempts: 4, VisibilityTimeoutS: 90})
+	rq := reader.Queue("batchfields", QueueOptions{MaxAttempts: 4, VisibilityTimeoutS: 90})
+
+	// Priority orders the claim (priority DESC), so "high" comes back
+	// first and "low" second — deterministic, no timing race.
+	ttl := int64(900)
+	highWant := emailPayload{Recipient: "high@example.com", Template: "urgent", Version: 11}
+	lowWant := emailPayload{Recipient: "low@example.com", Template: "bulk", Version: 22}
+
+	highID, err := wq.Enqueue(highWant, EnqueueOptions{Priority: 9, Expires: &ttl})
+	if err != nil {
+		t.Fatalf("enqueue high: %v", err)
+	}
+	lowID, err := wq.Enqueue(lowWant, EnqueueOptions{Priority: 1})
+	if err != nil {
+		t.Fatalf("enqueue low: %v", err)
+	}
+	if highID == lowID {
+		t.Fatalf("enqueue returned the same id twice: %d", highID)
+	}
+
+	jobs, err := wq.ClaimBatch("worker-batch", 2)
+	if err != nil {
+		t.Fatalf("ClaimBatch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("ClaimBatch returned %d jobs, want 2", len(jobs))
+	}
+	if jobs[0].ID == jobs[1].ID {
+		t.Fatalf("both claimed jobs carry id %d — the batch mapping collapsed the rows", jobs[0].ID)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		job         *Job
+		wantID      int64
+		wantPayload emailPayload
+		wantPrio    int64
+		wantExpires *int64
+	}{
+		{"high", jobs[0], highID, highWant, 9, &ttl},
+		{"low", jobs[1], lowID, lowWant, 1, nil},
+	} {
+		if tc.job.ID != tc.wantID {
+			t.Errorf("%s: job.ID = %d, want %d", tc.name, tc.job.ID, tc.wantID)
+		}
+		if tc.job.Priority != tc.wantPrio {
+			t.Errorf("%s: job.Priority = %d, want %d", tc.name, tc.job.Priority, tc.wantPrio)
+		}
+		got, err := DecodePayload[emailPayload](tc.job.Payload)
+		if err != nil {
+			t.Errorf("%s: decode payload: %v", tc.name, err)
+		} else if got != tc.wantPayload {
+			t.Errorf("%s: payload = %+v, want %+v", tc.name, got, tc.wantPayload)
+		}
+		switch {
+		case tc.wantExpires == nil && tc.job.ExpiresAt != nil:
+			t.Errorf("%s: job.ExpiresAt = %d, want nil (no TTL)", tc.name, *tc.job.ExpiresAt)
+		case tc.wantExpires != nil && tc.job.ExpiresAt == nil:
+			t.Errorf("%s: job.ExpiresAt = nil, want run_at + %d", tc.name, *tc.wantExpires)
+		case tc.wantExpires != nil && *tc.job.ExpiresAt-tc.job.RunAt != *tc.wantExpires:
+			t.Errorf("%s: job.ExpiresAt - RunAt = %d, want %d",
+				tc.name, *tc.job.ExpiresAt-tc.job.RunAt, *tc.wantExpires)
+		}
+		if tc.job.WorkerID != "worker-batch" {
+			t.Errorf("%s: job.WorkerID = %q, want %q", tc.name, tc.job.WorkerID, "worker-batch")
+		}
+		if tc.job.Attempts != 1 {
+			t.Errorf("%s: job.Attempts = %d, want 1", tc.name, tc.job.Attempts)
+		}
+		if tc.job.MaxAttempts != 4 {
+			t.Errorf("%s: job.MaxAttempts = %d, want 4", tc.name, tc.job.MaxAttempts)
+		}
+	}
+
+	// Each Job's own Ack has to land on its own row. A job carrying the
+	// wrong id acks a row that is already gone and returns false.
+	for i, job := range jobs {
+		acked, err := job.Ack()
+		if err != nil {
+			t.Fatalf("jobs[%d].Ack: %v", i, err)
+		}
+		if !acked {
+			t.Errorf("jobs[%d].Ack() = false for id %d, want true", i, job.ID)
+		}
+	}
+	for _, id := range []int64{highID, lowID} {
+		row, err := rq.GetJob(id)
+		if err != nil {
+			t.Fatalf("GetJob(%d): %v", id, err)
+		}
+		if row != nil {
+			t.Errorf("GetJob(%d) = %+v after ack, want nil", id, row)
+		}
 	}
 }
 

--- a/packages/honker-go/typed_jobs_test.go
+++ b/packages/honker-go/typed_jobs_test.go
@@ -226,6 +226,70 @@ func TestDelayedJobReportsItsRunAt(t *testing.T) {
 	}
 }
 
+// TestClaimedJobReportsBackDatedRunAt pins the claimed Job's RunAt and
+// CreatedAt apart. An immediately-enqueued job has run_at == created_at
+// to the second, so asserting both against the same instant proves
+// nothing: the two fields can be transposed in the claim decode and the
+// assertions still hold. Back-dating run_at with an absolute timestamp
+// keeps the job claimable (a delayed job is not) while the two values
+// differ by 100 seconds.
+func TestClaimedJobReportsBackDatedRunAt(t *testing.T) {
+	worker, reader := openTypedJobs(t)
+	wq := worker.Queue("backdated", QueueOptions{MaxAttempts: 3, VisibilityTimeoutS: 60})
+	rq := reader.Queue("backdated", QueueOptions{MaxAttempts: 3, VisibilityTimeoutS: 60})
+
+	before := time.Now().Unix()
+	past := before - 100
+	id, err := wq.Enqueue(
+		emailPayload{Recipient: "bob@example.com", Template: "reminder", Version: 1},
+		EnqueueOptions{RunAt: &past},
+	)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	after := time.Now().Unix()
+
+	// ---- snapshot keeps the two apart --------------------------------
+	row, err := rq.GetJob(id)
+	if err != nil || row == nil {
+		t.Fatalf("GetJob: row=%v err=%v", row, err)
+	}
+	if row.RunAt != past {
+		t.Errorf("row.RunAt = %d, want %d (the back-dated absolute run_at)", row.RunAt, past)
+	}
+	if row.CreatedAt < before || row.CreatedAt > after {
+		t.Errorf("row.CreatedAt = %d, want within [%d, %d]", row.CreatedAt, before, after)
+	}
+	if row.RunAt == row.CreatedAt {
+		t.Fatalf("row.RunAt == row.CreatedAt == %d, fixture no longer separates them", row.RunAt)
+	}
+
+	// ---- claimed job keeps the two apart -----------------------------
+	job, err := wq.ClaimOne("worker-backdated")
+	if err != nil {
+		t.Fatalf("ClaimOne: %v", err)
+	}
+	if job == nil {
+		t.Fatalf("ClaimOne returned nil, want the back-dated job to be claimable")
+	}
+	if job.RunAt != past {
+		t.Errorf("job.RunAt = %d, want %d (the back-dated absolute run_at)", job.RunAt, past)
+	}
+	if job.CreatedAt < before || job.CreatedAt > after {
+		t.Errorf("job.CreatedAt = %d, want within [%d, %d]", job.CreatedAt, before, after)
+	}
+	if job.RunAt == job.CreatedAt {
+		t.Errorf("job.RunAt == job.CreatedAt == %d, want run_at %d and created_at ~%d",
+			job.RunAt, past, before)
+	}
+	if job.CreatedAt-job.RunAt != row.CreatedAt-row.RunAt {
+		t.Errorf(
+			"claimed gap CreatedAt-RunAt = %d, snapshot gap = %d, want equal",
+			job.CreatedAt-job.RunAt, row.CreatedAt-row.RunAt,
+		)
+	}
+}
+
 // TestDecodePayloadRejectsEmptyInput: an empty payload must not decode
 // to a zero-valued T with a nil error. The core never emits an empty
 // payload, so empty means the bytes never arrived, and a caller cannot

--- a/packages/honker-go/typed_jobs_test.go
+++ b/packages/honker-go/typed_jobs_test.go
@@ -1,0 +1,227 @@
+package honker
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Issue #136: a claimed Job and a GetJob snapshot must both carry the
+// full twelve-field job shape the core already returns, and a typed
+// payload must survive the round trip through the database.
+
+type emailPayload struct {
+	Recipient string `json:"recipient"`
+	Template  string `json:"template"`
+	Version   int    `json:"version"`
+}
+
+// openTypedJobs returns two independent Database handles on one file:
+// `worker` claims, `reader` reads. Separate handles mean separate
+// connection pools, so the reader sees only what the worker committed.
+func openTypedJobs(t *testing.T) (worker *Database, reader *Database) {
+	t.Helper()
+	extPath := findExtension(t)
+	dbPath := filepath.Join(t.TempDir(), "typed.db")
+
+	worker, err := Open(dbPath, extPath)
+	if err != nil {
+		t.Fatalf("open worker: %v", err)
+	}
+	t.Cleanup(func() { _ = worker.Close() })
+
+	reader, err = Open(dbPath, extPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	t.Cleanup(func() { _ = reader.Close() })
+
+	return worker, reader
+}
+
+func TestClaimedJobAndSnapshotCarryEveryField(t *testing.T) {
+	worker, reader := openTypedJobs(t)
+	wq := worker.Queue("emails", QueueOptions{MaxAttempts: 5, VisibilityTimeoutS: 120})
+	rq := reader.Queue("emails", QueueOptions{MaxAttempts: 5, VisibilityTimeoutS: 120})
+
+	expires := int64(600)
+	before := time.Now().Unix()
+	id, err := wq.Enqueue(
+		emailPayload{Recipient: "alice@example.com", Template: "welcome", Version: 2},
+		EnqueueOptions{Priority: 7, Expires: &expires},
+	)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	after := time.Now().Unix()
+	if id <= 0 {
+		t.Fatalf("enqueue returned id %d", id)
+	}
+
+	// ---- pending snapshot -------------------------------------------
+	pending, err := rq.GetJob(id)
+	if err != nil || pending == nil {
+		t.Fatalf("GetJob(pending): row=%v err=%v", pending, err)
+	}
+	if pending.ID != id {
+		t.Errorf("pending.ID = %d, want %d", pending.ID, id)
+	}
+	if pending.Queue != "emails" {
+		t.Errorf("pending.Queue = %q, want %q", pending.Queue, "emails")
+	}
+	if pending.State != "pending" {
+		t.Errorf("pending.State = %q, want %q", pending.State, "pending")
+	}
+	if pending.Priority != 7 {
+		t.Errorf("pending.Priority = %d, want 7", pending.Priority)
+	}
+	if pending.RunAt < before || pending.RunAt > after {
+		t.Errorf("pending.RunAt = %d, want within [%d, %d]", pending.RunAt, before, after)
+	}
+	if pending.WorkerID != nil {
+		t.Errorf("pending.WorkerID = %q, want nil before any claim", *pending.WorkerID)
+	}
+	if pending.ClaimExpiresAt != nil {
+		t.Errorf("pending.ClaimExpiresAt = %d, want nil before any claim", *pending.ClaimExpiresAt)
+	}
+	if pending.Attempts != 0 {
+		t.Errorf("pending.Attempts = %d, want 0", pending.Attempts)
+	}
+	if pending.MaxAttempts != 5 {
+		t.Errorf("pending.MaxAttempts = %d, want 5", pending.MaxAttempts)
+	}
+	if pending.CreatedAt < before || pending.CreatedAt > after {
+		t.Errorf("pending.CreatedAt = %d, want within [%d, %d]", pending.CreatedAt, before, after)
+	}
+	if pending.ExpiresAt == nil {
+		t.Fatalf("pending.ExpiresAt = nil, want run_at + %d", expires)
+	}
+	// enqueue derives run_at and expires_at from one unixepoch() read,
+	// so the gap is exactly the requested TTL.
+	if got := *pending.ExpiresAt - pending.RunAt; got != expires {
+		t.Errorf("pending.ExpiresAt - RunAt = %d, want %d", got, expires)
+	}
+	pendingPayload, err := DecodePayload[emailPayload](pending.PayloadBytes())
+	if err != nil {
+		t.Fatalf("decode pending payload: %v", err)
+	}
+	want := emailPayload{Recipient: "alice@example.com", Template: "welcome", Version: 2}
+	if pendingPayload != want {
+		t.Errorf("pending payload = %+v, want %+v", pendingPayload, want)
+	}
+
+	// ---- claimed job -------------------------------------------------
+	claimBefore := time.Now().Unix()
+	job, err := wq.ClaimOne("worker-go")
+	if err != nil || job == nil {
+		t.Fatalf("ClaimOne: job=%v err=%v", job, err)
+	}
+	claimAfter := time.Now().Unix()
+
+	if job.ID != id {
+		t.Errorf("job.ID = %d, want %d", job.ID, id)
+	}
+	if job.Queue != "emails" {
+		t.Errorf("job.Queue = %q, want %q", job.Queue, "emails")
+	}
+	if job.State != "processing" {
+		t.Errorf("job.State = %q, want %q", job.State, "processing")
+	}
+	if job.Priority != 7 {
+		t.Errorf("job.Priority = %d, want 7", job.Priority)
+	}
+	if job.RunAt != pending.RunAt {
+		t.Errorf("job.RunAt = %d, want %d (unchanged by claim)", job.RunAt, pending.RunAt)
+	}
+	if job.WorkerID != "worker-go" {
+		t.Errorf("job.WorkerID = %q, want %q", job.WorkerID, "worker-go")
+	}
+	if job.ClaimExpiresAt < claimBefore+120 || job.ClaimExpiresAt > claimAfter+120 {
+		t.Errorf(
+			"job.ClaimExpiresAt = %d, want within [%d, %d] (claim time + 120s timeout)",
+			job.ClaimExpiresAt, claimBefore+120, claimAfter+120,
+		)
+	}
+	if job.Attempts != 1 {
+		t.Errorf("job.Attempts = %d, want 1 (claim increments)", job.Attempts)
+	}
+	if job.MaxAttempts != 5 {
+		t.Errorf("job.MaxAttempts = %d, want 5", job.MaxAttempts)
+	}
+	if job.CreatedAt != pending.CreatedAt {
+		t.Errorf("job.CreatedAt = %d, want %d (unchanged by claim)", job.CreatedAt, pending.CreatedAt)
+	}
+	if job.ExpiresAt == nil || *job.ExpiresAt != *pending.ExpiresAt {
+		t.Errorf("job.ExpiresAt = %v, want %d", job.ExpiresAt, *pending.ExpiresAt)
+	}
+	claimedPayload, err := DecodePayload[emailPayload](job.Payload)
+	if err != nil {
+		t.Fatalf("decode claimed payload: %v", err)
+	}
+	if claimedPayload != want {
+		t.Errorf("claimed payload = %+v, want %+v", claimedPayload, want)
+	}
+
+	// ---- the reader sees the processing details ----------------------
+	processing, err := rq.GetJob(id)
+	if err != nil || processing == nil {
+		t.Fatalf("GetJob(processing): row=%v err=%v", processing, err)
+	}
+	if processing.State != "processing" {
+		t.Errorf("processing.State = %q, want %q", processing.State, "processing")
+	}
+	if processing.WorkerID == nil || *processing.WorkerID != "worker-go" {
+		t.Errorf("processing.WorkerID = %v, want %q", processing.WorkerID, "worker-go")
+	}
+	if processing.ClaimExpiresAt == nil || *processing.ClaimExpiresAt != job.ClaimExpiresAt {
+		t.Errorf("processing.ClaimExpiresAt = %v, want %d", processing.ClaimExpiresAt, job.ClaimExpiresAt)
+	}
+	if processing.Attempts != 1 {
+		t.Errorf("processing.Attempts = %d, want 1", processing.Attempts)
+	}
+
+	// ---- after ack the reader gets nothing ---------------------------
+	acked, err := job.Ack()
+	if err != nil || !acked {
+		t.Fatalf("Ack: acked=%v err=%v", acked, err)
+	}
+	gone, err := rq.GetJob(id)
+	if err != nil {
+		t.Fatalf("GetJob after ack: %v", err)
+	}
+	if gone != nil {
+		t.Fatalf("GetJob after ack = %+v, want nil", gone)
+	}
+}
+
+func TestDelayedJobReportsItsRunAt(t *testing.T) {
+	worker, _ := openTypedJobs(t)
+	q := worker.Queue("delayed", QueueOptions{})
+
+	delay := int64(3600)
+	before := time.Now().Unix()
+	id, err := q.Enqueue(map[string]any{"to": "later"}, EnqueueOptions{Delay: &delay})
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	after := time.Now().Unix()
+
+	row, err := q.GetJob(id)
+	if err != nil || row == nil {
+		t.Fatalf("GetJob: row=%v err=%v", row, err)
+	}
+	if row.State != "pending" {
+		t.Errorf("row.State = %q, want %q", row.State, "pending")
+	}
+	if row.RunAt < before+delay || row.RunAt > after+delay {
+		t.Errorf("row.RunAt = %d, want within [%d, %d]", row.RunAt, before+delay, after+delay)
+	}
+	// Not claimable until run_at.
+	job, err := q.ClaimOne("worker-go")
+	if err != nil {
+		t.Fatalf("ClaimOne: %v", err)
+	}
+	if job != nil {
+		t.Fatalf("delayed job claimed early: %+v", job)
+	}
+}

--- a/packages/honker-go/typed_jobs_test.go
+++ b/packages/honker-go/typed_jobs_test.go
@@ -225,3 +225,37 @@ func TestDelayedJobReportsItsRunAt(t *testing.T) {
 		t.Fatalf("delayed job claimed early: %+v", job)
 	}
 }
+
+// TestDecodePayloadRejectsEmptyInput: an empty payload must not decode
+// to a zero-valued T with a nil error. The core never emits an empty
+// payload, so empty means the bytes never arrived, and a caller cannot
+// otherwise tell that apart from a clean decode.
+func TestDecodePayloadRejectsEmptyInput(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		payload []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DecodePayload[emailPayload](tc.payload)
+			if err == nil {
+				t.Fatalf("DecodePayload(%s) = %+v, nil — want an error", tc.name, got)
+			}
+			if got != (emailPayload{}) {
+				t.Errorf("DecodePayload(%s) value = %+v, want the zero value", tc.name, got)
+			}
+		})
+	}
+
+	// A real payload still decodes.
+	want := emailPayload{Recipient: "carol@example.com", Template: "digest", Version: 3}
+	got, err := DecodePayload[emailPayload]([]byte(`{"recipient":"carol@example.com","template":"digest","version":3}`))
+	if err != nil {
+		t.Fatalf("DecodePayload(valid): %v", err)
+	}
+	if got != want {
+		t.Errorf("DecodePayload(valid) = %+v, want %+v", got, want)
+	}
+}


### PR DESCRIPTION
Part of #136 — the Go binding's slice of "full job details and typed payloads in every binding".

**Stacked on #124 (`feat/node-typed-jobs`). Merge #124 first.** The widened
`honker_claim_batch` RETURNING clause that exposes the full job snapshot lives
only on that branch; on `main` claim_batch still returns the old 8 fields, so
this PR targets `feat/node-typed-jobs` as its base.

## What changed

- `Job` now carries all twelve fields the core already returns: `ID`, `Queue`,
  `Payload`, `State`, `Priority`, `RunAt`, `WorkerID`, `ClaimExpiresAt`,
  `Attempts`, `MaxAttempts`, `CreatedAt`, `ExpiresAt`. Previously it kept five.
  A claimed `Job` and a `GetJob` snapshot (`JobRow`) now describe the same row;
  `Job` keeps `Ack` / `Retry` / `Fail` / `Heartbeat`, `JobRow` stays data only.
- New `honker.DecodePayload[T](payload []byte) (T, error)` and
  `JobRow.PayloadBytes()`, so a claimed job and a snapshot decode a typed
  payload through the same path. Payloads stay raw JSON, as the issue calls for
  in Go.
- README section documenting the field list and the decode helper.

No core or SQL ABI changes. `packages/honker-node` untouched. `claimed_at`
(#135) is deliberately not here.

## Not runtime validation

The type parameter on `DecodePayload[T]` is a compile-time contract between
producer and consumer. Honker does not inspect or validate payload shape in the
database — a mismatch surfaces as an unmarshal error at decode time, never as
an enqueue failure. The doc comment and README both say so.

## Tests

`packages/honker-go/typed_jobs_test.go`:

- `TestClaimedJobAndSnapshotCarryEveryField` — enqueues with a priority (7),
  TTL (600s), and max-attempts (5), then asserts every one of the twelve fields
  against its expected *value* on three reads: the pending snapshot, the
  claimed `Job`, and a second independent `Database` handle's processing
  snapshot. Checks `ExpiresAt - RunAt == 600` exactly, `ClaimExpiresAt` inside
  the claim-time + 120s visibility window, `Attempts` going 0 → 1, `WorkerID`
  and `ClaimExpiresAt` nil while pending and set once claimed, and `RunAt` /
  `CreatedAt` unchanged by the claim. After ack, the reader gets `nil`.
- `TestDelayedJobReportsItsRunAt` — a `Delay: 3600` job reports the right
  `RunAt` and is not claimable early.

```
$ go test -tags sqlite_load_extension -count=1 ./packages/honker-go
ok  	github.com/russellromney/honker-go	17.716s
```

### Load-bearing proof

Dropped `Priority: r.Priority` from the `ClaimBatch` row mapping (so the field
falls back to Go's zero value) and reran:

```
--- FAIL: TestClaimedJobAndSnapshotCarryEveryField (0.12s)
    typed_jobs_test.go:131: job.Priority = 0, want 7
FAIL	github.com/russellromney/honker-go	0.430s
```

Restored, full suite green again.

https://claude.ai/code/session_01YMCFasvKC52r37DDKSTeMC
