### PR TITLE
feat(dotnet): full job details and typed queues (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,21 @@
   fallback; loud is better than either. `worker_id` and
   `claim_expires_at` are in the old ABI, so their new throws did not
   catch it. Nothing in the binding constructs a `JobRow` — it is only a
-  deserialization target — so `required` costs callers nothing.
+  deserialization target.
+- `JobRow` is public, so `required` is a source-breaking change for a
+  downstream caller who constructs one: `new JobRow { Id = 1 }` compiled
+  before and is now `CS9035: Required member 'JobRow.Payload' must be
+  set`. Nothing outside a decoder has a reason to build a `JobRow`, and
+  the package is pre-1.0, so this is the accepted cost of the loud
+  decode.
+- Against a 0.5.x extension, `required` moves the failure from a wrong
+  `Job.State` to a `JsonException` thrown inside `ClaimBatch` — after
+  the rows are claimed in the database, which is the same stranding
+  shape the `Job<TPayload>.Payload` fix above removes. It is still the
+  right trade: a version-mismatched core fails on the very first claim
+  and every claim after, so the worker never appears to run, whereas one
+  producer's mismatched payload is an ordinary production event a
+  healthy worker has to survive.
 - The README now names the `TypedQueue<T>` vs `Queue<T>` collision, shows
   the poison-payload worker loop, separates the four spellings of
   "payload" across the typed and untyped pairs, and says `GetJob` is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,17 @@
 - Tests for the previously uncovered typed surface: `ClaimBatch`,
   `AckBatch`, `ClaimAsync`, `Cancel`, `Name`, `Job<T>.Untyped`,
   `Job<T>.Retry`, and `Job<T>.Heartbeat`.
+- Every `JobRow` member is now `required`, so a core that omits a field
+  fails the decode with a `JsonException` naming it. `ClaimBatch` decodes
+  into `JobRow` now, and `JobRow.State` defaulted to `""` — so this
+  binding run against a 0.5.x extension, whose `honker_claim_batch`
+  returns six columns and no `state`, would have reported
+  `Job.State == ""`. The `row.State ?? "processing"` fallback this PR
+  removed was right for that case. Wrong and silent is worse than the
+  fallback; loud is better than either. `worker_id` and
+  `claim_expires_at` are in the old ABI, so their new throws did not
+  catch it. Nothing in the binding constructs a `JobRow` — it is only a
+  deserialization target — so `required` costs callers nothing.
 - The README now names the `TypedQueue<T>` vs `Queue<T>` collision, shows
   the poison-payload worker loop, separates the four spellings of
   "payload" across the typed and untyped pairs, and says `GetJob` is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,25 @@
 - Regression test claims a job at a deadline with one claim forced to
   return empty: it fails on the unpatched `api.js` and passes on the fix.
 
+## Unreleased — .NET job details and typed queues
+
+- .NET claimed jobs (`Job`) now carry every field the core returns:
+  `State`, `Priority`, `RunAt`, `MaxAttempts`, `CreatedAt`, and
+  `ExpiresAt` join the id, queue, payload, worker, attempts, and
+  claim-expiry fields they already had. `ClaimBatch` decodes the claim
+  ABI into the same `JobRow` shape `GetJob()` returns, so the old
+  `row.State ?? "processing"` fallback is gone — `state` is now a real
+  value from the core.
+- New `db.Queue<TPayload>(name)` returns a `TypedQueue<TPayload>` whose
+  claims yield `Job<TPayload>` and whose `GetJob()` yields the
+  data-only `JobSnapshot<TPayload>` record. Named `TypedQueue` rather
+  than `Queue<T>` so it cannot collide with
+  `System.Collections.Generic.Queue<T>` in callers' files.
+- Payload typing is compile-time only. Honker never validates payload
+  shape in the database, and this binding adds no runtime check.
+- A claimed row missing `worker_id` or `claim_expires_at` now throws
+  instead of being silently defaulted.
+
 ## Unreleased — typed Node jobs
 
 - Node `Queue`, `Job`, `JobSnapshot`, `ClaimWaker`, and `Outbox` APIs now carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@
   shape in the database, and this binding adds no runtime check.
 - A claimed row missing `worker_id` or `claim_expires_at` now throws
   instead of being silently defaulted.
+- The typed job tests enqueue with a back-dated absolute `RunAtUnix`
+  (`now - 100`) so the job stays claimable while `RunAt` and `CreatedAt`
+  differ, then pin `RunAt` exactly and assert the two are not equal.
+  With an immediate enqueue the two are equal to the second, so all four
+  properties (`Job<T>.RunAt`/`CreatedAt` and `JobSnapshot<T>.FromRow`'s
+  two assignments) could be transposed and the suite stayed green.
+- `Job<TPayload>.PayloadRaw` is now asserted against the enqueued JSON.
+  Only `JobSnapshot<T>.PayloadRaw` was covered before.
 
 ## Unreleased — typed Node jobs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,27 @@
   two assignments) could be transposed and the suite stayed green.
 - `Job<TPayload>.PayloadRaw` is now asserted against the enqueued JSON.
   Only `JobSnapshot<T>.PayloadRaw` was covered before.
+- `Job<TPayload>.Payload` decodes on first read instead of inside the
+  constructor. It used to decode during the claim, so a payload that did
+  not match `TPayload` threw from inside `ClaimBatch`/`ClaimOne`/
+  `ClaimAsync` — after the rows were already claimed in the database.
+  The caller got an exception and no handle, so it could not `Ack`,
+  `Retry`, or `Fail` any job in that batch; they stayed invisible until
+  the visibility timeout and then poisoned the next claim. Honker never
+  validates payload shape, so one disagreeing producer was enough. A
+  claim now never decodes and never throws; the `JsonException` arrives
+  when you read `Payload`, with the job in hand to `Fail`.
+- `TypedQueue<T>.GetJob` still decodes eagerly and still throws on a
+  mismatched payload — a read holds no claim, so nothing is stranded.
+  `Untyped.GetJob` reads the row whatever shape it is. Both behaviours
+  are documented on the members and in the README.
+- Tests for the previously uncovered typed surface: `ClaimBatch`,
+  `AckBatch`, `ClaimAsync`, `Cancel`, `Name`, `Job<T>.Untyped`,
+  `Job<T>.Retry`, and `Job<T>.Heartbeat`.
+- The README now names the `TypedQueue<T>` vs `Queue<T>` collision, shows
+  the poison-payload worker loop, separates the four spellings of
+  "payload" across the typed and untyped pairs, and says `GetJob` is not
+  queue-scoped. `Queue.GetJob` says so in its XML doc too (#134).
 
 ## Unreleased — typed Node jobs
 

--- a/packages/honker-dotnet/README.md
+++ b/packages/honker-dotnet/README.md
@@ -64,10 +64,42 @@ if (job is not null)
 }
 ```
 
+The handle `db.Queue<TPayload>(name)` returns is called
+`TypedQueue<TPayload>`, not `Queue<TPayload>`. A `Honker.Queue<T>` would
+shadow `System.Collections.Generic.Queue<T>` in any file that uses both,
+so `var` or `TypedQueue<EmailPayload>` is the name to write down.
+
 The type parameter is a compile-time contract only. Honker stores
 payloads as opaque JSON and never validates their shape — in this
 binding or in the database — so every process writing to a queue has to
-agree on the payload type.
+agree on the payload type. When a producer disagrees, the row still
+lands in the queue and the decode is what fails:
+
+```csharp
+foreach (var job in emails.ClaimBatch("worker-1", 10))
+{
+    EmailPayload payload;
+    try
+    {
+        // Claiming never decodes, so the claim itself cannot throw and
+        // you always hold a handle. Payload decodes on first read.
+        payload = job.Payload!;
+    }
+    catch (JsonException e)
+    {
+        job.Fail(e.Message);   // dead-letter it; job.PayloadRaw has the text
+        continue;
+    }
+
+    Send(payload.To);
+    job.Ack();
+}
+```
+
+`GetJob()` is the one exception: it decodes eagerly and throws on a
+payload that does not match, because a read holds no claim and so
+strands nothing. `emails.Untyped.GetJob(id)` reads the row whatever
+shape it is.
 
 Claimed jobs (`Job`, `Job<TPayload>`) and read-only snapshots
 (`JobRow`, `JobSnapshot<TPayload>`) carry every field the core returns:
@@ -76,7 +108,19 @@ Claimed jobs (`Job`, `Job<TPayload>`) and read-only snapshots
 A claimed job additionally has `Ack`, `Retry`, `Fail`, and `Heartbeat`;
 a snapshot is data only, because reading a row does not claim it.
 `Untyped` on `TypedQueue<TPayload>` and `Job<TPayload>` gets you back
-to the untyped handle when an API needs one.
+to the untyped handle when an API needs one — results (`SaveResult`,
+`GetResult`, `WaitResult`) live there, since a result's type has
+nothing to do with `TPayload`.
+
+Two spellings of "payload" sit side by side, so watch which type you
+hold. On the typed pair (`Job<T>`, `JobSnapshot<T>`) `Payload` is the
+decoded `T` and `PayloadRaw` is the JSON text. On the untyped pair,
+`Job.Payload` is a `JsonElement` (`Job.GetPayload<T>()` decodes) and
+`JobRow.Payload` is the JSON text with no `PayloadRaw` beside it.
+
+`GetJob` is not scoped to the queue you called it on: job ids are
+globally unique and the lookup spans every queue, so pass only ids you
+know this queue owns.
 
 ## Native loading
 

--- a/packages/honker-dotnet/README.md
+++ b/packages/honker-dotnet/README.md
@@ -66,8 +66,8 @@ if (job is not null)
 
 The handle `db.Queue<TPayload>(name)` returns is called
 `TypedQueue<TPayload>`, not `Queue<TPayload>`. A `Honker.Queue<T>` would
-shadow `System.Collections.Generic.Queue<T>` in any file that uses both,
-so `var` or `TypedQueue<EmailPayload>` is the name to write down.
+shadow `System.Collections.Generic.Queue<T>` in any file that uses both.
+Write `var`, or `TypedQueue<EmailPayload>` where you need the name.
 
 The type parameter is a compile-time contract only. Honker stores
 payloads as opaque JSON and never validates their shape — in this
@@ -112,11 +112,11 @@ to the untyped handle when an API needs one — results (`SaveResult`,
 `GetResult`, `WaitResult`) live there, since a result's type has
 nothing to do with `TPayload`.
 
-Two spellings of "payload" sit side by side, so watch which type you
-hold. On the typed pair (`Job<T>`, `JobSnapshot<T>`) `Payload` is the
-decoded `T` and `PayloadRaw` is the JSON text. On the untyped pair,
-`Job.Payload` is a `JsonElement` (`Job.GetPayload<T>()` decodes) and
-`JobRow.Payload` is the JSON text with no `PayloadRaw` beside it.
+`Payload` means something different on each of these types, so check
+which one you hold. On the typed pair (`Job<T>`, `JobSnapshot<T>`) it is
+the decoded `T`, with `PayloadRaw` beside it for the JSON text. On `Job`
+it is a `JsonElement`, and `Job.GetPayload<T>()` decodes. On `JobRow` it
+is the JSON text itself, with no `PayloadRaw` beside it.
 
 `GetJob` is not scoped to the queue you called it on: job ids are
 globally unique and the lookup spans every queue, so pass only ids you

--- a/packages/honker-dotnet/README.md
+++ b/packages/honker-dotnet/README.md
@@ -40,6 +40,44 @@ if (job is not null)
 }
 ```
 
+## Typed queues and job details
+
+`db.Queue<TPayload>(name)` gives the queue a payload contract. Claimed
+jobs and `GetJob()` snapshots keep it:
+
+```csharp
+record EmailPayload(string To, string Template);
+
+var emails = db.Queue<EmailPayload>("emails");
+var id = emails.Enqueue(new EmailPayload("alice@example.com", "welcome"));
+
+// Read-only snapshot: data, no claim methods.
+JobSnapshot<EmailPayload>? pending = emails.GetJob(id);
+Console.WriteLine($"{pending!.State} {pending.Priority} {pending.RunAt}");
+
+Job<EmailPayload>? job = emails.ClaimOne("worker-1");
+if (job is not null)
+{
+    Send(job.Payload!.To);
+    Console.WriteLine($"{job.Attempts}/{job.MaxAttempts} until {job.ClaimExpiresAt}");
+    job.Ack();
+}
+```
+
+The type parameter is a compile-time contract only. Honker stores
+payloads as opaque JSON and never validates their shape — in this
+binding or in the database — so every process writing to a queue has to
+agree on the payload type.
+
+Claimed jobs (`Job`, `Job<TPayload>`) and read-only snapshots
+(`JobRow`, `JobSnapshot<TPayload>`) carry every field the core returns:
+`Id`, queue name, payload, `State`, `Priority`, `RunAt`, `WorkerId`,
+`ClaimExpiresAt`, `Attempts`, `MaxAttempts`, `CreatedAt`, `ExpiresAt`.
+A claimed job additionally has `Ack`, `Retry`, `Fail`, and `Heartbeat`;
+a snapshot is data only, because reading a row does not claim it.
+`Untyped` on `TypedQueue<TPayload>` and `Job<TPayload>` gets you back
+to the untyped handle when an API needs one.
+
 ## Native loading
 
 `Database.Open(...)` loads the Honker extension and runs

--- a/packages/honker-dotnet/src/Honker/Database.cs
+++ b/packages/honker-dotnet/src/Honker/Database.cs
@@ -83,6 +83,20 @@ public sealed class Database : IDisposable
         }
     }
 
+    /// <summary>
+    /// Get a queue whose payloads are typed as
+    /// <typeparamref name="TPayload"/>. Wraps the same underlying
+    /// queue <see cref="Queue(string, QueueOptions?)"/> returns, so a
+    /// typed and an untyped handle to one queue stay consistent.
+    ///
+    /// Typing is compile-time only: honker never checks payload shape
+    /// in the database.
+    /// </summary>
+    public TypedQueue<TPayload> Queue<TPayload>(string name, QueueOptions? options = null)
+    {
+        return new TypedQueue<TPayload>(Queue(name, options));
+    }
+
     public Stream Stream(string name)
     {
         lock (_gate)

--- a/packages/honker-dotnet/src/Honker/Models.cs
+++ b/packages/honker-dotnet/src/Honker/Models.cs
@@ -98,11 +98,12 @@ public sealed class ScheduleUpdate
 ///
 /// Every member is required, so a core that omits one fails the decode
 /// with a JsonException naming the field. That matters most for a
-/// binding running against an older extension: honker_claim_batch before
-/// 0.6 returned six columns and no `state`, and a defaulted <c>""</c>
-/// would have travelled all the way to <see cref="Job.State"/> as a
-/// silently wrong value. The nullable members still have to be present
-/// in the JSON — the core emits them as null, never omits them.
+/// binding running against an older extension: honker_claim_batch in
+/// 0.5.x and earlier returns six columns and no `state`, and a defaulted
+/// <c>""</c> would have travelled all the way to
+/// <see cref="Job.State"/> as a silently wrong value. The nullable
+/// members still have to be present in the JSON — the core emits them
+/// as null, it never omits them.
 /// </summary>
 public sealed record JobRow
 {

--- a/packages/honker-dotnet/src/Honker/Models.cs
+++ b/packages/honker-dotnet/src/Honker/Models.cs
@@ -222,8 +222,8 @@ public sealed class Job
 /// <summary>
 /// A claimed unit of work with a decoded payload of type
 /// <typeparamref name="TPayload"/>. Same fields and claim methods as
-/// <see cref="Job"/>; the payload is decoded once, when the job is
-/// claimed.
+/// <see cref="Job"/>, plus <see cref="Payload"/> decoded as
+/// <typeparamref name="TPayload"/>.
 ///
 /// The type parameter is a compile-time contract only. Honker stores
 /// payloads as opaque JSON and never validates their shape, so every
@@ -232,11 +232,12 @@ public sealed class Job
 public sealed class Job<TPayload>
 {
     private readonly Job _job;
+    private TPayload? _payload;
+    private bool _decoded;
 
     internal Job(Job job)
     {
         _job = job;
-        Payload = job.GetPayload<TPayload>();
     }
 
     /// <summary>The untyped job, for APIs that take one.</summary>
@@ -244,7 +245,36 @@ public sealed class Job<TPayload>
 
     public long Id => _job.Id;
     public string QueueName => _job.QueueName;
-    public TPayload? Payload { get; }
+
+    /// <summary>
+    /// The payload decoded as <typeparamref name="TPayload"/>, decoded
+    /// on first read and cached. Throws
+    /// <see cref="JsonException"/> when the stored JSON does not match
+    /// <typeparamref name="TPayload"/> — honker never checks payload
+    /// shape, so a producer that disagrees puts a row here anyway.
+    ///
+    /// Decoding deliberately does NOT happen during the claim. By the
+    /// time the binding sees the payload the row is already held in the
+    /// database, so throwing inside ClaimBatch/ClaimOne/ClaimAsync would
+    /// strand it: invisible until the visibility timeout, with no handle
+    /// to Ack, Retry, or Fail it, poisoning every later claim. Catch the
+    /// exception here and <see cref="Fail"/> the job, or read
+    /// <see cref="PayloadRaw"/> instead.
+    /// </summary>
+    public TPayload? Payload
+    {
+        get
+        {
+            if (!_decoded)
+            {
+                _payload = _job.GetPayload<TPayload>();
+                _decoded = true;
+            }
+
+            return _payload;
+        }
+    }
+
     public string PayloadRaw => _job.PayloadRaw;
     /// <summary>Always "processing" for a claimed job.</summary>
     public string State => _job.State;
@@ -270,12 +300,24 @@ public sealed class Job<TPayload>
 ///
 /// The type parameter is a compile-time contract only; honker never
 /// validates payload shape.
+///
+/// Unlike <see cref="Job{TPayload}"/>, the payload here is decoded
+/// eagerly, so <see cref="TypedQueue{TPayload}.GetJob"/> throws
+/// <see cref="JsonException"/> on a payload that does not match
+/// <typeparamref name="TPayload"/>. A read holds nothing, so nothing is
+/// stranded by that throw — use <see cref="TypedQueue{TPayload}.Untyped"/>'s
+/// <see cref="Queue.GetJob"/> to read the row regardless of its shape.
 /// </summary>
 public sealed record JobSnapshot<TPayload>
 {
     public required long Id { get; init; }
     public required string QueueName { get; init; }
+    /// <summary>
+    /// The payload decoded as <typeparamref name="TPayload"/>. Null only
+    /// when the stored JSON is literally <c>null</c>.
+    /// </summary>
     public required TPayload? Payload { get; init; }
+    /// <summary>The payload exactly as stored, before decoding.</summary>
     public required string PayloadRaw { get; init; }
     /// <summary>"pending" or "processing".</summary>
     public required string State { get; init; }

--- a/packages/honker-dotnet/src/Honker/Models.cs
+++ b/packages/honker-dotnet/src/Honker/Models.cs
@@ -149,38 +149,51 @@ public static class Schedules
     }
 }
 
+/// <summary>
+/// A claimed unit of work. Carries the same job detail the core
+/// returns — see <see cref="JobRow"/> for the read-only shape — plus
+/// the claim methods Ack, Retry, Fail, and Heartbeat.
+/// </summary>
 public sealed class Job
 {
     private readonly Queue _queue;
     private JsonDocument? _document;
 
-    internal Job(
-        Queue queue,
-        long id,
-        string queueName,
-        string payloadRaw,
-        string workerId,
-        long attempts,
-        long claimExpiresAt,
-        string state = "processing")
+    internal Job(Queue queue, JobRow row)
     {
         _queue = queue;
-        Id = id;
-        QueueName = queueName;
-        PayloadRaw = payloadRaw;
-        WorkerId = workerId;
-        Attempts = attempts;
-        ClaimExpiresAt = claimExpiresAt;
-        State = state;
+        Id = row.Id;
+        QueueName = row.Queue;
+        PayloadRaw = row.Payload;
+        State = row.State;
+        Priority = row.Priority;
+        RunAt = row.RunAt;
+        // A claimed row always carries the claim columns. If the core
+        // ever hands one back without them, that is a bug worth
+        // crashing on, not a silent default.
+        WorkerId = row.WorkerId
+            ?? throw new InvalidOperationException($"claimed job {row.Id} has no worker_id");
+        ClaimExpiresAt = row.ClaimExpiresAt
+            ?? throw new InvalidOperationException($"claimed job {row.Id} has no claim_expires_at");
+        Attempts = row.Attempts;
+        MaxAttempts = row.MaxAttempts;
+        CreatedAt = row.CreatedAt;
+        ExpiresAt = row.ExpiresAt;
     }
 
     public long Id { get; }
     public string QueueName { get; }
     public string PayloadRaw { get; }
-    public string WorkerId { get; }
-    public long Attempts { get; }
-    public long ClaimExpiresAt { get; }
+    /// <summary>Always "processing" for a claimed job.</summary>
     public string State { get; }
+    public long Priority { get; }
+    public long RunAt { get; }
+    public string WorkerId { get; }
+    public long ClaimExpiresAt { get; }
+    public long Attempts { get; }
+    public long MaxAttempts { get; }
+    public long CreatedAt { get; }
+    public long? ExpiresAt { get; }
     public JsonElement Payload
     {
         get
@@ -190,6 +203,11 @@ public sealed class Job
         }
     }
 
+    /// <summary>
+    /// Decode the payload as T. Compile-time typing only: honker never
+    /// checks payload shape in the database, so every writer to this
+    /// queue has to agree on the JSON.
+    /// </summary>
     public T? GetPayload<T>()
     {
         return JsonSerializer.Deserialize<T>(PayloadRaw);
@@ -199,4 +217,93 @@ public sealed class Job
     public bool Retry(int delaySeconds = 60, string error = "") => _queue.Retry(Id, WorkerId, delaySeconds, error);
     public bool Fail(string error = "") => _queue.Fail(Id, WorkerId, error);
     public bool Heartbeat(int? extendSeconds = null) => _queue.Heartbeat(Id, WorkerId, extendSeconds);
+}
+
+/// <summary>
+/// A claimed unit of work with a decoded payload of type
+/// <typeparamref name="TPayload"/>. Same fields and claim methods as
+/// <see cref="Job"/>; the payload is decoded once, when the job is
+/// claimed.
+///
+/// The type parameter is a compile-time contract only. Honker stores
+/// payloads as opaque JSON and never validates their shape, so every
+/// producer writing to this queue must agree on it.
+/// </summary>
+public sealed class Job<TPayload>
+{
+    private readonly Job _job;
+
+    internal Job(Job job)
+    {
+        _job = job;
+        Payload = job.GetPayload<TPayload>();
+    }
+
+    /// <summary>The untyped job, for APIs that take one.</summary>
+    public Job Untyped => _job;
+
+    public long Id => _job.Id;
+    public string QueueName => _job.QueueName;
+    public TPayload? Payload { get; }
+    public string PayloadRaw => _job.PayloadRaw;
+    /// <summary>Always "processing" for a claimed job.</summary>
+    public string State => _job.State;
+    public long Priority => _job.Priority;
+    public long RunAt => _job.RunAt;
+    public string WorkerId => _job.WorkerId;
+    public long ClaimExpiresAt => _job.ClaimExpiresAt;
+    public long Attempts => _job.Attempts;
+    public long MaxAttempts => _job.MaxAttempts;
+    public long CreatedAt => _job.CreatedAt;
+    public long? ExpiresAt => _job.ExpiresAt;
+
+    public bool Ack() => _job.Ack();
+    public bool Retry(int delaySeconds = 60, string error = "") => _job.Retry(delaySeconds, error);
+    public bool Fail(string error = "") => _job.Fail(error);
+    public bool Heartbeat(int? extendSeconds = null) => _job.Heartbeat(extendSeconds);
+}
+
+/// <summary>
+/// A read-only job snapshot with a decoded payload of type
+/// <typeparamref name="TPayload"/>. Data only — no ack, retry, fail,
+/// or heartbeat, because reading a row does not claim it.
+///
+/// The type parameter is a compile-time contract only; honker never
+/// validates payload shape.
+/// </summary>
+public sealed record JobSnapshot<TPayload>
+{
+    public required long Id { get; init; }
+    public required string QueueName { get; init; }
+    public required TPayload? Payload { get; init; }
+    public required string PayloadRaw { get; init; }
+    /// <summary>"pending" or "processing".</summary>
+    public required string State { get; init; }
+    public required long Priority { get; init; }
+    public required long RunAt { get; init; }
+    /// <summary>Null while the job is pending.</summary>
+    public required string? WorkerId { get; init; }
+    /// <summary>Null while the job is pending.</summary>
+    public required long? ClaimExpiresAt { get; init; }
+    public required long Attempts { get; init; }
+    public required long MaxAttempts { get; init; }
+    public required long CreatedAt { get; init; }
+    public required long? ExpiresAt { get; init; }
+
+    internal static JobSnapshot<TPayload> FromRow(JobRow row) => new()
+    {
+        Id = row.Id,
+        QueueName = row.Queue,
+        Payload = JsonSerializer.Deserialize<TPayload>(row.Payload),
+        PayloadRaw = row.Payload,
+        State = row.State,
+        Priority = row.Priority,
+        RunAt = row.RunAt,
+        WorkerId = row.WorkerId,
+        ClaimExpiresAt = row.ClaimExpiresAt,
+        Attempts = row.Attempts,
+        MaxAttempts = row.MaxAttempts,
+        CreatedAt = row.CreatedAt,
+        ExpiresAt = row.ExpiresAt,
+    };
 }

--- a/packages/honker-dotnet/src/Honker/Models.cs
+++ b/packages/honker-dotnet/src/Honker/Models.cs
@@ -91,43 +91,61 @@ public sealed class ScheduleUpdate
     public ScheduleUpdate WithMaxAttempts(int? value) { MaxAttempts = value; HasMaxAttempts = true; return this; }
 }
 
+/// <summary>
+/// A job row exactly as the core returns it. Decodes the output of both
+/// honker_get_job and honker_claim_batch, which emit the same twelve
+/// keys.
+///
+/// Every member is required, so a core that omits one fails the decode
+/// with a JsonException naming the field. That matters most for a
+/// binding running against an older extension: honker_claim_batch before
+/// 0.6 returned six columns and no `state`, and a defaulted <c>""</c>
+/// would have travelled all the way to <see cref="Job.State"/> as a
+/// silently wrong value. The nullable members still have to be present
+/// in the JSON — the core emits them as null, never omits them.
+/// </summary>
 public sealed record JobRow
 {
     [System.Text.Json.Serialization.JsonPropertyName("id")]
-    public long Id { get; init; }
+    public required long Id { get; init; }
 
     [System.Text.Json.Serialization.JsonPropertyName("queue")]
-    public string Queue { get; init; } = "";
+    public required string Queue { get; init; }
 
+    /// <summary>The payload as stored: JSON text, not yet decoded.</summary>
     [System.Text.Json.Serialization.JsonPropertyName("payload")]
-    public string Payload { get; init; } = "";
+    public required string Payload { get; init; }
 
+    /// <summary>"pending" or "processing".</summary>
     [System.Text.Json.Serialization.JsonPropertyName("state")]
-    public string State { get; init; } = "";
+    public required string State { get; init; }
 
     [System.Text.Json.Serialization.JsonPropertyName("priority")]
-    public long Priority { get; init; }
+    public required long Priority { get; init; }
 
     [System.Text.Json.Serialization.JsonPropertyName("run_at")]
-    public long RunAt { get; init; }
+    public required long RunAt { get; init; }
 
+    /// <summary>Null while the job is pending.</summary>
     [System.Text.Json.Serialization.JsonPropertyName("worker_id")]
-    public string? WorkerId { get; init; }
+    public required string? WorkerId { get; init; }
 
+    /// <summary>Null while the job is pending.</summary>
     [System.Text.Json.Serialization.JsonPropertyName("claim_expires_at")]
-    public long? ClaimExpiresAt { get; init; }
+    public required long? ClaimExpiresAt { get; init; }
 
     [System.Text.Json.Serialization.JsonPropertyName("attempts")]
-    public long Attempts { get; init; }
+    public required long Attempts { get; init; }
 
     [System.Text.Json.Serialization.JsonPropertyName("max_attempts")]
-    public long MaxAttempts { get; init; }
+    public required long MaxAttempts { get; init; }
 
     [System.Text.Json.Serialization.JsonPropertyName("created_at")]
-    public long CreatedAt { get; init; }
+    public required long CreatedAt { get; init; }
 
+    /// <summary>Null when the job never expires.</summary>
     [System.Text.Json.Serialization.JsonPropertyName("expires_at")]
-    public long? ExpiresAt { get; init; }
+    public required long? ExpiresAt { get; init; }
 }
 
 public sealed record OutboxOptions(

--- a/packages/honker-dotnet/src/Honker/Queue.cs
+++ b/packages/honker-dotnet/src/Honker/Queue.cs
@@ -203,6 +203,12 @@ public sealed class Queue
     /// <summary>
     /// Read a single job row by id. Returns the row or null on miss
     /// (ack'd, dead'd, or never existed). Pure read.
+    ///
+    /// NOT queue-scoped: job ids are globally unique and this lookup
+    /// spans every queue, so it can return a row belonging to a
+    /// different queue than this handle. Check
+    /// <see cref="JobRow.Queue"/> if that matters. Node's equivalent is
+    /// already scoped; aligning .NET is tracked in #134.
     /// </summary>
     public JobRow? GetJob(long jobId)
     {

--- a/packages/honker-dotnet/src/Honker/Queue.cs
+++ b/packages/honker-dotnet/src/Honker/Queue.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Data.Sqlite;
 
 namespace Honker;
@@ -52,9 +51,11 @@ public sealed class Queue
             _options.VisibilityTimeoutSeconds
         )) ?? "[]";
 
-        var rows = JsonSerializer.Deserialize<List<ClaimedJobRow>>(rowsJson) ?? [];
+        // honker_claim_batch returns the whole job snapshot, the same
+        // field set honker_get_job returns, so JobRow decodes both.
+        var rows = JsonSerializer.Deserialize<List<JobRow>>(rowsJson) ?? [];
         return rows
-            .Select(row => new Job(this, row.Id, row.Queue, row.Payload, row.WorkerId, row.Attempts, row.ClaimExpiresAt, row.State ?? "processing"))
+            .Select(row => new Job(this, row))
             .ToList();
     }
 
@@ -317,29 +318,5 @@ public sealed class Queue
         tx.Execute("DROP TABLE IF EXISTS _honker_pending");
         tx.Execute("DROP TABLE IF EXISTS _honker_processing");
         tx.Commit();
-    }
-
-    private sealed class ClaimedJobRow
-    {
-        [JsonPropertyName("id")]
-        public long Id { get; init; }
-
-        [JsonPropertyName("queue")]
-        public string Queue { get; init; } = "";
-
-        [JsonPropertyName("payload")]
-        public string Payload { get; init; } = "";
-
-        [JsonPropertyName("worker_id")]
-        public string WorkerId { get; init; } = "";
-
-        [JsonPropertyName("attempts")]
-        public long Attempts { get; init; }
-
-        [JsonPropertyName("claim_expires_at")]
-        public long ClaimExpiresAt { get; init; }
-
-        [JsonPropertyName("state")]
-        public string? State { get; init; }
     }
 }

--- a/packages/honker-dotnet/src/Honker/TypedQueue.cs
+++ b/packages/honker-dotnet/src/Honker/TypedQueue.cs
@@ -14,6 +14,23 @@ namespace Honker;
 /// payloads as opaque JSON and never validates their shape, in this
 /// binding or in the database. Every process writing to the queue has
 /// to agree on the payload type; nothing enforces it at runtime.
+///
+/// It is named TypedQueue rather than Queue&lt;TPayload&gt; because a
+/// <c>Honker.Queue&lt;T&gt;</c> would shadow
+/// <c>System.Collections.Generic.Queue&lt;T&gt;</c> in any file that uses
+/// both — it broke this binding's own Listener and Stream first. Get one
+/// from <see cref="Database.Queue{TPayload}(string, QueueOptions?)"/>.
+///
+/// This wrapper covers enqueue, claim, ack, cancel, and read. Anything
+/// else on <see cref="Queue"/> — results (SaveResult, GetResult,
+/// WaitResult, SweepResults) and the by-id Ack/Retry/Fail/Heartbeat
+/// overloads — is reached through <see cref="Untyped"/>; results carry
+/// their own type, unrelated to <typeparamref name="TPayload"/>.
+///
+/// No claim method decodes the payload, so none of them throws on a
+/// payload that does not match <typeparamref name="TPayload"/>; see
+/// <see cref="Job{TPayload}.Payload"/>. <see cref="GetJob"/> is the one
+/// exception and the reason is spelled out there.
 /// </summary>
 public sealed class TypedQueue<TPayload>
 {
@@ -52,8 +69,7 @@ public sealed class TypedQueue<TPayload>
         TimeSpan? idlePoll = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await foreach (var job in _queue.ClaimAsync(workerId, idlePoll, cancellationToken)
-            .WithCancellation(cancellationToken))
+        await foreach (var job in _queue.ClaimAsync(workerId, idlePoll, cancellationToken))
         {
             yield return new Job<TPayload>(job);
         }
@@ -62,6 +78,19 @@ public sealed class TypedQueue<TPayload>
     /// <summary>
     /// Read a single job row by id. Returns the snapshot or null on
     /// miss (ack'd, dead'd, or never existed). Pure read.
+    ///
+    /// NOT queue-scoped: job ids are globally unique and this lookup
+    /// spans every queue, so an id owned by another queue comes back as
+    /// a <see cref="JobSnapshot{TPayload}"/> whose payload was never
+    /// meant to be a <typeparamref name="TPayload"/>. Pass only ids you
+    /// know this queue owns. Scoping is tracked in #134.
+    ///
+    /// Throws <see cref="System.Text.Json.JsonException"/> when the
+    /// stored payload does not decode as <typeparamref name="TPayload"/>.
+    /// A read holds no claim, so nothing is stranded by that throw —
+    /// unlike a claim, which is why <see cref="Job{TPayload}.Payload"/>
+    /// defers instead. Use <see cref="Untyped"/>'s
+    /// <see cref="Queue.GetJob"/> to read the row regardless of shape.
     /// </summary>
     public JobSnapshot<TPayload>? GetJob(long jobId)
     {

--- a/packages/honker-dotnet/src/Honker/TypedQueue.cs
+++ b/packages/honker-dotnet/src/Honker/TypedQueue.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Honker;
+
+/// <summary>
+/// A queue whose payloads are typed as <typeparamref name="TPayload"/>.
+/// A thin wrapper over <see cref="Queue"/>: enqueue takes a
+/// <typeparamref name="TPayload"/>, claims return
+/// <see cref="Job{TPayload}"/>, and reads return
+/// <see cref="JobSnapshot{TPayload}"/>.
+///
+/// The type parameter is a compile-time contract only. Honker stores
+/// payloads as opaque JSON and never validates their shape, in this
+/// binding or in the database. Every process writing to the queue has
+/// to agree on the payload type; nothing enforces it at runtime.
+/// </summary>
+public sealed class TypedQueue<TPayload>
+{
+    private readonly Queue _queue;
+
+    internal TypedQueue(Queue queue)
+    {
+        _queue = queue;
+    }
+
+    public string Name => _queue.Name;
+
+    /// <summary>The untyped queue, for APIs this wrapper does not cover.</summary>
+    public Queue Untyped => _queue;
+
+    public long Enqueue(TPayload payload, EnqueueOptions? options = null, HonkerTransaction? transaction = null)
+    {
+        return _queue.Enqueue(payload, options, transaction);
+    }
+
+    public IReadOnlyList<Job<TPayload>> ClaimBatch(string workerId, int batchSize)
+    {
+        return _queue.ClaimBatch(workerId, batchSize)
+            .Select(job => new Job<TPayload>(job))
+            .ToList();
+    }
+
+    public Job<TPayload>? ClaimOne(string workerId)
+    {
+        var job = _queue.ClaimOne(workerId);
+        return job is null ? null : new Job<TPayload>(job);
+    }
+
+    public async IAsyncEnumerable<Job<TPayload>> ClaimAsync(
+        string workerId,
+        TimeSpan? idlePoll = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var job in _queue.ClaimAsync(workerId, idlePoll, cancellationToken)
+            .WithCancellation(cancellationToken))
+        {
+            yield return new Job<TPayload>(job);
+        }
+    }
+
+    /// <summary>
+    /// Read a single job row by id. Returns the snapshot or null on
+    /// miss (ack'd, dead'd, or never existed). Pure read.
+    /// </summary>
+    public JobSnapshot<TPayload>? GetJob(long jobId)
+    {
+        var row = _queue.GetJob(jobId);
+        return row is null ? null : JobSnapshot<TPayload>.FromRow(row);
+    }
+
+    public int AckBatch(IEnumerable<long> ids, string workerId) => _queue.AckBatch(ids, workerId);
+
+    public bool Cancel(long jobId) => _queue.Cancel(jobId);
+
+    public long NextClaimAt() => _queue.NextClaimAt();
+}

--- a/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
@@ -345,7 +345,7 @@ public sealed class JobDetailTests
     [Fact]
     public void AClaimRowFromAnOlderCoreIsRejectedRatherThanDefaulted()
     {
-        // honker_claim_batch before 0.6 returned six columns and no
+        // honker_claim_batch in 0.5.x and earlier returns six columns, no
         // "state". This is that payload, key for key. ClaimBatch now
         // decodes it into JobRow like every other row, and JobRow's
         // defaults would have made State "" and carried it to

--- a/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
@@ -1,0 +1,310 @@
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace Honker.Tests;
+
+/// <summary>
+/// Every field the core returns for a job — claimed or read back —
+/// has to arrive with the right value, not merely be present.
+/// </summary>
+public sealed class JobDetailTests
+{
+    private sealed record OrderPayload(string Sku, int Quantity);
+
+    [Fact]
+    public void ClaimedJobCarriesEveryCoreDetail()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        var queue = db.Queue("work", new QueueOptions(VisibilityTimeoutSeconds: 120, MaxAttempts: 3));
+
+        var runAt = Now(db) - 5;
+        var enqueuedBefore = Now(db);
+        var id = queue.Enqueue(
+            new { k = 7 },
+            new EnqueueOptions(RunAtUnix: runAt, Priority: 9, MaxAttempts: 5, ExpiresSeconds: 600));
+        var enqueuedAfter = Now(db);
+
+        var claimedBefore = Now(db);
+        var job = queue.ClaimOne("worker-1");
+        var claimedAfter = Now(db);
+
+        Assert.NotNull(job);
+        Assert.Equal(id, job!.Id);
+        Assert.Equal("work", job.QueueName);
+        Assert.Equal(7, job.Payload.GetProperty("k").GetInt32());
+        Assert.Equal("processing", job.State);
+        Assert.Equal(9, job.Priority);
+        Assert.Equal(runAt, job.RunAt);
+        Assert.Equal("worker-1", job.WorkerId);
+        Assert.InRange(job.ClaimExpiresAt, claimedBefore + 120, claimedAfter + 120);
+        Assert.Equal(1, job.Attempts);
+        Assert.Equal(5, job.MaxAttempts);
+        Assert.InRange(job.CreatedAt, enqueuedBefore, enqueuedAfter);
+        Assert.NotNull(job.ExpiresAt);
+        Assert.InRange(job.ExpiresAt!.Value, enqueuedBefore + 600, enqueuedAfter + 600);
+    }
+
+    [Fact]
+    public void PendingSnapshotCarriesEveryCoreDetail()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        var queue = db.Queue("work");
+
+        var runAt = Now(db) + 3600;
+        var enqueuedBefore = Now(db);
+        var id = queue.Enqueue(
+            new { k = 3 },
+            new EnqueueOptions(RunAtUnix: runAt, Priority: 4, MaxAttempts: 2, ExpiresSeconds: 900));
+        var enqueuedAfter = Now(db);
+
+        var row = queue.GetJob(id);
+
+        Assert.NotNull(row);
+        Assert.Equal(id, row!.Id);
+        Assert.Equal("work", row.Queue);
+        Assert.Equal("{\"k\":3}", row.Payload);
+        Assert.Equal("pending", row.State);
+        Assert.Equal(4, row.Priority);
+        Assert.Equal(runAt, row.RunAt);
+        Assert.Null(row.WorkerId);
+        Assert.Null(row.ClaimExpiresAt);
+        Assert.Equal(0, row.Attempts);
+        Assert.Equal(2, row.MaxAttempts);
+        Assert.InRange(row.CreatedAt, enqueuedBefore, enqueuedAfter);
+        Assert.NotNull(row.ExpiresAt);
+        Assert.InRange(row.ExpiresAt!.Value, enqueuedBefore + 900, enqueuedAfter + 900);
+    }
+
+    [Fact]
+    public void ReaderSeesProcessingDetailWhileWorkerHoldsTheClaimAndNothingAfterAck()
+    {
+        using var harness = TestHarness.Create();
+        using var worker = harness.Open();
+        using var reader = harness.Open();
+
+        var workerQueue = worker.Queue("work", new QueueOptions(VisibilityTimeoutSeconds: 45));
+        var readerQueue = reader.Queue("work", new QueueOptions(VisibilityTimeoutSeconds: 45));
+
+        var id = workerQueue.Enqueue(new { k = 1 });
+        var claimedBefore = Now(worker);
+        var job = workerQueue.ClaimOne("worker-7");
+        var claimedAfter = Now(worker);
+        Assert.NotNull(job);
+
+        var processing = readerQueue.GetJob(id);
+        Assert.NotNull(processing);
+        Assert.Equal("processing", processing!.State);
+        Assert.Equal("worker-7", processing.WorkerId);
+        Assert.Equal(1, processing.Attempts);
+        Assert.NotNull(processing.ClaimExpiresAt);
+        Assert.InRange(processing.ClaimExpiresAt!.Value, claimedBefore + 45, claimedAfter + 45);
+
+        Assert.True(job!.Ack());
+        Assert.Null(readerQueue.GetJob(id));
+    }
+
+    [Fact]
+    public void DelayedJobReportsItsRunAt()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        var queue = db.Queue("work");
+
+        var before = Now(db);
+        var id = queue.Enqueue(new { k = 2 }, new EnqueueOptions(DelaySeconds: 60));
+        var after = Now(db);
+
+        var row = queue.GetJob(id);
+        Assert.NotNull(row);
+        Assert.Equal("pending", row!.State);
+        Assert.InRange(row.RunAt, before + 60, after + 60);
+        Assert.Null(queue.ClaimOne("early-worker"));
+    }
+
+    [Fact]
+    public void TypedQueueDecodesClaimedPayloadsAndKeepsEveryDetail()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        var queue = db.Queue<OrderPayload>("orders", new QueueOptions(VisibilityTimeoutSeconds: 90, MaxAttempts: 4));
+
+        var enqueuedBefore = Now(db);
+        var id = queue.Enqueue(new OrderPayload("SKU-42", 3), new EnqueueOptions(Priority: 6, ExpiresSeconds: 300));
+        var enqueuedAfter = Now(db);
+
+        var claimedBefore = Now(db);
+        var job = queue.ClaimOne("typed-worker");
+        var claimedAfter = Now(db);
+
+        Assert.NotNull(job);
+        Assert.Equal(id, job!.Id);
+        Assert.Equal("orders", job.QueueName);
+        Assert.Equal(new OrderPayload("SKU-42", 3), job.Payload);
+        Assert.Equal("processing", job.State);
+        Assert.Equal(6, job.Priority);
+        Assert.InRange(job.RunAt, enqueuedBefore, enqueuedAfter);
+        Assert.Equal("typed-worker", job.WorkerId);
+        Assert.InRange(job.ClaimExpiresAt, claimedBefore + 90, claimedAfter + 90);
+        Assert.Equal(1, job.Attempts);
+        Assert.Equal(4, job.MaxAttempts);
+        Assert.InRange(job.CreatedAt, enqueuedBefore, enqueuedAfter);
+        Assert.NotNull(job.ExpiresAt);
+        Assert.InRange(job.ExpiresAt!.Value, enqueuedBefore + 300, enqueuedAfter + 300);
+        Assert.True(job.Ack());
+    }
+
+    [Fact]
+    public void TypedSnapshotDecodesPayloadAndCarriesEveryDetail()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        var queue = db.Queue<OrderPayload>("orders", new QueueOptions(VisibilityTimeoutSeconds: 30));
+
+        var enqueuedBefore = Now(db);
+        var id = queue.Enqueue(new OrderPayload("SKU-9", 11), new EnqueueOptions(Priority: 2, MaxAttempts: 7, ExpiresSeconds: 120));
+        var enqueuedAfter = Now(db);
+
+        var pending = queue.GetJob(id);
+        Assert.NotNull(pending);
+        Assert.Equal(id, pending!.Id);
+        Assert.Equal("orders", pending.QueueName);
+        Assert.Equal(new OrderPayload("SKU-9", 11), pending.Payload);
+        Assert.Equal("{\"Sku\":\"SKU-9\",\"Quantity\":11}", pending.PayloadRaw);
+        Assert.Equal("pending", pending.State);
+        Assert.Equal(2, pending.Priority);
+        Assert.InRange(pending.RunAt, enqueuedBefore, enqueuedAfter);
+        Assert.Null(pending.WorkerId);
+        Assert.Null(pending.ClaimExpiresAt);
+        Assert.Equal(0, pending.Attempts);
+        Assert.Equal(7, pending.MaxAttempts);
+        Assert.InRange(pending.CreatedAt, enqueuedBefore, enqueuedAfter);
+        Assert.NotNull(pending.ExpiresAt);
+        Assert.InRange(pending.ExpiresAt!.Value, enqueuedBefore + 120, enqueuedAfter + 120);
+
+        var claimedBefore = Now(db);
+        var job = queue.ClaimOne("typed-worker");
+        var claimedAfter = Now(db);
+        Assert.NotNull(job);
+
+        var processing = queue.GetJob(id);
+        Assert.NotNull(processing);
+        Assert.Equal("processing", processing!.State);
+        Assert.Equal("typed-worker", processing.WorkerId);
+        Assert.Equal(1, processing.Attempts);
+        Assert.NotNull(processing.ClaimExpiresAt);
+        Assert.InRange(processing.ClaimExpiresAt!.Value, claimedBefore + 30, claimedAfter + 30);
+
+        Assert.True(job!.Ack());
+        Assert.Null(queue.GetJob(id));
+    }
+
+    [Fact]
+    public void TypedAndUntypedHandlesShareOneQueue()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        var typed = db.Queue<OrderPayload>("orders");
+        var untyped = db.Queue("orders");
+
+        var id = typed.Enqueue(new OrderPayload("SKU-1", 1));
+        var job = untyped.ClaimOne("w1");
+
+        Assert.NotNull(job);
+        Assert.Equal(id, job!.Id);
+        Assert.Equal(new OrderPayload("SKU-1", 1), job.GetPayload<OrderPayload>());
+        Assert.Same(untyped, typed.Untyped);
+    }
+
+    private static long Now(Database db)
+    {
+        return Convert.ToInt64(db.Query("SELECT unixepoch() AS v").Single()["v"]);
+    }
+
+    private sealed class TestHarness : IDisposable
+    {
+        private readonly string _dir;
+
+        private TestHarness(string dir, string extensionPath)
+        {
+            _dir = dir;
+            ExtensionPath = extensionPath;
+            DatabasePath = Path.Combine(dir, "test.db");
+        }
+
+        public string ExtensionPath { get; }
+        public string DatabasePath { get; }
+
+        public static TestHarness Create()
+        {
+            var root = FindRepoRoot();
+            var extensionPath = FindExtension(root);
+            var dir = Path.Combine(Path.GetTempPath(), $"honker-dotnet-jobdetail-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            return new TestHarness(dir, extensionPath);
+        }
+
+        public Database Open()
+        {
+            return Database.Open(DatabasePath, new OpenOptions
+            {
+                ExtensionPath = ExtensionPath,
+                UpdatePollInterval = TimeSpan.FromMilliseconds(5),
+            });
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_dir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+
+        private static string FindRepoRoot()
+        {
+            var current = AppContext.BaseDirectory;
+            while (!string.IsNullOrEmpty(current))
+            {
+                if (Directory.Exists(Path.Combine(current, "honker-core")) &&
+                    File.Exists(Path.Combine(current, "Cargo.toml")))
+                {
+                    return current;
+                }
+
+                current = Path.GetDirectoryName(current) ?? "";
+            }
+
+            throw new DirectoryNotFoundException("could not locate honker repo root from test base directory");
+        }
+
+        private static string FindExtension(string root)
+        {
+            var candidates = new[]
+            {
+                Path.Combine(root, "target", "release", ExtensionFileName()),
+                Path.Combine(root, "target", "debug", ExtensionFileName()),
+            };
+
+            var found = candidates.FirstOrDefault(File.Exists);
+            if (found is null)
+            {
+                throw new FileNotFoundException($"expected built honker extension at one of: {string.Join(", ", candidates)}");
+            }
+
+            return found;
+        }
+
+        private static string ExtensionFileName()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "honker_ext.dll";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "libhonker_ext.dylib";
+            return "libhonker_ext.so";
+        }
+    }
+}

--- a/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
@@ -233,6 +233,115 @@ public sealed class JobDetailTests
         Assert.Same(untyped, typed.Untyped);
     }
 
+    [Fact]
+    public void TypedClaimHandsBackAJobWhosePayloadDoesNotDecode()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        var typed = db.Queue<OrderPayload>("orders");
+        var untyped = db.Queue("orders");
+
+        // A producer that disagrees about the payload shape. Honker never
+        // validates it, so the row lands in the queue either way.
+        var id = untyped.Enqueue(new { Sku = "SKU-BAD", Quantity = "three" });
+
+        var job = typed.ClaimOne("typed-worker");
+
+        // The claim already happened in the database before the binding saw
+        // the payload. If decoding threw inside ClaimOne, the row would be
+        // held invisible with no handle to ack, fail, or retry it, and it
+        // would poison every claim after the visibility timeout.
+        Assert.NotNull(job);
+        Assert.Equal(id, job!.Id);
+        Assert.Equal("{\"Sku\":\"SKU-BAD\",\"Quantity\":\"three\"}", job.PayloadRaw);
+        Assert.Throws<JsonException>(() => _ = job.Payload);
+
+        // The worker can still dead-letter it, which is the whole point.
+        Assert.True(job.Fail("payload does not match OrderPayload"));
+        Assert.Null(typed.GetJob(id));
+    }
+
+    [Fact]
+    public void TypedClaimBatchDecodesEveryJobAndOneBadPayloadDoesNotSinkTheRest()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        var typed = db.Queue<OrderPayload>("orders");
+        var untyped = db.Queue("orders");
+
+        var good = typed.Enqueue(new OrderPayload("SKU-A", 1));
+        var bad = untyped.Enqueue(new { Sku = "SKU-B", Quantity = "two" });
+        var alsoGood = typed.Enqueue(new OrderPayload("SKU-C", 3));
+
+        var claimed = typed.ClaimBatch("batch-worker", 10).ToDictionary(job => job.Id);
+
+        Assert.Equal(3, claimed.Count);
+        Assert.Equal(new OrderPayload("SKU-A", 1), claimed[good].Payload);
+        Assert.Equal(new OrderPayload("SKU-C", 3), claimed[alsoGood].Payload);
+        Assert.Throws<JsonException>(() => _ = claimed[bad].Payload);
+        Assert.All(claimed.Values, job => Assert.Equal("batch-worker", job.WorkerId));
+
+        Assert.Equal(3, typed.AckBatch(claimed.Keys, "batch-worker"));
+    }
+
+    [Fact]
+    public async Task TypedClaimAsyncYieldsDecodedJobs()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        var queue = db.Queue<OrderPayload>("orders");
+        var id = queue.Enqueue(new OrderPayload("SKU-ASYNC", 5));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using var jobs = queue
+            .ClaimAsync("async-worker", TimeSpan.FromSeconds(30), cts.Token)
+            .GetAsyncEnumerator(cts.Token);
+
+        Assert.True(await jobs.MoveNextAsync());
+        var job = jobs.Current;
+        Assert.Equal(id, job.Id);
+        Assert.Equal(new OrderPayload("SKU-ASYNC", 5), job.Payload);
+        Assert.Equal("async-worker", job.WorkerId);
+        Assert.True(job.Ack());
+    }
+
+    [Fact]
+    public void TypedJobHeartbeatsRetriesAndCancels()
+    {
+        using var harness = TestHarness.Create();
+        using var db = harness.Open();
+        var queue = db.Queue<OrderPayload>("orders", new QueueOptions(VisibilityTimeoutSeconds: 30, MaxAttempts: 3));
+        Assert.Equal("orders", queue.Name);
+
+        var id = queue.Enqueue(new OrderPayload("SKU-R", 2));
+        var job = queue.ClaimOne("w1");
+        Assert.NotNull(job);
+        // Untyped is the documented escape hatch: same claim, same worker.
+        Assert.Equal(id, job!.Untyped.Id);
+        Assert.Equal("w1", job.Untyped.WorkerId);
+
+        var beatBefore = Now(db);
+        Assert.True(job.Heartbeat(90));
+        var beatAfter = Now(db);
+        Assert.InRange(queue.GetJob(id)!.ClaimExpiresAt!.Value, beatBefore + 90, beatAfter + 90);
+
+        var retriedBefore = Now(db);
+        Assert.True(job.Retry(delaySeconds: 45, error: "boom"));
+        var retriedAfter = Now(db);
+
+        var back = queue.GetJob(id);
+        Assert.NotNull(back);
+        Assert.Equal("pending", back!.State);
+        Assert.Null(back.WorkerId);
+        Assert.Null(back.ClaimExpiresAt);
+        Assert.Equal(1, back.Attempts);
+        Assert.InRange(back.RunAt, retriedBefore + 45, retriedAfter + 45);
+        Assert.Equal(new OrderPayload("SKU-R", 2), back.Payload);
+
+        Assert.True(queue.Cancel(id));
+        Assert.Null(queue.GetJob(id));
+    }
+
     private static long Now(Database db)
     {
         return Convert.ToInt64(db.Query("SELECT unixepoch() AS v").Single()["v"]);

--- a/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
@@ -130,8 +130,15 @@ public sealed class JobDetailTests
         using var db = harness.Open();
         var queue = db.Queue<OrderPayload>("orders", new QueueOptions(VisibilityTimeoutSeconds: 90, MaxAttempts: 4));
 
+        // Back-dated absolute run_at: the job stays claimable (a delayed
+        // job is not) while RunAt and CreatedAt differ by 100 seconds. With
+        // an immediate enqueue the two are equal to the second, so the two
+        // properties could be transposed and every assertion still held.
+        var runAt = Now(db) - 100;
         var enqueuedBefore = Now(db);
-        var id = queue.Enqueue(new OrderPayload("SKU-42", 3), new EnqueueOptions(Priority: 6, ExpiresSeconds: 300));
+        var id = queue.Enqueue(
+            new OrderPayload("SKU-42", 3),
+            new EnqueueOptions(RunAtUnix: runAt, Priority: 6, ExpiresSeconds: 300));
         var enqueuedAfter = Now(db);
 
         var claimedBefore = Now(db);
@@ -142,14 +149,16 @@ public sealed class JobDetailTests
         Assert.Equal(id, job!.Id);
         Assert.Equal("orders", job.QueueName);
         Assert.Equal(new OrderPayload("SKU-42", 3), job.Payload);
+        Assert.Equal("{\"Sku\":\"SKU-42\",\"Quantity\":3}", job.PayloadRaw);
         Assert.Equal("processing", job.State);
         Assert.Equal(6, job.Priority);
-        Assert.InRange(job.RunAt, enqueuedBefore, enqueuedAfter);
+        Assert.Equal(runAt, job.RunAt);
         Assert.Equal("typed-worker", job.WorkerId);
         Assert.InRange(job.ClaimExpiresAt, claimedBefore + 90, claimedAfter + 90);
         Assert.Equal(1, job.Attempts);
         Assert.Equal(4, job.MaxAttempts);
         Assert.InRange(job.CreatedAt, enqueuedBefore, enqueuedAfter);
+        Assert.NotEqual(job.RunAt, job.CreatedAt);
         Assert.NotNull(job.ExpiresAt);
         Assert.InRange(job.ExpiresAt!.Value, enqueuedBefore + 300, enqueuedAfter + 300);
         Assert.True(job.Ack());
@@ -162,8 +171,14 @@ public sealed class JobDetailTests
         using var db = harness.Open();
         var queue = db.Queue<OrderPayload>("orders", new QueueOptions(VisibilityTimeoutSeconds: 30));
 
+        // Same back-dating as the claimed-job test, and for the same
+        // reason: it is the only thing that separates RunAt from CreatedAt
+        // on a job this test still needs to claim further down.
+        var runAt = Now(db) - 100;
         var enqueuedBefore = Now(db);
-        var id = queue.Enqueue(new OrderPayload("SKU-9", 11), new EnqueueOptions(Priority: 2, MaxAttempts: 7, ExpiresSeconds: 120));
+        var id = queue.Enqueue(
+            new OrderPayload("SKU-9", 11),
+            new EnqueueOptions(RunAtUnix: runAt, Priority: 2, MaxAttempts: 7, ExpiresSeconds: 120));
         var enqueuedAfter = Now(db);
 
         var pending = queue.GetJob(id);
@@ -174,12 +189,13 @@ public sealed class JobDetailTests
         Assert.Equal("{\"Sku\":\"SKU-9\",\"Quantity\":11}", pending.PayloadRaw);
         Assert.Equal("pending", pending.State);
         Assert.Equal(2, pending.Priority);
-        Assert.InRange(pending.RunAt, enqueuedBefore, enqueuedAfter);
+        Assert.Equal(runAt, pending.RunAt);
         Assert.Null(pending.WorkerId);
         Assert.Null(pending.ClaimExpiresAt);
         Assert.Equal(0, pending.Attempts);
         Assert.Equal(7, pending.MaxAttempts);
         Assert.InRange(pending.CreatedAt, enqueuedBefore, enqueuedAfter);
+        Assert.NotEqual(pending.RunAt, pending.CreatedAt);
         Assert.NotNull(pending.ExpiresAt);
         Assert.InRange(pending.ExpiresAt!.Value, enqueuedBefore + 120, enqueuedAfter + 120);
 

--- a/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
@@ -342,6 +342,33 @@ public sealed class JobDetailTests
         Assert.Null(queue.GetJob(id));
     }
 
+    [Fact]
+    public void AClaimRowFromAnOlderCoreIsRejectedRatherThanDefaulted()
+    {
+        // honker_claim_batch before 0.6 returned six columns and no
+        // "state". This is that payload, key for key. ClaimBatch now
+        // decodes it into JobRow like every other row, and JobRow's
+        // defaults would have made State "" and carried it to
+        // Job.State — where the old ClaimedJobRow's `?? "processing"`
+        // had been correct. Wrong and silent is the worst outcome, so
+        // the decode has to fail instead.
+        const string oldAbi =
+            """[{"id":1,"queue":"work","payload":"{}","worker_id":"w1","attempts":1,"claim_expires_at":100}]""";
+
+        var error = Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize<List<JobRow>>(oldAbi));
+        Assert.Contains("state", error.Message);
+
+        // The current core emits all twelve, nulls included, and decodes.
+        const string currentAbi =
+            """[{"id":1,"queue":"work","payload":"{}","state":"processing","priority":0,"run_at":5,"worker_id":"w1","claim_expires_at":100,"attempts":1,"max_attempts":3,"created_at":5,"expires_at":null}]""";
+
+        var rows = JsonSerializer.Deserialize<List<JobRow>>(currentAbi);
+        Assert.NotNull(rows);
+        Assert.Equal("processing", rows!.Single().State);
+        Assert.Null(rows.Single().ExpiresAt);
+    }
+
     private static long Now(Database db)
     {
         return Convert.ToInt64(db.Query("SELECT unixepoch() AS v").Single()["v"]);

--- a/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
+++ b/packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs
@@ -120,6 +120,9 @@ public sealed class JobDetailTests
         Assert.NotNull(row);
         Assert.Equal("pending", row!.State);
         Assert.InRange(row.RunAt, before + 60, after + 60);
+        // No ExpiresSeconds was given, so this has to be null, not 0.
+        // Every other test here enqueues with an expiry.
+        Assert.Null(row.ExpiresAt);
         Assert.Null(queue.ClaimOne("early-worker"));
     }
 


### PR DESCRIPTION
Part of #136 — the .NET half. The Bun half is a separate PR.

**Stacked on #124 (`feat/node-typed-jobs`), which is the base of this PR. Merge after #124.**
It depends on the widened `honker_claim_batch` RETURNING clause that only exists there. No honker-core or SQL ABI change here; core already returns everything needed.

## What changed

- `Job` (claimed) now carries all twelve fields the core returns: `Id`, `QueueName`, payload, `State`, `Priority`, `RunAt`, `WorkerId`, `ClaimExpiresAt`, `Attempts`, `MaxAttempts`, `CreatedAt`, `ExpiresAt`. It keeps `Ack`/`Retry`/`Fail`/`Heartbeat`.
- `ClaimBatch` now decodes `honker_claim_batch` into the same `JobRow` record `GetJob()` returns (the two SQL functions return the same field set). The old `row.State ?? "processing"` fallback — against a field core did not previously return — is gone; `State` is a real core value now.
- A claimed row arriving without `worker_id` or `claim_expires_at` throws instead of being silently defaulted.
- New `db.Queue<TPayload>(name)` returns `TypedQueue<TPayload>`: `Enqueue(TPayload)`, `ClaimBatch`/`ClaimOne`/`ClaimAsync` yielding `Job<TPayload>`, and `GetJob()` yielding the data-only `JobSnapshot<TPayload>` record (no ack/retry/fail/heartbeat — reading a row does not claim it). `Untyped` gets you back to the plain handle.
- Named `TypedQueue<T>` rather than `Queue<T>` on purpose: a `Honker.Queue<T>` would collide with `System.Collections.Generic.Queue<T>` in any file that imports both (it broke this binding's own `Listener.cs`/`Stream.cs` first).
- Typing is **compile-time only**. Honker never validates payload shape in the database and this binding adds no runtime check; the README and XML docs say so.

Read-only snapshots needed no field work — `JobRow` already had all twelve.

### Snapshot payload encoding (flagged for a repo-wide decision)

No existing .NET payload encoding changed here. `Queue.GetJob()` still returns `JobRow` with `Payload` as raw JSON text, and `Job.Payload` is still a `JsonElement` with `GetPayload<T>()` for decoding. The new opt-in `JobSnapshot<TPayload>` (reachable only through `db.Queue<TPayload>()`) carries both: `Payload` decoded as `TPayload` and `PayloadRaw` as the original text.

Bindings currently disagree on snapshot payload encoding — Node (#124) decodes; Bun (#145), Go, and Python return raw text — and this PR does not try to settle it.

## Tests

New `packages/honker-dotnet/tests/Honker.Tests/JobDetailTests.cs`, 7 tests, each asserting values rather than presence:

- `ClaimedJobCarriesEveryCoreDetail` — explicit `runAt`/`priority`/`maxAttempts`/`expires`, then every field checked against the value that was enqueued (times bounded by `unixepoch()` reads taken around the call).
- `PendingSnapshotCarriesEveryCoreDetail` — pending snapshot: `state=pending`, null worker/claim expiry, exact payload JSON.
- `ReaderSeesProcessingDetailWhileWorkerHoldsTheClaimAndNothingAfterAck` — second connection reads the processing snapshot, then gets null after ack.
- `DelayedJobReportsItsRunAt`
- `TypedQueueDecodesClaimedPayloadsAndKeepsEveryDetail`
- `TypedSnapshotDecodesPayloadAndCarriesEveryDetail`
- `TypedAndUntypedHandlesShareOneQueue`

Local: `dotnet test ... -c Release` → 110 passed, 0 failed (whole suite, after building `Honker.QueueHelper`).

### Falsification

Broke `RunAt = row.RunAt` to `RunAt = row.CreatedAt` in the `Job` constructor:

```
Failed Honker.Tests.JobDetailTests.ClaimedJobCarriesEveryCoreDetail [9 ms]
  Assert.Equal() Failure: Values differ
  Expected: 1788254421
  Actual:   1788254426
  at Honker.Tests.JobDetailTests.ClaimedJobCarriesEveryCoreDetail() in JobDetailTests.cs:line 38
```

Restored, suite green again.

## Not in scope

- `claimed_at` (#135) — deliberately not added.
- Queue-scoping of `GetJob` (#134) — .NET `GetJob` is still global, unlike Node's now-scoped one.
- No changes to honker-core, the SQL ABI, honker-node, or any other binding.

https://claude.ai/code/session_01YMCFasvKC52r37DDKSTeMC
