### PR TITLE
feat(core): add claimed_at to _honker_live so attempt runtime is answerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # CHANGELOG
 
+## Unreleased — `claimed_at` on `_honker_live`
+
+- New nullable `claimed_at INTEGER` column on `_honker_live`: when the
+  CURRENT attempt started. Nothing else could answer that.
+  `created_at` includes queue wait, `run_at` is when the job became
+  ready, and `claim_expires_at` moves on every heartbeat.
+- NULL until the first claim. Set to `unixepoch()` on every successful
+  claim and reclaim, so it tracks the current attempt and not the first
+  one. Cleared when `retry` returns the job to pending — a job waiting
+  in the queue is not running. `heartbeat()` deliberately leaves it
+  alone; refreshing it there would reintroduce exactly the blind spot
+  the column exists to fix.
+- Exposed in `claim_batch`'s RETURNING and JSON, and in `get_job`'s
+  JSON. Both are additive; no binding declares
+  `serde(deny_unknown_fields)`, so existing consumers ignore it until
+  they opt in.
+- Existing databases migrate with `ALTER TABLE ... ADD COLUMN`, matching
+  the `enabled` and `max_attempts` migrations, and tolerating the
+  "duplicate column" error when a concurrent bootstrap wins the race.
+  `CREATE TABLE IF NOT EXISTS` cannot add a column to a table that
+  already exists, which is what the migration test pins.
+- Tests: NULL before first claim, first claim, heartbeat-does-not-move,
+  retry clears, reclaim resets, plus a migration test proving a
+  pre-column database gains the column and keeps its rows with
+  `claimed_at` NULL rather than a backfilled timestamp.
+
 ## Unreleased — Core SQLite error propagation
 
 - `honker-core` no longer discards SQLite errors in five lookups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@
   JSON. Both are additive; no binding declares
   `serde(deny_unknown_fields)`, so existing consumers ignore it until
   they opt in.
+- Validity window, documented in README under "How long has this job
+  been running": `claimed_at` is the start of the CURRENT claim and is
+  only meaningful while `claim_expires_at >= unixepoch()`. A claim that
+  lapses without a reclaim leaves `worker_id`, `claim_expires_at` and
+  `claimed_at` on the row, all stale together, until the next claim
+  overwrites all three. Nothing clears them, by design — there is no
+  expiry sweep for processing rows, and blanking `claimed_at` alone
+  would throw away the abandoned attempt's start time while leaving the
+  other two stale anyway.
 - Existing databases migrate with `ALTER TABLE ... ADD COLUMN`, matching
   the `enabled` and `max_attempts` migrations, and tolerating the
   "duplicate column" error when a concurrent bootstrap wins the race.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,17 @@
   "duplicate column" error when a concurrent bootstrap wins the race.
   `CREATE TABLE IF NOT EXISTS` cannot add a column to a table that
   already exists, which is what the migration test pins.
+- No language binding maps `claimed_at` onto its job type yet, so for
+  now it is read in SQL. #136 tracks adding it to the full job shape
+  per binding.
 - Tests: NULL before first claim, first claim, heartbeat-does-not-move,
-  retry clears, reclaim resets, plus a migration test proving a
-  pre-column database gains the column and keeps its rows with
-  `claimed_at` NULL rather than a backfilled timestamp.
+  retry clears, reclaim resets to the reclaim time (bounded by a clock
+  read taken either side of the reclaim, not just "moved off the old
+  value"), ack and fail both remove the row, an expired claim keeps
+  `claimed_at` alongside the rest of the stale claim, plus a migration
+  test proving a pre-column database gains the column, keeps its rows
+  with `claimed_at` NULL rather than a backfilled timestamp, and ends
+  up with the same columns in the same order as a fresh database.
 
 ## Unreleased — Core SQLite error propagation
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,34 @@ The extension shares tables with the language bindings, so a Python
 worker can claim jobs written by SQL, Node, Ruby, Go, or any other
 binding.
 
+### How long has this job been running
+
+`_honker_live.claimed_at` is when the CURRENT claim started. Nothing
+else answers that: `created_at` includes queue wait, `run_at` is when
+the job became ready, and `claim_expires_at` moves on every heartbeat.
+No language binding exposes `claimed_at` yet, so read it in SQL:
+
+```sql
+SELECT id, queue, unixepoch() - claimed_at AS running_s
+  FROM _honker_live
+ WHERE state = 'processing'
+   AND claim_expires_at >= unixepoch();   -- required, see below
+```
+
+`claimed_at` is only meaningful while `claim_expires_at >= unixepoch()`.
+When a claim lapses and nobody reclaims the job — attempts exhausted, no
+worker on that queue, queue drained — honker does not touch the row.
+`worker_id`, `claim_expires_at` and `claimed_at` all stay put and all go
+stale together, and the next claim overwrites all three. Without the
+`claim_expires_at` filter, `unixepoch() - claimed_at` keeps counting up
+for an attempt nobody is running.
+
+`claimed_at` is NULL until the first claim, and stays NULL for jobs that
+were already in flight when an existing database was upgraded: the
+migration adds the column without backfilling, because a backfill would
+date those rows to upgrade time and read as a claim that never happened.
+They pick up a real value on their next claim.
+
 ## Architecture
 
 - One `PRAGMA data_version` watcher per `Database`; the default

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -656,6 +656,16 @@ fn dead_letter_exhausted_claimable(conn: &Connection, queue: &str) -> rusqlite::
 /// first one. `heartbeat()` deliberately leaves it alone — that is the
 /// whole reason `claim_expires_at` cannot answer "how long has this
 /// been running".
+///
+/// Here it is always a number: the UPDATE just wrote it on every row
+/// this RETURNING sees. `get_job` is the one that can report
+/// `"claimed_at": null`, for a job that has never been claimed.
+///
+/// Validity window: `claimed_at` is the start of the CURRENT claim and
+/// is only meaningful while `claim_expires_at >= unixepoch()`. When a
+/// claim lapses without a reclaim, `worker_id`, `claim_expires_at` and
+/// `claimed_at` all stay on the row and all go stale together; the
+/// next claim overwrites the three of them.
 pub fn claim_batch(
     conn: &Connection,
     queue: &str,
@@ -1014,6 +1024,12 @@ pub fn cancel(conn: &Connection, job_id: i64) -> rusqlite::Result<i64> {
 /// Read a single job row by id. Returns a JSON object on success or
 /// the empty string on miss (job ack'd, dead'd, or never existed).
 /// Pure read — does not change state.
+///
+/// `claimed_at` is null for a job that has never been claimed, and for
+/// a job that was already in flight when an existing database migrated
+/// (the migration adds the column without backfilling). Otherwise it is
+/// the start of the current claim, and it is only meaningful while
+/// `claim_expires_at >= unixepoch()` — see `claim_batch`.
 pub fn get_job(conn: &Connection, job_id: i64) -> rusqlite::Result<String> {
     let row: Option<(
         i64,
@@ -2404,14 +2420,22 @@ mod claimed_at_tests {
         )
         .unwrap();
 
+        // Read the clock before the reclaim. `second > first - 3600`
+        // would only prove the value moved off the backdated one; any
+        // write at all satisfies it. Measured: with the claim writing
+        // `unixepoch() - 1000`, the old bound passes and this one
+        // fails. `second >= before_reclaim` pins the actual reclaim.
+        let before_reclaim = now(&conn);
         let batch: serde_json::Value = serde_json::from_str(&claim(&conn, "w2", 300)).unwrap();
         assert_eq!(batch[0]["id"].as_i64(), Some(id), "w2 must reclaim the row");
+        let after_reclaim = now(&conn);
 
         let second = stored_claimed_at(&conn, id).unwrap();
         assert!(
-            second > first - 3600,
-            "a reclaim starts a new attempt, so claimed_at must move forward \
-             to the reclaim time; got {second}, backdated first claim was {}",
+            second >= before_reclaim && second <= after_reclaim,
+            "a reclaim starts a new attempt, so claimed_at must be the reclaim time, \
+             between {before_reclaim} and {after_reclaim}; got {second}, \
+             backdated first claim was {}",
             first - 3600
         );
         assert_eq!(
@@ -2421,14 +2445,98 @@ mod claimed_at_tests {
         );
     }
 
+    // Both terminal paths DELETE the row, so `claimed_at` leaves with
+    // it. Neither reads the column. This pins that the extra column
+    // breaks neither one, and that the row really leaves _honker_live
+    // rather than lingering with a stale claimed_at.
     #[test]
     fn ack_and_fail_do_not_need_claimed_at_but_still_work() {
         let conn = db();
-        let id = enqueue(&conn);
+
+        let acked_id = enqueue(&conn);
         claim(&conn, "w1", 300);
         let acked: i64 = conn
-            .query_row("SELECT honker_ack(?1, 'w1')", [id], |r| r.get(0))
+            .query_row("SELECT honker_ack(?1, 'w1')", [acked_id], |r| r.get(0))
             .unwrap();
         assert_eq!(acked, 1, "the extra column must not break the ack path");
+        assert_eq!(
+            live_row_count(&conn, acked_id),
+            0,
+            "ack must remove the row, taking claimed_at with it"
+        );
+
+        let failed_id = enqueue(&conn);
+        claim(&conn, "w1", 300);
+        assert!(
+            stored_claimed_at(&conn, failed_id).is_some(),
+            "the claim must have set claimed_at before fail() runs"
+        );
+        let failed: i64 = conn
+            .query_row("SELECT honker_fail(?1, 'w1', 'boom')", [failed_id], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(failed, 1, "the extra column must not break the fail path");
+        assert_eq!(
+            live_row_count(&conn, failed_id),
+            0,
+            "fail must remove the row from _honker_live"
+        );
+        let dead: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM _honker_dead WHERE id = ?1",
+                [failed_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(dead, 1, "fail must land the job in _honker_dead");
+    }
+
+    // `claimed_at` is the start of the CURRENT claim, and it is only
+    // meaningful while `claim_expires_at >= now`. When a claim lapses
+    // with nobody reclaiming (attempts exhausted, no worker on the
+    // queue, queue drained) the row keeps `state='processing'`,
+    // `worker_id`, `claim_expires_at` AND `claimed_at` — all of it is
+    // the last claim, and all of it goes stale together. Nothing
+    // clears it; the next claim overwrites it. This is the one case
+    // where `unixepoch() - claimed_at` read without the
+    // `claim_expires_at` filter gives a growing number for an attempt
+    // nobody is running, so the behaviour is pinned here and the
+    // filter is documented in README.
+    #[test]
+    fn an_expired_claim_keeps_claimed_at_with_the_rest_of_the_stale_claim() {
+        let conn = db();
+        let id = enqueue(&conn);
+        // A timeout already in the past: claimed, and immediately past
+        // its deadline.
+        claim(&conn, "w1", -60);
+
+        let job: serde_json::Value = serde_json::from_str(&get_job(&conn, id).unwrap()).unwrap();
+        let now_s = now(&conn);
+        assert_eq!(job["state"].as_str(), Some("processing"));
+        assert!(
+            job["claim_expires_at"].as_i64().unwrap() < now_s,
+            "the claim must actually be expired for this test to mean anything"
+        );
+        assert_eq!(
+            job["worker_id"].as_str(),
+            Some("w1"),
+            "worker_id is not cleared on expiry either — claimed_at is no more \
+             stale than the rest of the claim"
+        );
+        assert!(
+            job["claimed_at"].as_i64().is_some(),
+            "claimed_at is deliberately left in place: it is the last claim's \
+             start, valid only while claim_expires_at >= now"
+        );
+    }
+
+    fn live_row_count(conn: &Connection, id: i64) -> i64 {
+        conn.query_row(
+            "SELECT count(*) FROM _honker_live WHERE id = ?1",
+            [id],
+            |r| r.get(0),
+        )
+        .unwrap()
     }
 }

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -649,7 +649,13 @@ fn dead_letter_exhausted_claimable(conn: &Connection, queue: &str) -> rusqlite::
     Ok(count)
 }
 
-/// Returns JSON text: `[{"id":1,"queue":"...","payload":"...","worker_id":"...","attempts":N,"claim_expires_at":T}, ...]`
+/// Returns JSON text: `[{"id":1,"queue":"...","payload":"...","worker_id":"...","attempts":N,"claim_expires_at":T,"claimed_at":T}, ...]`
+///
+/// `claimed_at` is set to `unixepoch()` on every successful claim,
+/// reclaim included, so it measures the current attempt and not the
+/// first one. `heartbeat()` deliberately leaves it alone — that is the
+/// whole reason `claim_expires_at` cannot answer "how long has this
+/// been running".
 pub fn claim_batch(
     conn: &Connection,
     queue: &str,
@@ -668,6 +674,7 @@ pub fn claim_batch(
          SET state = 'processing',
              worker_id = ?1,
              claim_expires_at = unixepoch() + ?4,
+             claimed_at = unixepoch(),
              attempts = attempts + 1
          WHERE id IN (
            SELECT id FROM _honker_live
@@ -680,7 +687,8 @@ pub fn claim_batch(
            ORDER BY priority DESC, run_at ASC, id ASC
            LIMIT ?3
          )
-         RETURNING id, queue, payload, worker_id, attempts, claim_expires_at",
+         RETURNING id, queue, payload, worker_id, attempts, claim_expires_at,
+                   claimed_at",
     )?;
     let rows = stmt.query_map(rusqlite::params![worker_id, queue, n, timeout_s], |row| {
         Ok((
@@ -690,11 +698,12 @@ pub fn claim_batch(
             row.get::<_, String>(3)?,
             row.get::<_, i64>(4)?,
             row.get::<_, i64>(5)?,
+            row.get::<_, i64>(6)?,
         ))
     })?;
     let mut out = Vec::new();
     for row in rows {
-        let (id, q, payload, w, attempts, claim_expires_at) = row?;
+        let (id, q, payload, w, attempts, claim_expires_at, claimed_at) = row?;
         // payload stays a JSON string (double-encoded on the wire) so
         // every binding's existing parse path keeps working.
         out.push(json!({
@@ -704,6 +713,7 @@ pub fn claim_batch(
             "worker_id": w,
             "attempts": attempts,
             "claim_expires_at": claim_expires_at,
+            "claimed_at": claimed_at,
         }));
     }
     Ok(Value::Array(out).to_string())
@@ -897,7 +907,8 @@ pub fn retry(
              SET state = 'pending',
                  run_at = unixepoch() + ?2,
                  worker_id = NULL,
-                 claim_expires_at = NULL
+                 claim_expires_at = NULL,
+                 claimed_at = NULL
              WHERE id = ?1",
             rusqlite::params![id, delay_s],
         )?;
@@ -1017,10 +1028,12 @@ pub fn get_job(conn: &Connection, job_id: i64) -> rusqlite::Result<String> {
         i64,
         i64,
         Option<i64>,
+        Option<i64>,
     )> = conn
         .query_row(
             "SELECT id, queue, payload, state, priority, run_at, worker_id,
-                    claim_expires_at, attempts, max_attempts, created_at, expires_at
+                    claim_expires_at, attempts, max_attempts, created_at, expires_at,
+                    claimed_at
                FROM _honker_live WHERE id = ?1",
             rusqlite::params![job_id],
             |r| {
@@ -1037,6 +1050,7 @@ pub fn get_job(conn: &Connection, job_id: i64) -> rusqlite::Result<String> {
                     r.get(9)?,
                     r.get(10)?,
                     r.get(11)?,
+                    r.get(12)?,
                 ))
             },
         )
@@ -1054,6 +1068,7 @@ pub fn get_job(conn: &Connection, job_id: i64) -> rusqlite::Result<String> {
         max_attempts,
         created_at,
         expires_at,
+        claimed_at,
     )) = row
     else {
         return Ok(String::new());
@@ -1071,6 +1086,7 @@ pub fn get_job(conn: &Connection, job_id: i64) -> rusqlite::Result<String> {
         "max_attempts": max_attempts,
         "created_at": created_at,
         "expires_at": expires_at,
+        "claimed_at": claimed_at,
     })
     .to_string())
 }
@@ -1078,6 +1094,12 @@ pub fn get_job(conn: &Connection, job_id: i64) -> rusqlite::Result<String> {
 /// Extend the current claim by `extend_s` seconds. Returns 1 if the
 /// heartbeat landed, 0 if we're not the holder (either the row is
 /// in a different state or worker_id doesn't match).
+///
+/// Moves `claim_expires_at` only. `claimed_at` must NOT be touched
+/// here: it marks when the current attempt started, and a heartbeat
+/// does not start a new attempt. Refreshing it would make a
+/// long-running job look like it just began, which is exactly the
+/// blind spot `claimed_at` exists to fix.
 pub fn heartbeat(
     conn: &Connection,
     job_id: i64,
@@ -2197,5 +2219,216 @@ mod optional_error_tests {
             err.to_string().contains("expires_at"),
             "expected the error to name the bad column, got: {err}"
         );
+    }
+}
+
+// `claimed_at` records when the CURRENT attempt started. The other
+// timestamps cannot answer that: `created_at` includes queue wait,
+// `run_at` is when the job became ready, and `claim_expires_at` moves
+// on every heartbeat. These tests pin the four transitions that decide
+// whether it means anything — first claim, heartbeat, retry, reclaim.
+#[cfg(test)]
+mod claimed_at_tests {
+    use super::{get_job, heartbeat, retry};
+    use crate::{attach_honker_functions, bootstrap_honker_schema};
+    use rusqlite::Connection;
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        attach_honker_functions(&conn).unwrap();
+        bootstrap_honker_schema(&conn).unwrap();
+        conn
+    }
+
+    fn enqueue(conn: &Connection) -> i64 {
+        conn.query_row(
+            "SELECT honker_enqueue('emails', '{}', NULL, NULL, 0, 3, NULL)",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    fn claim(conn: &Connection, worker: &str, timeout_s: i64) -> String {
+        conn.query_row(
+            "SELECT honker_claim_batch('emails', ?1, 8, ?2)",
+            rusqlite::params![worker, timeout_s],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    fn stored_claimed_at(conn: &Connection, id: i64) -> Option<i64> {
+        conn.query_row(
+            "SELECT claimed_at FROM _honker_live WHERE id = ?1",
+            [id],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    fn now(conn: &Connection) -> i64 {
+        conn.query_row("SELECT unixepoch()", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn claimed_at_is_null_until_the_first_claim() {
+        let conn = db();
+        let id = enqueue(&conn);
+        assert_eq!(
+            stored_claimed_at(&conn, id),
+            None,
+            "a job that was never claimed must have claimed_at NULL, not 0 and not the enqueue time"
+        );
+        let job: serde_json::Value = serde_json::from_str(&get_job(&conn, id).unwrap()).unwrap();
+        assert!(
+            job["claimed_at"].is_null(),
+            "get_job must report claimed_at as null on a pending job, got {}",
+            job["claimed_at"]
+        );
+    }
+
+    #[test]
+    fn first_claim_sets_claimed_at_and_returns_it() {
+        let conn = db();
+        let id = enqueue(&conn);
+        let before = now(&conn);
+        let batch: serde_json::Value = serde_json::from_str(&claim(&conn, "w1", 300)).unwrap();
+        let after = now(&conn);
+
+        let claimed_at = batch[0]["claimed_at"]
+            .as_i64()
+            .expect("claim_batch must return claimed_at as a number");
+        assert!(
+            claimed_at >= before && claimed_at <= after,
+            "claimed_at {claimed_at} must be the claim time, between {before} and {after}"
+        );
+        assert_eq!(stored_claimed_at(&conn, id), Some(claimed_at));
+
+        let job: serde_json::Value = serde_json::from_str(&get_job(&conn, id).unwrap()).unwrap();
+        assert_eq!(
+            job["claimed_at"].as_i64(),
+            Some(claimed_at),
+            "get_job must report the same claimed_at the claim returned"
+        );
+    }
+
+    // The reason the column exists. A heartbeat pushes claim_expires_at
+    // out, so claim_expires_at cannot tell you how long the attempt has
+    // been running. claimed_at has to stay put or it inherits the same
+    // blind spot.
+    #[test]
+    fn heartbeat_moves_the_deadline_but_not_claimed_at() {
+        let conn = db();
+        let id = enqueue(&conn);
+        claim(&conn, "w1", 300);
+        // Backdate the claim. Without this the heartbeat lands in the
+        // same second as the claim, so a heartbeat that DID refresh
+        // claimed_at would write back the identical value and this test
+        // would pass on broken code. Verified: with the backdate
+        // removed, adding `claimed_at = unixepoch()` to heartbeat's
+        // UPDATE still passed.
+        conn.execute(
+            "UPDATE _honker_live SET claimed_at = claimed_at - 3600 WHERE id = ?1",
+            [id],
+        )
+        .unwrap();
+        let claimed_at = stored_claimed_at(&conn, id).unwrap();
+        let deadline_before: i64 = conn
+            .query_row(
+                "SELECT claim_expires_at FROM _honker_live WHERE id = ?1",
+                [id],
+                |r| r.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(heartbeat(&conn, id, "w1", 900).unwrap(), 1);
+
+        let deadline_after: i64 = conn
+            .query_row(
+                "SELECT claim_expires_at FROM _honker_live WHERE id = ?1",
+                [id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            deadline_after > deadline_before,
+            "the heartbeat must actually extend the deadline, \
+             otherwise this test proves nothing about claimed_at"
+        );
+        assert_eq!(
+            stored_claimed_at(&conn, id),
+            Some(claimed_at),
+            "a heartbeat must NOT refresh claimed_at: it extends the claim, \
+             it does not start a new attempt"
+        );
+    }
+
+    #[test]
+    fn retry_clears_claimed_at_when_the_job_goes_back_to_pending() {
+        let conn = db();
+        let id = enqueue(&conn);
+        claim(&conn, "w1", 300);
+        assert!(stored_claimed_at(&conn, id).is_some());
+
+        assert_eq!(retry(&conn, id, "w1", 0, "boom").unwrap(), 1);
+        let state: String = conn
+            .query_row("SELECT state FROM _honker_live WHERE id = ?1", [id], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(state, "pending", "retry must return the job to pending");
+        assert_eq!(
+            stored_claimed_at(&conn, id),
+            None,
+            "a job waiting in the queue is not running, so claimed_at must be cleared"
+        );
+    }
+
+    // Reclaim after the visibility timeout is a new attempt, so
+    // claimed_at moves. Otherwise it would report the first attempt's
+    // start time forever.
+    #[test]
+    fn reclaim_resets_claimed_at_to_the_new_attempt() {
+        let conn = db();
+        let id = enqueue(&conn);
+        // Claim with a timeout already in the past so the row is
+        // immediately reclaimable.
+        claim(&conn, "w1", -60);
+        let first = stored_claimed_at(&conn, id).unwrap();
+        // Backdate the first claim so the reclaim is unambiguously later.
+        conn.execute(
+            "UPDATE _honker_live SET claimed_at = claimed_at - 3600 WHERE id = ?1",
+            [id],
+        )
+        .unwrap();
+
+        let batch: serde_json::Value = serde_json::from_str(&claim(&conn, "w2", 300)).unwrap();
+        assert_eq!(batch[0]["id"].as_i64(), Some(id), "w2 must reclaim the row");
+
+        let second = stored_claimed_at(&conn, id).unwrap();
+        assert!(
+            second > first - 3600,
+            "a reclaim starts a new attempt, so claimed_at must move forward \
+             to the reclaim time; got {second}, backdated first claim was {}",
+            first - 3600
+        );
+        assert_eq!(
+            batch[0]["claimed_at"].as_i64(),
+            Some(second),
+            "the reclaim batch must report the new claimed_at"
+        );
+    }
+
+    #[test]
+    fn ack_and_fail_do_not_need_claimed_at_but_still_work() {
+        let conn = db();
+        let id = enqueue(&conn);
+        claim(&conn, "w1", 300);
+        let acked: i64 = conn
+            .query_row("SELECT honker_ack(?1, 'w1')", [id], |r| r.get(0))
+            .unwrap();
+        assert_eq!(acked, 1, "the extra column must not break the ack path");
     }
 }

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -362,7 +362,8 @@ pub const BOOTSTRAP_HONKER_SQL: &str = "
       attempts INTEGER NOT NULL DEFAULT 0,
       max_attempts INTEGER NOT NULL DEFAULT 3,
       created_at INTEGER NOT NULL DEFAULT (unixepoch()),
-      expires_at INTEGER
+      expires_at INTEGER,
+      claimed_at INTEGER
     );
     CREATE INDEX IF NOT EXISTS _honker_live_claim
       ON _honker_live(queue, priority DESC, run_at, id)
@@ -477,6 +478,29 @@ pub fn bootstrap_honker_schema(conn: &Connection) -> Result<(), Error> {
             "ALTER TABLE _honker_scheduler_tasks ADD COLUMN max_attempts INTEGER NOT NULL DEFAULT 3",
             [],
         ) {
+            Ok(_) => {}
+            Err(e) if e.to_string().to_lowercase().contains("duplicate column") => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+    // Migration: `claimed_at` on _honker_live. When the current attempt
+    // started. `created_at` includes queue wait, `run_at` is when the
+    // job became ready, and `claim_expires_at` moves on every heartbeat
+    // — none of them answer "how long has this attempt been running".
+    //
+    // Nullable with no default: NULL until the first claim. A default
+    // would date every pre-existing row to migration time and read as a
+    // claim that never happened.
+    //
+    // CREATE TABLE IF NOT EXISTS does not add columns to a table that
+    // already exists, so an existing database only gets this here.
+    let has_claimed_at: bool = {
+        let mut stmt = conn
+            .prepare("SELECT 1 FROM pragma_table_info('_honker_live') WHERE name='claimed_at'")?;
+        stmt.query_row([], |_| Ok(true)).unwrap_or(false)
+    };
+    if !has_claimed_at {
+        match conn.execute("ALTER TABLE _honker_live ADD COLUMN claimed_at INTEGER", []) {
             Ok(_) => {}
             Err(e) if e.to_string().to_lowercase().contains("duplicate column") => {}
             Err(e) => return Err(e.into()),
@@ -2305,6 +2329,78 @@ while True:
     }
 
     #[test]
+    fn bootstrap_pre_claimed_at_database_gains_the_column_and_keeps_its_rows() {
+        // A database created before `claimed_at` existed. The table is
+        // already there, so `CREATE TABLE IF NOT EXISTS` is a no-op and
+        // cannot add the column — only the ALTER TABLE migration can.
+        let conn = mem();
+        conn.execute_batch(
+            "CREATE TABLE _honker_live (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              queue TEXT NOT NULL,
+              payload TEXT NOT NULL,
+              state TEXT NOT NULL DEFAULT 'pending',
+              priority INTEGER NOT NULL DEFAULT 0,
+              run_at INTEGER NOT NULL DEFAULT (unixepoch()),
+              worker_id TEXT,
+              claim_expires_at INTEGER,
+              attempts INTEGER NOT NULL DEFAULT 0,
+              max_attempts INTEGER NOT NULL DEFAULT 3,
+              created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+              expires_at INTEGER
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO _honker_live (id, queue, payload, state, attempts, created_at)
+             VALUES (7, 'emails', '{\"legacy\":true}', 'processing', 2, 1000)",
+            [],
+        )
+        .unwrap();
+
+        bootstrap_honker_schema(&conn).unwrap();
+
+        let has: bool = conn
+            .query_row(
+                "SELECT 1 FROM pragma_table_info('_honker_live') WHERE name='claimed_at'",
+                [],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        assert!(
+            has,
+            "claimed_at must be added to a table that already existed; \
+             CREATE TABLE IF NOT EXISTS cannot do it"
+        );
+
+        // The pre-existing row survives untouched, and its claimed_at is
+        // NULL. A default would date every legacy row to migration time
+        // and read as a claim that never happened.
+        let (payload, attempts, created_at, claimed_at): (String, i64, i64, Option<i64>) = conn
+            .query_row(
+                "SELECT payload, attempts, created_at, claimed_at
+                   FROM _honker_live WHERE id = 7",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            payload, "{\"legacy\":true}",
+            "existing row data must survive"
+        );
+        assert_eq!(attempts, 2);
+        assert_eq!(created_at, 1000);
+        assert_eq!(
+            claimed_at, None,
+            "a migrated row must have claimed_at NULL, not a backfilled timestamp"
+        );
+
+        // Idempotent: the second bootstrap must not error on the column
+        // it just added.
+        bootstrap_honker_schema(&conn).unwrap();
+    }
+
+    #[test]
     fn bootstrap_honker_schema_creates_tables_and_index() {
         let conn = mem();
         bootstrap_honker_schema(&conn).unwrap();
@@ -2312,7 +2408,7 @@ while True:
         // Idempotent.
         bootstrap_honker_schema(&conn).unwrap();
 
-        // _honker_live has the 12 columns we expect (Python binding
+        // _honker_live has the 13 columns we expect (Python binding
         // and the extension have historically disagreed on _honker_dead
         // column count; this pins both).
         let live_cols: Vec<String> = conn
@@ -2322,8 +2418,9 @@ while True:
             .unwrap()
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
-        assert_eq!(live_cols.len(), 12);
+        assert_eq!(live_cols.len(), 13);
         assert!(live_cols.contains(&"expires_at".to_string()));
+        assert!(live_cols.contains(&"claimed_at".to_string()));
 
         let dead_cols: Vec<String> = conn
             .prepare("SELECT name FROM pragma_table_info('_honker_dead')")

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -2398,6 +2398,38 @@ while True:
         // Idempotent: the second bootstrap must not error on the column
         // it just added.
         bootstrap_honker_schema(&conn).unwrap();
+
+        // A migrated table and a fresh one must be the same table. Not
+        // just the same set of names — the same names in the same `cid`
+        // order, so anything that reads _honker_live positionally (a
+        // `SELECT *` in a user's own SQL, a dump and restore) behaves
+        // identically on both. ALTER TABLE ADD COLUMN appends, and the
+        // CREATE TABLE puts claimed_at last, which is what makes this
+        // hold; it breaks the moment someone inserts a column mid-list
+        // in BOOTSTRAP_HONKER_SQL. Measured: moving claimed_at above
+        // expires_at in the CREATE TABLE fails this and nothing else.
+        let migrated_cols = live_column_names(&conn);
+        let fresh = mem();
+        bootstrap_honker_schema(&fresh).unwrap();
+        let fresh_cols = live_column_names(&fresh);
+        assert_eq!(
+            migrated_cols, fresh_cols,
+            "a migrated _honker_live must have the same columns in the same order as a fresh one"
+        );
+        assert_eq!(
+            migrated_cols.last().map(String::as_str),
+            Some("claimed_at"),
+            "claimed_at is appended by ALTER TABLE, so the fresh CREATE TABLE must put it last too"
+        );
+    }
+
+    fn live_column_names(conn: &Connection) -> Vec<String> {
+        conn.prepare("SELECT name FROM pragma_table_info('_honker_live') ORDER BY cid")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Closes #135.

> **Stacked PR — must merge second.** Base is `fix/propagate-sqlite-errors` (#138), not `main`. Both branches touch `honker_ops.rs` and conflict if merged out of order. Merge #138 first, then this.

`_honker_live` had no column recording when the current attempt started, so Honker could not report how long a job had been running. None of the existing timestamps answer it:

- `created_at` is total job age and includes queue wait
- `run_at` is when the job became ready to run
- `claim_expires_at` moves on every heartbeat

## Change

New nullable `claimed_at INTEGER` on `_honker_live`.

| transition | `claimed_at` |
| --- | --- |
| enqueued, never claimed | `NULL` |
| first claim | `unixepoch()` |
| heartbeat | **unchanged** |
| retry back to pending | `NULL` |
| reclaim after visibility timeout | `unixepoch()` (new attempt) |

Set in `claim_batch`'s UPDATE, which is the single statement handling both first claim and reclaim, so both are covered by one change. Cleared in `retry`'s pending-flip. `heartbeat()` is untouched by design and now says so in its doc comment — refreshing `claimed_at` on a heartbeat would make a long-running job look like it just started, which is the exact blind spot this column exists to fix.

Exposed in `claim_batch`'s `RETURNING` and JSON, and in `get_job`'s JSON.

## Migration

Existing databases get the column through `ALTER TABLE _honker_live ADD COLUMN claimed_at INTEGER`, using the same `pragma_table_info` check and `"duplicate column"` tolerance as the existing `enabled` and `max_attempts` migrations in `lib.rs`. `CREATE TABLE IF NOT EXISTS` does not add columns to a table that already exists, so the ALTER is the only path for an existing database.

Nullable with no default on purpose: a default would date every pre-existing row to migration time and read as a claim that never happened.

The column is declared last in `BOOTSTRAP_HONKER_SQL` so a freshly created table and an ALTER-migrated one agree on column order.

## Binding impact

None required, and none made — core only. Both JSON changes are additive, and no binding declares `serde(deny_unknown_fields)` (checked across `packages/` and `honker-extension/`), so existing consumers ignore the new field until they opt in. Issue #135 leaves the per-binding rollout open; that is follow-up work.

## Tests

```
claimed_at_is_null_until_the_first_claim ... ok
first_claim_sets_claimed_at_and_returns_it ... ok
heartbeat_moves_the_deadline_but_not_claimed_at ... ok
retry_clears_claimed_at_when_the_job_goes_back_to_pending ... ok
reclaim_resets_claimed_at_to_the_new_attempt ... ok
ack_and_fail_do_not_need_claimed_at_but_still_work ... ok
bootstrap_pre_claimed_at_database_gains_the_column_and_keeps_its_rows ... ok

test result: ok. 74 passed; 0 failed; 1 ignored
```

`bootstrap_honker_schema_creates_tables_and_index` updated from 12 to 13 `_honker_live` columns.

## Proof the tests are load-bearing

**Break A — add `claimed_at = unixepoch()` to `heartbeat()`'s UPDATE** (the forbidden change):

```
heartbeat_moves_the_deadline_but_not_claimed_at ... FAILED
  assertion `left == right` failed: a heartbeat must NOT refresh claimed_at:
  it extends the claim, it does not start a new attempt
    left: Some(1788254358)
   right: Some(1788250758)
```

Worth calling out: **the first version of this test passed under Break A.** The claim and the heartbeat landed in the same second, so a heartbeat that did refresh `claimed_at` wrote back an identical value and the equality assertion could not see it. The test now backdates `claimed_at` by an hour before the heartbeat, and a comment in the test records why. Break A was re-run after the fix and fails as shown.

**Break B — drop `claimed_at = NULL` from `retry`'s pending-flip:**

```
retry_clears_claimed_at_when_the_job_goes_back_to_pending ... FAILED
  assertion `left == right` failed: a job waiting in the queue is not running,
  so claimed_at must be cleared
```

**Break C — remove the ALTER TABLE migration, leaving only `CREATE TABLE IF NOT EXISTS`:**

```
bootstrap_pre_claimed_at_database_gains_the_column_and_keeps_its_rows ... FAILED
  claimed_at must be added to a table that already existed;
  CREATE TABLE IF NOT EXISTS cannot do it
```

**Break D — drop `claimed_at = unixepoch()` from `claim_batch`'s UPDATE:**

```
test result: FAILED. 2 passed; 5 failed
```

All four breaks were restored and the suite is green.

## Scope

`honker-core/src/lib.rs`, `honker-core/src/honker_ops.rs`, `CHANGELOG.md`. No bindings touched.

https://claude.ai/code/session_01YMCFasvKC52r37DDKSTeMC
