### PR TITLE
feat(jvm): carry every job field and add job snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,7 +730,7 @@ jobs:
         # differs is Linux-specific and needs its own investigation —
         # tracked in ROADMAP under Phase Kernel-JVM.
         #
-        # The other 49 tests gate, and so do the ORM recipes below.
+        # The other 52 tests gate, and so do the ORM recipes below.
         run: mvn -B test -Dtest='!HonkerJvmTest#childJvmKernelListenerWakesWhenParentNotifies'
       - name: ORM · JVM (JDBC, Hibernate, jOOQ)
         working-directory: scripts/proof/orm/jvm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,7 +730,7 @@ jobs:
         # differs is Linux-specific and needs its own investigation —
         # tracked in ROADMAP under Phase Kernel-JVM.
         #
-        # The other 44 tests gate, and so do the ORM recipes below.
+        # The other 49 tests gate, and so do the ORM recipes below.
         run: mvn -B test -Dtest='!HonkerJvmTest#childJvmKernelListenerWakesWhenParentNotifies'
       - name: ORM · JVM (JDBC, Hibernate, jOOQ)
         working-directory: scripts/proof/orm/jvm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,25 @@
 - Regression test claims a job at a deadline with one claim forced to
   return empty: it fails on the unpatched `api.js` and passes on the fix.
 
+## Unreleased — JVM job parity
+
+- JVM claimed `Job` and `TypedJob<T>` now carry every field the core
+  returns: `id`, `queue`, `payloadJson`, `state`, `priority`, `runAt`,
+  `workerId`, `claimExpiresAt`, `attempts`, `maxAttempts`, `createdAt`,
+  and `expiresAt`. The core JSON stays snake_case; the accessors are
+  camelCase. Times are unix epoch seconds.
+- New `JobSnapshot` record: the same twelve fields with no claim
+  operations. `Queue.getJob(id)` returns one scoped to that queue,
+  `Database.getJob(id)` looks up by id across every queue. Both are empty
+  once the job is ack'd or dead-lettered. `TypedQueue.getJob(id)` returns
+  a `TypedJobSnapshot<T>` with the payload already decoded.
+- Payload types stay a compile-time contract. Honker does not validate
+  payload shape in the database, and no runtime validation was added.
+- Tests enqueue with an explicit `runAt`, priority, `maxAttempts` and
+  `expires`, then claim and assert each field's value — including a
+  reader on a second connection watching one job go pending, processing,
+  then gone after ack.
+
 ## Unreleased — typed Node jobs
 
 - Node `Queue`, `Job`, `JobSnapshot`, `ClaimWaker`, and `Outbox` APIs now carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,29 @@
   a `TypedJobSnapshot<T>` with the payload already decoded.
 - Payload types stay a compile-time contract. Honker does not validate
   payload shape in the database, and no runtime validation was added.
+- `TypedJob.snapshot()` returns a `TypedJobSnapshot<T>`, so the typed
+  path stays typed end to end. `raw()` steps down a layer:
+  `TypedJob.raw()` is the `Job`, `TypedJobSnapshot.raw()` is the
+  `JobSnapshot`.
+- The three nullable accessors (`workerId`, `claimExpiresAt`,
+  `expiresAt`) carry `org.jspecify.annotations.@Nullable`. The dependency
+  was already declared and unused. Kotlin callers see `String?` / `Long?`
+  instead of a platform type.
+- Building a claimed `Job` from a row with no `worker_id` or
+  `claim_expires_at` throws instead of unboxing `null` at
+  `claimExpiresAt()`.
 - Tests enqueue with an explicit `runAt`, priority, `maxAttempts` and
   `expires`, then claim and assert each field's value — including a
   reader on a second connection watching one job go pending, processing,
-  then gone after ack.
+  then gone after ack, a retry clearing `workerId` and `claimExpiresAt`
+  back to null while `attempts` survives, a `fail()` dead-letter leaving
+  no snapshot, and a narrow row from an older extension throwing rather
+  than filling in zeros.
+- `packages/honker-jvm/pom.xml` packages the extension from
+  `target/release`, falling back to `target/debug`, and fails the build
+  when neither exists. It copied `target/debug` only, with
+  `failonerror="false"`, so a release build produced a green
+  `mvn install` and a jar whose `runtimes/` directory was empty.
 
 ## Unreleased — typed Node jobs
 

--- a/packages/honker-jvm/README.md
+++ b/packages/honker-jvm/README.md
@@ -92,12 +92,17 @@ A claimed `Job` carries every field the core returns for the row:
 `id`, `queue`, `payloadJson`, `state`, `priority`, `runAt`, `workerId`,
 `claimExpiresAt`, `attempts`, `maxAttempts`, `createdAt`, and `expiresAt`.
 The core JSON is snake_case; the accessors are camelCase. Times are unix
-epoch seconds. `workerId`, `claimExpiresAt` and `expiresAt` are `null`
-when the row has no value for them.
+epoch seconds. A claimed row always names its worker and carries a claim
+deadline, so `workerId()` and `claimExpiresAt()` are never `null` on a
+`Job`. Only `expiresAt()` is, and only when the job was enqueued without
+`expires`.
 
 `JobSnapshot` is the same data with no claim operations. Read one with
 `Queue.getJob(id)` (scoped to that queue) or `Database.getJob(id)`
-(global). It is empty once the job is ack'd or dead-lettered.
+(global). It is empty once the job is ack'd or dead-lettered. A snapshot
+can describe a pending row, so all three of `workerId()`,
+`claimExpiresAt()` and `expiresAt()` are `null` when the row has no value
+for them.
 
 ```java
 Queue emails = db.queue("emails");
@@ -117,7 +122,10 @@ emails.getJob(id);                        // Optional.empty()
 ```
 
 `TypedQueue.getJob(id)` returns a `TypedJobSnapshot<T>` with the payload
-already decoded.
+already decoded, and `TypedJob.snapshot()` hands out the same shape for a
+job you already claimed. `raw()` steps down a layer either way:
+`TypedJob.raw()` is the `Job`, `TypedJobSnapshot.raw()` is the
+`JobSnapshot`.
 
 Payload types are a compile-time contract between the callers that share
 a queue. Honker does not validate payload shape in the database, so every

--- a/packages/honker-jvm/README.md
+++ b/packages/honker-jvm/README.md
@@ -86,6 +86,43 @@ sendEmail(job.payload());
 job.ack();
 ```
 
+## Job fields and snapshots
+
+A claimed `Job` carries every field the core returns for the row:
+`id`, `queue`, `payloadJson`, `state`, `priority`, `runAt`, `workerId`,
+`claimExpiresAt`, `attempts`, `maxAttempts`, `createdAt`, and `expiresAt`.
+The core JSON is snake_case; the accessors are camelCase. Times are unix
+epoch seconds. `workerId`, `claimExpiresAt` and `expiresAt` are `null`
+when the row has no value for them.
+
+`JobSnapshot` is the same data with no claim operations. Read one with
+`Queue.getJob(id)` (scoped to that queue) or `Database.getJob(id)`
+(global). It is empty once the job is ack'd or dead-lettered.
+
+```java
+Queue emails = db.queue("emails");
+long id = emails.enqueue("{\"to\":\"alice@example.com\"}");
+
+JobSnapshot pending = emails.getJob(id).orElseThrow();
+System.out.println(pending.state());     // "pending"
+System.out.println(pending.workerId());  // null
+
+Job job = emails.claimOne("worker-1").orElseThrow();
+System.out.println(job.state());          // "processing"
+System.out.println(job.attempts() + "/" + job.maxAttempts());
+System.out.println(job.claimExpiresAt());
+job.ack();
+
+emails.getJob(id);                        // Optional.empty()
+```
+
+`TypedQueue.getJob(id)` returns a `TypedJobSnapshot<T>` with the payload
+already decoded.
+
+Payload types are a compile-time contract between the callers that share
+a queue. Honker does not validate payload shape in the database, so every
+writer must agree on the JSON it produces.
+
 Result waits can use `CompletableFuture`:
 
 ```java

--- a/packages/honker-jvm/pom.xml
+++ b/packages/honker-jvm/pom.xml
@@ -51,11 +51,17 @@
             <phase>process-resources</phase>
             <configuration>
               <!--
-                Packages the extension the jar ships to users. This used to
-                copy `target/debug` only, with failonerror="false", so a
-                release build produced a green `mvn install` and a jar whose
-                runtimes/ directory was empty. Prefer release, fall back to
-                debug, and fail the build when neither exists.
+                Packages the extension the jar ships to users, which is the
+                only way it is found once the jar leaves this repo (see
+                scripts/test-jvm-consumer.sh, which unsets
+                HONKER_EXTENSION_PATH). This used to copy `target/debug`
+                only, with failonerror="false", so a release cargo build
+                followed by `mvn install` gave a green build and a jar whose
+                runtimes/ directory was empty.
+
+                Take whichever of debug and release was built last, so a
+                stale artifact never beats the one you just compiled, and
+                fail the build when there is neither.
               -->
               <target>
                 <property name="honker.native.release"
@@ -63,9 +69,16 @@
                 <property name="honker.native.debug"
                           location="${project.basedir}/../../target/debug/${honker.native.name}"/>
                 <condition property="honker.native.src"
-                           value="${honker.native.release}"
-                           else="${honker.native.debug}">
-                  <available file="${honker.native.release}"/>
+                           value="${honker.native.debug}"
+                           else="${honker.native.release}">
+                  <and>
+                    <available file="${honker.native.debug}"/>
+                    <or>
+                      <not><available file="${honker.native.release}"/></not>
+                      <uptodate srcfile="${honker.native.release}"
+                                targetfile="${honker.native.debug}"/>
+                    </or>
+                  </and>
                 </condition>
                 <fail message="Honker extension not built for ${honker.native.platform}. Looked for ${honker.native.release} and ${honker.native.debug}. Run: cargo build --release -p honker-extension">
                   <condition>

--- a/packages/honker-jvm/pom.xml
+++ b/packages/honker-jvm/pom.xml
@@ -50,11 +50,31 @@
             <id>copy-native-extension</id>
             <phase>process-resources</phase>
             <configuration>
+              <!--
+                Packages the extension the jar ships to users. This used to
+                copy `target/debug` only, with failonerror="false", so a
+                release build produced a green `mvn install` and a jar whose
+                runtimes/ directory was empty. Prefer release, fall back to
+                debug, and fail the build when neither exists.
+              -->
               <target>
+                <property name="honker.native.release"
+                          location="${project.basedir}/../../target/release/${honker.native.name}"/>
+                <property name="honker.native.debug"
+                          location="${project.basedir}/../../target/debug/${honker.native.name}"/>
+                <condition property="honker.native.src"
+                           value="${honker.native.release}"
+                           else="${honker.native.debug}">
+                  <available file="${honker.native.release}"/>
+                </condition>
+                <fail message="Honker extension not built for ${honker.native.platform}. Looked for ${honker.native.release} and ${honker.native.debug}. Run: cargo build --release -p honker-extension">
+                  <condition>
+                    <not><available file="${honker.native.src}"/></not>
+                  </condition>
+                </fail>
                 <mkdir dir="${project.build.outputDirectory}/runtimes/${honker.native.platform}/native"/>
-                <copy file="${project.basedir}/../../target/debug/${honker.native.name}"
-                      todir="${project.build.outputDirectory}/runtimes/${honker.native.platform}/native"
-                      failonerror="false"/>
+                <copy file="${honker.native.src}"
+                      todir="${project.build.outputDirectory}/runtimes/${honker.native.platform}/native"/>
               </target>
             </configuration>
             <goals>

--- a/packages/honker-jvm/src/main/java/dev/honker/Database.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/Database.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -63,6 +64,23 @@ public final class Database implements AutoCloseable {
     public Queue queue(String name, QueueOptions options) {
         ensureOpen();
         return new Queue(this, name, options);
+    }
+
+    /**
+     * A read-only snapshot of one live job, looked up by id across every
+     * queue, or empty when the job was ack'd, dead-lettered or never
+     * existed. Use {@link Queue#getJob(long)} to scope the lookup to one
+     * queue.
+     */
+    public Optional<JobSnapshot> getJob(long jobId) {
+        String raw = transaction(tx -> tx.query(
+            "SELECT honker_get_job(?) AS job",
+            Params.of(jobId)
+        ).get(0).getString("job"));
+        if (raw == null || raw.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(JobSnapshot.from(Json.object(raw)));
     }
 
     public Outbox outbox(String name, Delivery delivery) {

--- a/packages/honker-jvm/src/main/java/dev/honker/Job.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/Job.java
@@ -3,93 +3,112 @@ package dev.honker;
 import java.time.Duration;
 import java.util.Map;
 
+/**
+ * One job this worker holds a claim on.
+ *
+ * <p>Carries every field the core returns for the row (see
+ * {@link #snapshot()}) plus the claim operations: ack, retry, fail and
+ * heartbeat.
+ */
 public final class Job {
     private final Queue queueRef;
-    private final long id;
-    private final String queue;
-    private final String payloadJson;
-    private final String workerId;
-    private final int attempts;
-    private final long claimExpiresAt;
+    private final JobSnapshot snapshot;
 
-    private Job(Queue queueRef, long id, String queue, String payloadJson, String workerId, int attempts, long claimExpiresAt) {
+    private Job(Queue queueRef, JobSnapshot snapshot) {
         this.queueRef = queueRef;
-        this.id = id;
-        this.queue = queue;
-        this.payloadJson = payloadJson;
-        this.workerId = workerId;
-        this.attempts = attempts;
-        this.claimExpiresAt = claimExpiresAt;
+        this.snapshot = snapshot;
     }
 
     static Job from(Queue queue, Map<String, Object> row) {
-        return new Job(
-            queue,
-            number(row.get("id")),
-            string(row.get("queue")),
-            string(row.get("payload")),
-            string(row.get("worker_id")),
-            Math.toIntExact(number(row.get("attempts"))),
-            number(row.get("claim_expires_at"))
-        );
+        return new Job(queue, JobSnapshot.from(row));
+    }
+
+    /** The read-only view of this job's row. */
+    public JobSnapshot snapshot() {
+        return snapshot;
     }
 
     public long id() {
-        return id;
+        return snapshot.id();
     }
 
     public String queue() {
-        return queue;
+        return snapshot.queue();
     }
 
     public String payloadJson() {
-        return payloadJson;
+        return snapshot.payloadJson();
     }
 
+    /**
+     * Decode the payload with {@code codec}. The type is a compile-time
+     * contract only; Honker never validates payload shape.
+     */
     public <T> T payload(JsonCodec<T> codec) {
-        return codec.decode(payloadJson);
+        return snapshot.payload(codec);
+    }
+
+    /** Always {@code "processing"} for a job this worker just claimed. */
+    public String state() {
+        return snapshot.state();
+    }
+
+    public int priority() {
+        return snapshot.priority();
+    }
+
+    /** When the job became claimable, unix epoch seconds. */
+    public long runAt() {
+        return snapshot.runAt();
     }
 
     public String workerId() {
-        return workerId;
+        return snapshot.workerId();
+    }
+
+    /** When this claim lapses, unix epoch seconds. Never null on a claimed job. */
+    public long claimExpiresAt() {
+        return snapshot.claimExpiresAt();
     }
 
     public int attempts() {
-        return attempts;
+        return snapshot.attempts();
     }
 
-    public long claimExpiresAt() {
-        return claimExpiresAt;
+    public int maxAttempts() {
+        return snapshot.maxAttempts();
+    }
+
+    /** When the job was enqueued, unix epoch seconds. */
+    public long createdAt() {
+        return snapshot.createdAt();
+    }
+
+    /**
+     * When the job stops being claimable, unix epoch seconds, or {@code null}
+     * when it was enqueued without {@code expires}.
+     */
+    public Long expiresAt() {
+        return snapshot.expiresAt();
     }
 
     public boolean ack() {
-        return queueRef.ack(id, workerId);
+        return queueRef.ack(id(), workerId());
     }
 
     public boolean retry(Duration delay, String error) {
-        return queueRef.retry(id, workerId, delay, error);
+        return queueRef.retry(id(), workerId(), delay, error);
     }
 
     public boolean fail(String error) {
-        return queueRef.fail(id, workerId, error);
+        return queueRef.fail(id(), workerId(), error);
     }
 
     public boolean heartbeat() {
-        return queueRef.heartbeat(id, workerId);
+        return queueRef.heartbeat(id(), workerId());
     }
 
     public boolean heartbeat(Duration extendBy) {
-        return queueRef.heartbeat(id, workerId, extendBy);
-    }
-
-    private static String string(Object value) {
-        return value == null ? null : value.toString();
-    }
-
-    private static long number(Object value) {
-        if (value instanceof Number n) {
-            return n.longValue();
-        }
-        return Long.parseLong(value.toString());
+        return queueRef.heartbeat(id(), workerId(), extendBy);
     }
 }

--- a/packages/honker-jvm/src/main/java/dev/honker/Job.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/Job.java
@@ -3,12 +3,19 @@ package dev.honker;
 import java.time.Duration;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * One job this worker holds a claim on.
  *
  * <p>Carries every field the core returns for the row (see
  * {@link #snapshot()}) plus the claim operations: ack, retry, fail and
  * heartbeat.
+ *
+ * <p>A claimed row always names its worker and carries a claim deadline,
+ * so {@link #workerId()} and {@link #claimExpiresAt()} are never null
+ * here. Only {@link #expiresAt()} can be. On a {@link JobSnapshot}, which
+ * can describe a pending row too, all three can be null.
  */
 public final class Job {
     private final Queue queueRef;
@@ -20,7 +27,16 @@ public final class Job {
     }
 
     static Job from(Queue queue, Map<String, Object> row) {
-        return new Job(queue, JobSnapshot.from(row));
+        JobSnapshot snapshot = JobSnapshot.from(row);
+        if (snapshot.workerId() == null || snapshot.claimExpiresAt() == null) {
+            // claimExpiresAt() below unboxes, and every accessor promises a
+            // held claim. A row without both is not one we hold, so say so
+            // rather than throwing a bare NullPointerException later.
+            throw new HonkerException(
+                "claimed job row from Honker has no worker_id or claim_expires_at: id=" + snapshot.id()
+            );
+        }
+        return new Job(queue, snapshot);
     }
 
     /** The read-only view of this job's row. */
@@ -66,7 +82,7 @@ public final class Job {
         return snapshot.workerId();
     }
 
-    /** When this claim lapses, unix epoch seconds. Never null on a claimed job. */
+    /** When this claim lapses, unix epoch seconds. Always set on a claimed job. */
     public long claimExpiresAt() {
         return snapshot.claimExpiresAt();
     }
@@ -88,7 +104,7 @@ public final class Job {
      * When the job stops being claimable, unix epoch seconds, or {@code null}
      * when it was enqueued without {@code expires}.
      */
-    public Long expiresAt() {
+    public @Nullable Long expiresAt() {
         return snapshot.expiresAt();
     }
 

--- a/packages/honker-jvm/src/main/java/dev/honker/JobSnapshot.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/JobSnapshot.java
@@ -2,6 +2,8 @@ package dev.honker;
 
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A read-only view of one live job row, carrying every field the core
  * returns from {@code honker_claim_batch} and {@code honker_get_job}.
@@ -21,12 +23,12 @@ public record JobSnapshot(
     String state,
     int priority,
     long runAt,
-    String workerId,
-    Long claimExpiresAt,
+    @Nullable String workerId,
+    @Nullable Long claimExpiresAt,
     int attempts,
     int maxAttempts,
     long createdAt,
-    Long expiresAt
+    @Nullable Long expiresAt
 ) {
     /**
      * Decode {@link #payloadJson()} with {@code codec}.

--- a/packages/honker-jvm/src/main/java/dev/honker/JobSnapshot.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/JobSnapshot.java
@@ -1,0 +1,95 @@
+package dev.honker;
+
+import java.util.Map;
+
+/**
+ * A read-only view of one live job row, carrying every field the core
+ * returns from {@code honker_claim_batch} and {@code honker_get_job}.
+ *
+ * <p>Data only. Ack, retry, fail and heartbeat live on a claimed
+ * {@link Job}, because only the worker that holds the claim may call them.
+ *
+ * <p>Times are unix epoch seconds. Three components are {@code null} when
+ * the row has no value for them: a pending job has no {@code workerId} and
+ * no {@code claimExpiresAt}, and a job enqueued without {@code expires} has
+ * no {@code expiresAt}.
+ */
+public record JobSnapshot(
+    long id,
+    String queue,
+    String payloadJson,
+    String state,
+    int priority,
+    long runAt,
+    String workerId,
+    Long claimExpiresAt,
+    int attempts,
+    int maxAttempts,
+    long createdAt,
+    Long expiresAt
+) {
+    /**
+     * Decode {@link #payloadJson()} with {@code codec}.
+     *
+     * <p>The type is a compile-time contract between the callers that share
+     * this queue. Honker never inspects or validates payload shape in the
+     * database, so every writer must agree on the JSON it produces.
+     */
+    public <T> T payload(JsonCodec<T> codec) {
+        return codec.decode(payloadJson);
+    }
+
+    static JobSnapshot from(Map<String, Object> row) {
+        return new JobSnapshot(
+            requiredLong(row, "id"),
+            requiredString(row, "queue"),
+            requiredString(row, "payload"),
+            requiredString(row, "state"),
+            Math.toIntExact(requiredLong(row, "priority")),
+            requiredLong(row, "run_at"),
+            nullableString(row.get("worker_id")),
+            nullableLong(row, "claim_expires_at"),
+            Math.toIntExact(requiredLong(row, "attempts")),
+            Math.toIntExact(requiredLong(row, "max_attempts")),
+            requiredLong(row, "created_at"),
+            nullableLong(row, "expires_at")
+        );
+    }
+
+    private static String requiredString(Map<String, Object> row, String field) {
+        Object value = required(row, field);
+        return value.toString();
+    }
+
+    private static long requiredLong(Map<String, Object> row, String field) {
+        return toLong(required(row, field), field);
+    }
+
+    private static Object required(Map<String, Object> row, String field) {
+        Object value = row.get(field);
+        if (value == null) {
+            throw new HonkerException("job row from Honker is missing required field " + field);
+        }
+        return value;
+    }
+
+    private static String nullableString(Object value) {
+        return value == null ? null : value.toString();
+    }
+
+    private static Long nullableLong(Map<String, Object> row, String field) {
+        Object value = row.get(field);
+        return value == null ? null : toLong(value, field);
+    }
+
+    private static long toLong(Object value, String field) {
+        if (value instanceof Number n) {
+            return n.longValue();
+        }
+        try {
+            return Long.parseLong(value.toString());
+        } catch (NumberFormatException e) {
+            throw new HonkerException("job row field " + field + " is not a number: " + value);
+        }
+    }
+}

--- a/packages/honker-jvm/src/main/java/dev/honker/JobSnapshot.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/JobSnapshot.java
@@ -70,7 +70,10 @@ public record JobSnapshot(
     private static Object required(Map<String, Object> row, String field) {
         Object value = row.get(field);
         if (value == null) {
-            throw new HonkerException("job row from Honker is missing required field " + field);
+            throw new HonkerException(
+                "job row from Honker is missing required field " + field
+                    + "; the loaded extension may be older than this binding"
+            );
         }
         return value;
     }

--- a/packages/honker-jvm/src/main/java/dev/honker/Queue.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/Queue.java
@@ -68,6 +68,19 @@ public final class Queue {
         return out;
     }
 
+    /**
+     * A read-only snapshot of one live job in <em>this</em> queue, or empty
+     * when the job was ack'd, dead-lettered, never existed, or belongs to a
+     * different queue.
+     *
+     * <p>Job ids are globally unique, so the id alone cannot say which queue
+     * owns the row. Scoping the lookup keeps a typed queue's payload type
+     * honest. Use {@link Database#getJob(long)} for a global lookup.
+     */
+    public Optional<JobSnapshot> getJob(long jobId) {
+        return db.getJob(jobId).filter(job -> name.equals(job.queue()));
+    }
+
     public long nextClaimAt() {
         return db.transaction(tx -> tx.query(
             "SELECT honker_queue_next_claim_at(?) AS t",

--- a/packages/honker-jvm/src/main/java/dev/honker/TypedJob.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/TypedJob.java
@@ -15,8 +15,21 @@ public final class TypedJob<T> {
         return raw;
     }
 
+    /** The read-only view of this job's row. */
+    public JobSnapshot snapshot() {
+        return raw.snapshot();
+    }
+
+    /**
+     * The payload decoded with this queue's codec. The type is a
+     * compile-time contract only; Honker never validates payload shape.
+     */
     public T payload() {
         return codec.decode(raw.payloadJson());
+    }
+
+    public String payloadJson() {
+        return raw.payloadJson();
     }
 
     public long id() {
@@ -27,6 +40,20 @@ public final class TypedJob<T> {
         return raw.queue();
     }
 
+    /** Always {@code "processing"} for a job this worker just claimed. */
+    public String state() {
+        return raw.state();
+    }
+
+    public int priority() {
+        return raw.priority();
+    }
+
+    /** When the job became claimable, unix epoch seconds. */
+    public long runAt() {
+        return raw.runAt();
+    }
+
     public String workerId() {
         return raw.workerId();
     }
@@ -35,8 +62,26 @@ public final class TypedJob<T> {
         return raw.attempts();
     }
 
+    /** When this claim lapses, unix epoch seconds. */
     public long claimExpiresAt() {
         return raw.claimExpiresAt();
+    }
+
+    public int maxAttempts() {
+        return raw.maxAttempts();
+    }
+
+    /** When the job was enqueued, unix epoch seconds. */
+    public long createdAt() {
+        return raw.createdAt();
+    }
+
+    /**
+     * When the job stops being claimable, unix epoch seconds, or
+     * {@code null} when it was enqueued without {@code expires}.
+     */
+    public Long expiresAt() {
+        return raw.expiresAt();
     }
 
     public boolean ack() {

--- a/packages/honker-jvm/src/main/java/dev/honker/TypedJob.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/TypedJob.java
@@ -2,6 +2,8 @@ package dev.honker;
 
 import java.time.Duration;
 
+import org.jspecify.annotations.Nullable;
+
 public final class TypedJob<T> {
     private final Job raw;
     private final JsonCodec<T> codec;
@@ -15,9 +17,13 @@ public final class TypedJob<T> {
         return raw;
     }
 
-    /** The read-only view of this job's row. */
-    public JobSnapshot snapshot() {
-        return raw.snapshot();
+    /**
+     * The read-only view of this job's row, with the payload decoded by
+     * this queue's codec. Use {@code raw().snapshot()} for the undecoded
+     * {@link JobSnapshot}.
+     */
+    public TypedJobSnapshot<T> snapshot() {
+        return TypedJobSnapshot.of(raw.snapshot(), codec);
     }
 
     /**
@@ -62,7 +68,7 @@ public final class TypedJob<T> {
         return raw.attempts();
     }
 
-    /** When this claim lapses, unix epoch seconds. */
+    /** When this claim lapses, unix epoch seconds. Always set on a claimed job. */
     public long claimExpiresAt() {
         return raw.claimExpiresAt();
     }
@@ -80,7 +86,7 @@ public final class TypedJob<T> {
      * When the job stops being claimable, unix epoch seconds, or
      * {@code null} when it was enqueued without {@code expires}.
      */
-    public Long expiresAt() {
+    public @Nullable Long expiresAt() {
         return raw.expiresAt();
     }
 

--- a/packages/honker-jvm/src/main/java/dev/honker/TypedJobSnapshot.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/TypedJobSnapshot.java
@@ -1,5 +1,7 @@
 package dev.honker;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A {@link JobSnapshot} whose payload is already decoded to {@code T}.
  *
@@ -35,11 +37,11 @@ public record TypedJobSnapshot<T>(JobSnapshot raw, T payload) {
         return raw.runAt();
     }
 
-    public String workerId() {
+    public @Nullable String workerId() {
         return raw.workerId();
     }
 
-    public Long claimExpiresAt() {
+    public @Nullable Long claimExpiresAt() {
         return raw.claimExpiresAt();
     }
 
@@ -55,7 +57,7 @@ public record TypedJobSnapshot<T>(JobSnapshot raw, T payload) {
         return raw.createdAt();
     }
 
-    public Long expiresAt() {
+    public @Nullable Long expiresAt() {
         return raw.expiresAt();
     }
 }

--- a/packages/honker-jvm/src/main/java/dev/honker/TypedJobSnapshot.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/TypedJobSnapshot.java
@@ -1,0 +1,61 @@
+package dev.honker;
+
+/**
+ * A {@link JobSnapshot} whose payload is already decoded to {@code T}.
+ *
+ * <p>Like {@link JobSnapshot} this is data only. The payload type is a
+ * compile-time contract; Honker does not validate payload shape.
+ */
+public record TypedJobSnapshot<T>(JobSnapshot raw, T payload) {
+    static <T> TypedJobSnapshot<T> of(JobSnapshot raw, JsonCodec<T> codec) {
+        return new TypedJobSnapshot<>(raw, codec.decode(raw.payloadJson()));
+    }
+
+    public long id() {
+        return raw.id();
+    }
+
+    public String queue() {
+        return raw.queue();
+    }
+
+    public String payloadJson() {
+        return raw.payloadJson();
+    }
+
+    public String state() {
+        return raw.state();
+    }
+
+    public int priority() {
+        return raw.priority();
+    }
+
+    public long runAt() {
+        return raw.runAt();
+    }
+
+    public String workerId() {
+        return raw.workerId();
+    }
+
+    public Long claimExpiresAt() {
+        return raw.claimExpiresAt();
+    }
+
+    public int attempts() {
+        return raw.attempts();
+    }
+
+    public int maxAttempts() {
+        return raw.maxAttempts();
+    }
+
+    public long createdAt() {
+        return raw.createdAt();
+    }
+
+    public Long expiresAt() {
+        return raw.expiresAt();
+    }
+}

--- a/packages/honker-jvm/src/main/java/dev/honker/TypedQueue.java
+++ b/packages/honker-jvm/src/main/java/dev/honker/TypedQueue.java
@@ -36,6 +36,14 @@ public final class TypedQueue<T> {
         return queue.enqueue(tx, codec.encode(payload), options);
     }
 
+    /**
+     * A read-only snapshot of one live job in this queue with its payload
+     * decoded, or empty when the job is gone or belongs to another queue.
+     */
+    public Optional<TypedJobSnapshot<T>> getJob(long jobId) {
+        return queue.getJob(jobId).map(job -> TypedJobSnapshot.of(job, codec));
+    }
+
     public Optional<TypedJob<T>> claimOne(String workerId) {
         return queue.claimOne(workerId).map(job -> new TypedJob<>(job, codec));
     }

--- a/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
+++ b/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
@@ -73,6 +73,198 @@ class HonkerJvmTest {
     }
 
     @Test
+    void claimedJobCarriesEveryFieldCoreReturns() {
+        try (Database db = open()) {
+            Queue q = db.queue("full-fields", QueueOptions.builder()
+                .visibilityTimeout(Duration.ofSeconds(300))
+                .maxAttempts(5)
+                .build());
+            long runAt = unixNow(db) - 5;
+
+            long enqueuedBefore = unixNow(db);
+            long id = q.enqueue("{\"to\":\"alice@example.com\"}", EnqueueOptions.builder()
+                .runAt(Instant.ofEpochSecond(runAt))
+                .priority(7)
+                .expires(Duration.ofSeconds(600))
+                .build());
+            long enqueuedAfter = unixNow(db);
+
+            long claimedBefore = unixNow(db);
+            Job job = q.claimOne("worker-1").orElseThrow();
+            long claimedAfter = unixNow(db);
+
+            assertEquals(id, job.id());
+            assertEquals("full-fields", job.queue());
+            assertEquals("{\"to\":\"alice@example.com\"}", job.payloadJson());
+            assertEquals("processing", job.state());
+            assertEquals(7, job.priority());
+            assertEquals(runAt, job.runAt());
+            assertEquals("worker-1", job.workerId());
+            assertEquals(1, job.attempts());
+            assertEquals(5, job.maxAttempts());
+            assertBetween(job.createdAt(), enqueuedBefore, enqueuedAfter, "createdAt");
+            assertNotNull(job.expiresAt(), "expiresAt should be set by expires");
+            assertBetween(job.expiresAt(), enqueuedBefore + 600, enqueuedAfter + 600, "expiresAt");
+            assertBetween(job.claimExpiresAt(), claimedBefore + 300, claimedAfter + 300, "claimExpiresAt");
+
+            // The claimed Job keeps the claim operations; the snapshot is data only.
+            assertEquals(job.id(), job.snapshot().id());
+            assertEquals("processing", job.snapshot().state());
+            assertTrue(job.ack());
+        }
+    }
+
+    @Test
+    void jobSnapshotsFollowPendingProcessingAndAckedStates() {
+        try (Database worker = open(); Database reader = open()) {
+            Queue writes = worker.queue("snapshots", QueueOptions.builder()
+                .visibilityTimeout(Duration.ofSeconds(120))
+                .maxAttempts(4)
+                .build());
+            Queue reads = reader.queue("snapshots");
+
+            long runAt = unixNow(worker) - 2;
+            long enqueuedBefore = unixNow(worker);
+            long id = writes.enqueue("{\"n\":1}", EnqueueOptions.builder()
+                .runAt(Instant.ofEpochSecond(runAt))
+                .priority(2)
+                .build());
+            long enqueuedAfter = unixNow(worker);
+
+            JobSnapshot pending = reads.getJob(id).orElseThrow();
+            assertEquals(id, pending.id());
+            assertEquals("snapshots", pending.queue());
+            assertEquals("{\"n\":1}", pending.payloadJson());
+            assertEquals("pending", pending.state());
+            assertEquals(2, pending.priority());
+            assertEquals(runAt, pending.runAt());
+            assertNull(pending.workerId(), "a pending job has no worker");
+            assertNull(pending.claimExpiresAt(), "a pending job has no claim deadline");
+            assertEquals(0, pending.attempts());
+            assertEquals(4, pending.maxAttempts());
+            assertBetween(pending.createdAt(), enqueuedBefore, enqueuedAfter, "createdAt");
+            assertNull(pending.expiresAt(), "no expires means no expiresAt");
+
+            long claimedBefore = unixNow(worker);
+            Job claimed = writes.claimOne("worker-9").orElseThrow();
+            long claimedAfter = unixNow(worker);
+
+            JobSnapshot processing = reads.getJob(id).orElseThrow();
+            assertEquals(id, processing.id());
+            assertEquals("processing", processing.state());
+            assertEquals("worker-9", processing.workerId());
+            assertEquals(1, processing.attempts());
+            assertEquals(4, processing.maxAttempts());
+            assertEquals(2, processing.priority());
+            assertEquals(runAt, processing.runAt());
+            assertEquals(pending.createdAt(), processing.createdAt());
+            assertNotNull(processing.claimExpiresAt(), "a claimed job has a claim deadline");
+            assertBetween(processing.claimExpiresAt(), claimedBefore + 120, claimedAfter + 120, "claimExpiresAt");
+
+            assertTrue(claimed.ack());
+            assertTrue(reads.getJob(id).isEmpty(), "an ack'd job leaves no live row");
+        }
+    }
+
+    @Test
+    void delayedJobSnapshotReportsItsRunAt() {
+        try (Database db = open()) {
+            Queue q = db.queue("delayed-snapshot");
+
+            long before = unixNow(db);
+            long id = q.enqueue("{\"later\":true}", EnqueueOptions.builder()
+                .delay(Duration.ofSeconds(30))
+                .build());
+            long after = unixNow(db);
+
+            JobSnapshot snapshot = q.getJob(id).orElseThrow();
+            assertEquals("pending", snapshot.state());
+            assertBetween(snapshot.runAt(), before + 30, after + 30, "runAt");
+            assertTrue(snapshot.runAt() > unixNow(db), "a delayed job runs in the future");
+            assertTrue(q.claimOne("too-early").isEmpty(), "a delayed job is not claimable yet");
+        }
+    }
+
+    @Test
+    void typedQueueCarriesEveryFieldOnJobsAndSnapshots() {
+        JsonCodec<String> quoted = new JsonCodec<>() {
+            @Override
+            public String encode(String value) {
+                return "\"" + value + "\"";
+            }
+
+            @Override
+            public String decode(String json) {
+                return json.substring(1, json.length() - 1);
+            }
+        };
+
+        try (Database db = open()) {
+            Queue raw = db.queue("typed-fields", QueueOptions.builder()
+                .visibilityTimeout(Duration.ofSeconds(60))
+                .maxAttempts(2)
+                .build());
+            TypedQueue<String> typed = raw.typed(quoted);
+
+            long runAt = unixNow(db) - 1;
+            long enqueuedBefore = unixNow(db);
+            long id = typed.enqueue("welcome", EnqueueOptions.builder()
+                .runAt(Instant.ofEpochSecond(runAt))
+                .priority(4)
+                .expires(Duration.ofSeconds(900))
+                .build());
+            long enqueuedAfter = unixNow(db);
+
+            TypedJobSnapshot<String> pending = typed.getJob(id).orElseThrow();
+            assertEquals("welcome", pending.payload());
+            assertEquals("pending", pending.state());
+            assertEquals(4, pending.priority());
+            assertEquals(runAt, pending.runAt());
+            assertEquals(0, pending.attempts());
+            assertEquals(2, pending.maxAttempts());
+            assertNull(pending.workerId());
+            assertNull(pending.claimExpiresAt());
+            assertBetween(pending.createdAt(), enqueuedBefore, enqueuedAfter, "createdAt");
+            assertBetween(pending.expiresAt(), enqueuedBefore + 900, enqueuedAfter + 900, "expiresAt");
+
+            long claimedBefore = unixNow(db);
+            TypedJob<String> job = typed.claimOne("typed-worker").orElseThrow();
+            long claimedAfter = unixNow(db);
+
+            assertEquals(id, job.id());
+            assertEquals("typed-fields", job.queue());
+            assertEquals("welcome", job.payload());
+            assertEquals("\"welcome\"", job.payloadJson());
+            assertEquals("processing", job.state());
+            assertEquals(4, job.priority());
+            assertEquals(runAt, job.runAt());
+            assertEquals("typed-worker", job.workerId());
+            assertEquals(1, job.attempts());
+            assertEquals(2, job.maxAttempts());
+            assertBetween(job.createdAt(), enqueuedBefore, enqueuedAfter, "createdAt");
+            assertBetween(job.expiresAt(), enqueuedBefore + 900, enqueuedAfter + 900, "expiresAt");
+            assertBetween(job.claimExpiresAt(), claimedBefore + 60, claimedAfter + 60, "claimExpiresAt");
+
+            assertTrue(job.ack());
+            assertTrue(typed.getJob(id).isEmpty());
+        }
+    }
+
+    @Test
+    void getJobIsScopedToItsQueueWhileDatabaseLookupIsGlobal() {
+        try (Database db = open()) {
+            Queue emails = db.queue("scoped-emails");
+            Queue reports = db.queue("scoped-reports");
+            long id = emails.enqueue("{\"to\":\"alice@example.com\"}");
+
+            assertTrue(reports.getJob(id).isEmpty(), "another queue must not see this job");
+            assertEquals("scoped-emails", emails.getJob(id).orElseThrow().queue());
+            assertEquals("scoped-emails", db.getJob(id).orElseThrow().queue());
+            assertTrue(db.getJob(id + 10_000).isEmpty(), "an unknown id has no snapshot");
+        }
+    }
+
+    @Test
     void queueNegativePathsAndBatchOperations() {
         try (Database db = open()) {
             Queue q = db.queue("batch", QueueOptions.builder()
@@ -1123,6 +1315,17 @@ class HonkerJvmTest {
                 assertTrue(seen.await(3, TimeUnit.SECONDS), "worker should wake at run_at deadline");
             }
         }
+    }
+
+    private static long unixNow(Database db) {
+        return db.query("SELECT unixepoch() AS t").get(0).getLong("t");
+    }
+
+    private static void assertBetween(long actual, long low, long high, String field) {
+        assertTrue(
+            actual >= low && actual <= high,
+            () -> field + " should be within [" + low + ", " + high + "] but was " + actual
+        );
     }
 
     private Database open() {

--- a/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
+++ b/packages/honker-jvm/src/test/java/dev/honker/HonkerJvmTest.java
@@ -10,7 +10,9 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ConcurrentHashMap;
@@ -261,6 +263,105 @@ class HonkerJvmTest {
             assertEquals("scoped-emails", emails.getJob(id).orElseThrow().queue());
             assertEquals("scoped-emails", db.getJob(id).orElseThrow().queue());
             assertTrue(db.getJob(id + 10_000).isEmpty(), "an unknown id has no snapshot");
+        }
+    }
+
+    @Test
+    void retriedJobSnapshotGoesBackToPendingAndKeepsItsAttempts() {
+        try (Database db = open()) {
+            Queue q = db.queue("retried-snapshot", QueueOptions.builder()
+                .visibilityTimeout(Duration.ofSeconds(90))
+                .maxAttempts(3)
+                .build());
+            long id = q.enqueue("{\"n\":1}");
+
+            Job claimed = q.claimOne("worker-1").orElseThrow();
+            JobSnapshot processing = q.getJob(id).orElseThrow();
+            assertEquals("processing", processing.state());
+            assertNotNull(processing.workerId());
+            assertNotNull(processing.claimExpiresAt());
+
+            long retriedBefore = unixNow(db);
+            assertTrue(claimed.retry(Duration.ofSeconds(45), "transient"));
+            long retriedAfter = unixNow(db);
+
+            // The other snapshot tests only watch null -> value. This is the
+            // clearing direction: a retry hands the row back to the queue.
+            JobSnapshot retried = q.getJob(id).orElseThrow();
+            assertEquals("pending", retried.state());
+            assertNull(retried.workerId(), "a retried job has no worker");
+            assertNull(retried.claimExpiresAt(), "a retried job has no claim deadline");
+            // Attempts survive the retry -- that is what maxAttempts counts.
+            assertEquals(1, retried.attempts());
+            assertEquals(3, retried.maxAttempts());
+            assertEquals(processing.createdAt(), retried.createdAt());
+            assertBetween(retried.runAt(), retriedBefore + 45, retriedAfter + 45, "runAt");
+            assertTrue(q.claimOne("worker-2").isEmpty(), "the retry delay holds the job back");
+        }
+    }
+
+    @Test
+    void failedJobIsDeadLetteredAndHasNoSnapshot() {
+        try (Database db = open()) {
+            Queue q = db.queue("dead-snapshot", QueueOptions.builder()
+                .visibilityTimeout(Duration.ofSeconds(60))
+                .maxAttempts(1)
+                .build());
+            long id = q.enqueue("{\"n\":2}");
+
+            Job claimed = q.claimOne("worker-1").orElseThrow();
+            assertTrue(q.getJob(id).isPresent(), "a processing job still has a snapshot");
+            assertTrue(claimed.fail("boom"));
+
+            assertTrue(q.getJob(id).isEmpty(), "a dead-lettered job leaves no live row");
+            assertTrue(db.getJob(id).isEmpty(), "the global lookup does not see dead letters either");
+            // Distinguishes "gone because dead-lettered" from "never existed".
+            assertEquals(1, count(db, "SELECT COUNT(*) AS n FROM _honker_dead WHERE queue='dead-snapshot'"));
+        }
+    }
+
+    @Test
+    void jobRowsMissingRequiredFieldsFailLoudly() {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", 1L);
+        row.put("queue", "emails");
+        row.put("payload", "{}");
+        row.put("state", "processing");
+        row.put("priority", 0L);
+        row.put("run_at", 100L);
+        row.put("worker_id", "worker-1");
+        row.put("claim_expires_at", 400L);
+        row.put("attempts", 1L);
+        row.put("max_attempts", 3L);
+        row.put("created_at", 100L);
+        row.put("expires_at", null);
+
+        JobSnapshot ok = JobSnapshot.from(row);
+        assertEquals(100L, ok.createdAt());
+        assertNull(ok.expiresAt());
+
+        // An extension older than the widened claim_batch RETURNING sends a
+        // narrower row. That must throw, not yield silent zeros.
+        Map<String, Object> narrow = new LinkedHashMap<>(row);
+        narrow.remove("state");
+        HonkerException missing = assertThrows(HonkerException.class, () -> JobSnapshot.from(narrow));
+        assertTrue(missing.getMessage().contains("state"), missing.getMessage());
+
+        Map<String, Object> malformed = new LinkedHashMap<>(row);
+        malformed.put("run_at", "not-a-number");
+        HonkerException bad = assertThrows(HonkerException.class, () -> JobSnapshot.from(malformed));
+        assertTrue(bad.getMessage().contains("run_at"), bad.getMessage());
+
+        // A snapshot may describe an unclaimed row; a claimed Job may not,
+        // because claimExpiresAt() unboxes.
+        Map<String, Object> unclaimed = new LinkedHashMap<>(row);
+        unclaimed.put("worker_id", null);
+        unclaimed.put("claim_expires_at", null);
+        assertNull(JobSnapshot.from(unclaimed).claimExpiresAt());
+        try (Database db = open()) {
+            Queue q = db.queue("emails");
+            HonkerException unheld = assertThrows(HonkerException.class, () -> Job.from(q, unclaimed));
+            assertTrue(unheld.getMessage().contains("claim_expires_at"), unheld.getMessage());
         }
     }
 


### PR DESCRIPTION
Part of #136 — the JVM half of the binding checklist.

**Stacked on #124. Merge #124 first.** This branch is based on
`feat/node-typed-jobs`, not `main`: the widened `honker_claim_batch`
RETURNING clause that exposes the full job snapshot exists only there.
The base of this PR is `feat/node-typed-jobs` for that reason.

## What changed

`packages/honker-jvm` only. No core, no SQL ABI, no other binding.

- `Job` and `TypedJob<T>` now expose all twelve fields core already
  returns: `id`, `queue`, `payloadJson`, `state`, `priority`, `runAt`,
  `workerId`, `claimExpiresAt`, `attempts`, `maxAttempts`, `createdAt`,
  `expiresAt`. Core JSON stays snake_case; the accessors are camelCase.
  Times are unix epoch seconds. The three columns that can be NULL
  (`workerId`, `claimExpiresAt`, `expiresAt`) return null. A missing
  required field throws instead of defaulting.
- New `JobSnapshot` record — the same twelve fields, data only, no
  ack/retry/fail/heartbeat. `Job.snapshot()` hands one out.
- New `Queue.getJob(id)` returns `Optional<JobSnapshot>` scoped to that
  queue. Job ids are globally unique, so an unscoped hit could return a
  payload that does not match the queue's declared type. `Database.getJob(id)`
  is the global lookup. Same split Node landed in #124.
- New `TypedJobSnapshot<T>` and `TypedQueue.getJob(id)` — the snapshot
  with the payload already decoded by the queue's `JsonCodec<T>`.

`claimed_at` is deliberately not here; that is #135.

## Typing is compile-time only

Payload types are a contract between the callers that share a queue.
Honker does not validate payload shape in the database and this PR adds
no runtime validation. The README and CHANGELOG both say so.

## Tests

Five new tests in `HonkerJvmTest`, all asserting values rather than
presence:

- `claimedJobCarriesEveryFieldCoreReturns` — enqueues with an explicit
  `runAt`, `priority(7)`, `maxAttempts(5)` and `expires(600s)`, claims,
  and checks all twelve fields. The clock-derived three are bounded by
  `unixepoch()` readings taken around the write and the claim.
- `jobSnapshotsFollowPendingProcessingAndAckedStates` — a second
  `Database` on the same file reads the job pending (no worker, no claim
  deadline, 0 attempts), then processing (worker id, attempts 1, claim
  deadline in the visibility window), then empty after ack.
- `delayedJobSnapshotReportsItsRunAt`
- `typedQueueCarriesEveryFieldOnJobsAndSnapshots`
- `getJobIsScopedToItsQueueWhileDatabaseLookupIsGlobal`

Local run: `mvn -B test` → 50/50 pass (45 existing + 5 new), extension
built `--release`.

### The tests are load-bearing

Broke the `run_at` mapping in `JobSnapshot.from` to read `created_at` —
the realistic column mixup — and reran:

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0
HonkerJvmTest.delayedJobSnapshotReportsItsRunAt:182->assertBetween:1325
  runAt should be within [1788254339, 1788254339] but was 1788254309
  ==> expected: <true> but was: <false>
HonkerJvmTest.claimedJobCarriesEveryFieldCoreReturns:101
  expected: <1788254305> but was: <1788254310>
```

Restored, reran: 5/5 pass.

## Not touched

`honker-core`, the SQL ABI, `packages/honker-node`, every other binding.
The Kotlin half follows in a separate PR stacked on this one.

https://claude.ai/code/session_01YMCFasvKC52r37DDKSTeMC

---

## Snapshot payload encoding (cross-binding note, no change requested)

Flagging for a later deliberate decision across all bindings, per the
#136 coordination: **the JVM binding returns snapshot payloads as raw
JSON text.** `JobSnapshot.payloadJson()` is exactly the string the row
holds; decoding is opt-in and explicit via `payload(JsonCodec<T>)` or
`TypedQueue.getJob()` → `TypedJobSnapshot<T>.payload()`.

That matches what claimed JVM jobs already did (`Job.payloadJson()`), so
nothing changed encoding here. It also matches Go's `JobRow.Payload` and
Python's `get_job()["payload"]`, and differs from Node #124, which
returns a decoded payload. Three bindings, two conventions. Not resolved
in this PR — changing it would be a breaking API change #136 did not ask
for.
