### PR TITLE
feat(kotlin): add a JobDetails data class over the JVM job fields

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -182,9 +182,8 @@ updates:
     commit-message:
       prefix: "deps"
 
-  # honker-jvm and honker-kotlin have no CI job yet, so Dependabot is the
-  # only thing watching them. Keep the PRs coming even though nothing
-  # gates them — they at least surface CVEs.
+  # The `jvm` CI job now runs both binding test suites, so Dependabot PRs
+  # here are gated. Keep them coming: they also surface CVEs.
   - package-ecosystem: maven
     directories:
       - "/packages/honker-jvm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,7 +694,7 @@ jobs:
           python -m pytest tests/test_ruby_python_interop.py -q --tb=short
 
   jvm:
-    name: jvm · honker + documented ORM recipes
+    name: jvm · honker + kotlin + documented ORM recipes
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
@@ -732,6 +732,14 @@ jobs:
         #
         # The other 44 tests gate, and so do the ORM recipes below.
         run: mvn -B test -Dtest='!HonkerJvmTest#childJvmKernelListenerWakesWhenParentNotifies'
+      - name: Run honker-kotlin tests
+        # The Kotlin wrappers compile and run against the dev.honker:honker
+        # jar installed above, so this gates the Kotlin surface on the same
+        # extension build.
+        working-directory: packages/honker-kotlin
+        env:
+          HONKER_EXTENSION_PATH: ${{ github.workspace }}/target/release/libhonker_ext.so
+        run: mvn -B test
       - name: ORM · JVM (JDBC, Hibernate, jOOQ)
         working-directory: scripts/proof/orm/jvm
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@
 - The `jvm` CI job now runs `packages/honker-kotlin` tests too, against
   the same extension build and the `dev.honker:honker` jar it installs.
   The Kotlin binding previously had no CI job at all.
+- Fix: `Queue.asFlow` and `Listener.asFlow` closed their channel only
+  when the collector cancelled. If the producer thread died on anything
+  other than `HonkerClosedException` it printed a stack trace and left
+  every collector parked on the flow forever. Both now end the flow, and
+  hand a real failure to the collector instead of swallowing it.
+- `HonkerKotlinTest` carries a 60-second per-test timeout so a wrapper
+  that stops producing fails by name instead of burning the CI job's
+  20-minute budget with no diagnosis.
 
 ## Unreleased — JVM job parity
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@
 - Regression test claims a job at a deadline with one claim forced to
   return empty: it fails on the unpatched `api.js` and passes on the fix.
 
+## Unreleased — Kotlin job parity
+
+- New `JobDetails<T>` data class in `dev.honker.kotlin`: every field the
+  core returns for a job row, restated with Kotlin nullability so the
+  compiler knows a pending job has no `workerId` or `claimExpiresAt` and
+  an unexpiring job has no `expiresAt`. Data only — the claim operations
+  stay on the claimed `Job`.
+- `Job.details()`, `TypedJob<T>.details()`, `JobSnapshot.details()` and
+  `TypedJobSnapshot<T>.details()` build one. `Queue.jobDetails(id)`,
+  `TypedQueue<T>.jobDetails(id)` and `Database.jobDetails(id)` look one
+  up and return Kotlin `null` instead of `Optional.empty()`. The queue
+  lookups are scoped to their queue; the database lookup is global.
+- Payload typing is the JVM generic, so it stays a compile-time contract.
+  No runtime payload validation was added.
+- The `jvm` CI job now runs `packages/honker-kotlin` tests too, against
+  the same extension build and the `dev.honker:honker` jar it installs.
+  The Kotlin binding previously had no CI job at all.
+
 ## Unreleased — JVM job parity
 
 - JVM claimed `Job` and `TypedJob<T>` now carry every field the core

--- a/packages/honker-kotlin/README.md
+++ b/packages/honker-kotlin/README.md
@@ -80,11 +80,17 @@ does not match the queue's type. `Database.jobDetails(id)` is the global
 lookup.
 
 Pass a `JsonCodec<T>` — or use a `TypedQueue<T>` — to get the payload
-decoded:
+decoded. Both give the same `JobDetails<T>`; `payloadJson` is always the
+raw row text either way:
 
 ```kotlin
 val typed = db.queue("emails").typed(strings)
 val details: JobDetails<String>? = typed.jobDetails(id)
+
+// Same thing without a typed queue. The codec overload exists on
+// `Queue.jobDetails`, `Database.jobDetails`, `Job.details` and
+// `JobSnapshot.details`.
+val same: JobDetails<String>? = db.queue("emails").jobDetails(id, strings)
 ```
 
 The payload type is a compile-time contract between the callers that

--- a/packages/honker-kotlin/README.md
+++ b/packages/honker-kotlin/README.md
@@ -12,6 +12,8 @@ Current shape:
 - adds coroutine `TaskResult.await(...)`
 - adds codec-based typed queue/task helpers without forcing a JSON
   library dependency
+- adds a `JobDetails<T>` data class over the JVM job fields, with Kotlin
+  nullability and nullable `jobDetails(id)` lookups instead of `Optional`
 
 ## Quick start
 
@@ -43,6 +45,50 @@ val job = db.queue("emails").asFlow("worker").first()
 println(job.decode(strings))
 job.ack()
 ```
+
+## Job fields
+
+`JobDetails<T>` is a Kotlin data class carrying every field the core
+returns for a job row: `id`, `queue`, `payload`, `payloadJson`, `state`,
+`priority`, `runAt`, `workerId`, `claimExpiresAt`, `attempts`,
+`maxAttempts`, `createdAt`, `expiresAt`. Times are unix epoch seconds.
+`workerId`, `claimExpiresAt` and `expiresAt` are Kotlin nullable, so the
+compiler knows a pending job has no worker.
+
+It is data only. Ack, retry, fail and heartbeat stay on the claimed
+`Job`, because only the worker holding the claim may call them.
+
+```kotlin
+val emails = db.queue("emails")
+val id = emails.enqueueJson("""{"to":"alice@example.com"}""")
+
+val pending = emails.jobDetails(id)!!
+println(pending.state)      // "pending"
+println(pending.workerId)   // null
+
+val claimed = emails.claimOne("worker-1").orElseThrow()
+val job = claimed.details()
+println("${job.state} ${job.attempts}/${job.maxAttempts} ${job.priority}")
+claimed.ack()
+
+emails.jobDetails(id)       // null
+```
+
+`jobDetails(id)` on a `Queue` only returns jobs from that queue; job ids
+are globally unique, so an unscoped hit could hand back a payload that
+does not match the queue's type. `Database.jobDetails(id)` is the global
+lookup.
+
+Pass a `JsonCodec<T>` — or use a `TypedQueue<T>` — to get the payload
+decoded:
+
+```kotlin
+val typed = db.queue("emails").typed(strings)
+val details: JobDetails<String>? = typed.jobDetails(id)
+```
+
+The payload type is a compile-time contract between the callers that
+share a queue. Honker does not validate payload shape in the database.
 
 ## Local test
 

--- a/packages/honker-kotlin/src/main/kotlin/dev/honker/kotlin/HonkerKotlin.kt
+++ b/packages/honker-kotlin/src/main/kotlin/dev/honker/kotlin/HonkerKotlin.kt
@@ -80,7 +80,15 @@ fun Listener.asFlow(timeout: Duration = Duration.ofSeconds(15)): Flow<Notificati
             while (!Thread.currentThread().isInterrupted) {
                 next(timeout).ifPresent { trySend(it).isSuccess }
             }
+            close()
         } catch (ignored: HonkerClosedException) {
+            // The database went away under us: the flow simply ends.
+            close()
+        } catch (failure: Throwable) {
+            // Anything else is a real failure. Hand it to the collector.
+            // Without this the producer thread dies and every collector
+            // parks on this flow forever.
+            close(failure)
         }
     }
     thread.isDaemon = true
@@ -115,7 +123,15 @@ fun Queue.asFlow(
                 }
                 updates.awaitUpdate(wait)
             }
+            close()
         } catch (ignored: HonkerClosedException) {
+            // The database went away under us: the flow simply ends.
+            close()
+        } catch (failure: Throwable) {
+            // Anything else is a real failure. Hand it to the collector.
+            // Without this the producer thread dies and every collector
+            // parks on this flow forever.
+            close(failure)
         } finally {
             updates.close()
         }

--- a/packages/honker-kotlin/src/main/kotlin/dev/honker/kotlin/Jobs.kt
+++ b/packages/honker-kotlin/src/main/kotlin/dev/honker/kotlin/Jobs.kt
@@ -1,0 +1,105 @@
+package dev.honker.kotlin
+
+import dev.honker.Database
+import dev.honker.Job
+import dev.honker.JobSnapshot
+import dev.honker.JsonCodec
+import dev.honker.Queue
+import dev.honker.TypedJob
+import dev.honker.TypedJobSnapshot
+import dev.honker.TypedQueue
+
+/**
+ * Every field the core returns for one live job row, with the payload
+ * decoded to [T].
+ *
+ * Data only: ack, retry, fail and heartbeat stay on a claimed [Job],
+ * because only the worker holding the claim may call them.
+ *
+ * The Java [JobSnapshot] record carries the same twelve fields with
+ * platform types. This data class restates them in Kotlin so the compiler
+ * knows which columns can be absent: a pending job has no [workerId] and
+ * no [claimExpiresAt], and a job enqueued without `expires` has no
+ * [expiresAt]. Times are unix epoch seconds.
+ *
+ * [T] is a compile-time contract between the callers that share a queue.
+ * Honker never inspects payload shape in the database, so every writer
+ * must agree on the JSON it produces.
+ */
+data class JobDetails<T>(
+    val id: Long,
+    val queue: String,
+    val payload: T,
+    val payloadJson: String,
+    val state: String,
+    val priority: Int,
+    val runAt: Long,
+    val workerId: String?,
+    val claimExpiresAt: Long?,
+    val attempts: Int,
+    val maxAttempts: Int,
+    val createdAt: Long,
+    val expiresAt: Long?,
+)
+
+private fun <T> JobSnapshot.toDetails(payload: T): JobDetails<T> = JobDetails(
+    id = id(),
+    queue = queue(),
+    payload = payload,
+    payloadJson = payloadJson(),
+    state = state(),
+    priority = priority(),
+    runAt = runAt(),
+    workerId = workerId(),
+    claimExpiresAt = claimExpiresAt(),
+    attempts = attempts(),
+    maxAttempts = maxAttempts(),
+    createdAt = createdAt(),
+    expiresAt = expiresAt(),
+)
+
+/** Every field, payload left as the raw JSON string. */
+fun JobSnapshot.details(): JobDetails<String> = toDetails(payloadJson())
+
+/** Every field, payload decoded with [codec]. */
+fun <T> JobSnapshot.details(codec: JsonCodec<T>): JobDetails<T> =
+    toDetails(codec.decode(payloadJson()))
+
+/** Every field, keeping the payload this snapshot already decoded. */
+fun <T> TypedJobSnapshot<T>.details(): JobDetails<T> = raw().toDetails(payload())
+
+/** Every field of a job this worker holds a claim on, payload left as JSON. */
+fun Job.details(): JobDetails<String> = snapshot().details()
+
+/** Every field of a job this worker holds a claim on, payload decoded with [codec]. */
+fun <T> Job.details(codec: JsonCodec<T>): JobDetails<T> = snapshot().details(codec)
+
+/** Every field of a claimed typed job, payload decoded by the queue's codec. */
+fun <T> TypedJob<T>.details(): JobDetails<T> = snapshot().toDetails(payload())
+
+/**
+ * A snapshot of one live job in *this* queue, or `null` when the job was
+ * ack'd, dead-lettered, never existed, or belongs to another queue.
+ */
+fun Queue.jobDetails(jobId: Long): JobDetails<String>? =
+    getJob(jobId).map { it.details() }.orElse(null)
+
+/** As [jobDetails], with the payload decoded by [codec]. */
+fun <T> Queue.jobDetails(jobId: Long, codec: JsonCodec<T>): JobDetails<T>? =
+    getJob(jobId).map { it.details(codec) }.orElse(null)
+
+/** As [jobDetails], with the payload decoded by this typed queue's codec. */
+fun <T> TypedQueue<T>.jobDetails(jobId: Long): JobDetails<T>? =
+    getJob(jobId).map { it.details() }.orElse(null)
+
+/**
+ * A snapshot of one live job looked up by id across every queue, or
+ * `null` when the job is gone. Use [Queue.jobDetails] to scope the lookup
+ * to one queue.
+ */
+fun Database.jobDetails(jobId: Long): JobDetails<String>? =
+    getJob(jobId).map { it.details() }.orElse(null)
+
+/** As [jobDetails], with the payload decoded by [codec]. */
+fun <T> Database.jobDetails(jobId: Long, codec: JsonCodec<T>): JobDetails<T>? =
+    getJob(jobId).map { it.details(codec) }.orElse(null)

--- a/packages/honker-kotlin/src/main/kotlin/dev/honker/kotlin/Jobs.kt
+++ b/packages/honker-kotlin/src/main/kotlin/dev/honker/kotlin/Jobs.kt
@@ -75,7 +75,10 @@ fun Job.details(): JobDetails<String> = snapshot().details()
 fun <T> Job.details(codec: JsonCodec<T>): JobDetails<T> = snapshot().details(codec)
 
 /** Every field of a claimed typed job, payload decoded by the queue's codec. */
-fun <T> TypedJob<T>.details(): JobDetails<T> = snapshot().toDetails(payload())
+// `raw().snapshot()`, not `snapshot()`: TypedJob.snapshot() returns the
+// decoded TypedJobSnapshot<T> on the current JVM binding and the undecoded
+// JobSnapshot on older ones. Job.snapshot() is JobSnapshot either way.
+fun <T> TypedJob<T>.details(): JobDetails<T> = raw().snapshot().toDetails(payload())
 
 /**
  * A snapshot of one live job in *this* queue, or `null` when the job was

--- a/packages/honker-kotlin/src/test/kotlin/dev/honker/kotlin/HonkerKotlinTest.kt
+++ b/packages/honker-kotlin/src/test/kotlin/dev/honker/kotlin/HonkerKotlinTest.kt
@@ -5,14 +5,18 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.async
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import dev.honker.Database
 import dev.honker.HonkerInvalidOptionException
 import dev.honker.JsonCodec
 import dev.honker.WatcherBackend
 import java.nio.file.Path
 import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.assertFailsWith
 
@@ -103,6 +107,219 @@ class HonkerKotlinTest {
                 assertEquals("world", result.raw().await(stringCodec, Duration.ofSeconds(2)))
             }
         }
+    }
+
+    @Test
+    fun claimedJobDetailsCarryEveryCoreField() {
+        honker(tmp.resolve("job-fields.db")) {
+            fallbackPollInterval(Duration.ofMillis(2))
+        }.use { db ->
+            val queue = db.queue("full-fields", queueOptions {
+                visibilityTimeout(Duration.ofSeconds(300))
+                maxAttempts(5)
+            })
+            val runAt = unixNow(db) - 5
+
+            val enqueuedBefore = unixNow(db)
+            val id = queue.enqueueJson("""{"to":"alice@example.com"}""", enqueueOptions {
+                runAt(Instant.ofEpochSecond(runAt))
+                priority(7)
+                expires(Duration.ofSeconds(600))
+            })
+            val enqueuedAfter = unixNow(db)
+
+            val claimedBefore = unixNow(db)
+            val claimed = queue.claimOne("worker-1").orElseThrow()
+            val claimedAfter = unixNow(db)
+
+            val job = claimed.details()
+            assertEquals(id, job.id)
+            assertEquals("full-fields", job.queue)
+            assertEquals("""{"to":"alice@example.com"}""", job.payload)
+            assertEquals("""{"to":"alice@example.com"}""", job.payloadJson)
+            assertEquals("processing", job.state)
+            assertEquals(7, job.priority)
+            assertEquals(runAt, job.runAt)
+            assertEquals("worker-1", job.workerId)
+            assertEquals(1, job.attempts)
+            assertEquals(5, job.maxAttempts)
+            assertBetween(job.createdAt, enqueuedBefore, enqueuedAfter, "createdAt")
+            assertBetween(assertNotNull(job.expiresAt), enqueuedBefore + 600, enqueuedAfter + 600, "expiresAt")
+            assertBetween(
+                assertNotNull(job.claimExpiresAt),
+                claimedBefore + 300,
+                claimedAfter + 300,
+                "claimExpiresAt",
+            )
+
+            // Details are data only; the claim operations stay on the claimed job.
+            assertTrue(claimed.ack())
+        }
+    }
+
+    @Test
+    fun jobDetailsFollowPendingProcessingAndAckedStates() {
+        honker(tmp.resolve("snapshots.db")) {
+            fallbackPollInterval(Duration.ofMillis(2))
+        }.use { worker ->
+            honker(tmp.resolve("snapshots.db")) {
+                fallbackPollInterval(Duration.ofMillis(2))
+            }.use { reader ->
+                val writes = worker.queue("snapshots", queueOptions {
+                    visibilityTimeout(Duration.ofSeconds(120))
+                    maxAttempts(4)
+                })
+                val reads = reader.queue("snapshots")
+
+                val runAt = unixNow(worker) - 2
+                val enqueuedBefore = unixNow(worker)
+                val id = writes.enqueueJson("""{"n":1}""", enqueueOptions {
+                    runAt(Instant.ofEpochSecond(runAt))
+                    priority(2)
+                })
+                val enqueuedAfter = unixNow(worker)
+
+                val pending = assertNotNull(reads.jobDetails(id))
+                assertEquals(id, pending.id)
+                assertEquals("snapshots", pending.queue)
+                assertEquals("""{"n":1}""", pending.payload)
+                assertEquals("pending", pending.state)
+                assertEquals(2, pending.priority)
+                assertEquals(runAt, pending.runAt)
+                assertNull(pending.workerId, "a pending job has no worker")
+                assertNull(pending.claimExpiresAt, "a pending job has no claim deadline")
+                assertEquals(0, pending.attempts)
+                assertEquals(4, pending.maxAttempts)
+                assertBetween(pending.createdAt, enqueuedBefore, enqueuedAfter, "createdAt")
+                assertNull(pending.expiresAt, "no expires means no expiresAt")
+
+                val claimedBefore = unixNow(worker)
+                val claimed = writes.claimOne("worker-9").orElseThrow()
+                val claimedAfter = unixNow(worker)
+
+                val processing = assertNotNull(reads.jobDetails(id))
+                assertEquals(id, processing.id)
+                assertEquals("processing", processing.state)
+                assertEquals("worker-9", processing.workerId)
+                assertEquals(1, processing.attempts)
+                assertEquals(4, processing.maxAttempts)
+                assertEquals(2, processing.priority)
+                assertEquals(runAt, processing.runAt)
+                assertEquals(pending.createdAt, processing.createdAt)
+                assertBetween(
+                    assertNotNull(processing.claimExpiresAt),
+                    claimedBefore + 120,
+                    claimedAfter + 120,
+                    "claimExpiresAt",
+                )
+
+                assertTrue(claimed.ack())
+                assertNull(reads.jobDetails(id), "an ack'd job leaves no live row")
+            }
+        }
+    }
+
+    @Test
+    fun delayedJobDetailsReportItsRunAt() {
+        honker(tmp.resolve("delayed.db")) {
+            fallbackPollInterval(Duration.ofMillis(2))
+        }.use { db ->
+            val queue = db.queue("delayed-snapshot")
+
+            val before = unixNow(db)
+            val id = queue.enqueueJson("""{"later":true}""", enqueueOptions {
+                delay(Duration.ofSeconds(30))
+            })
+            val after = unixNow(db)
+
+            val details = assertNotNull(queue.jobDetails(id))
+            assertEquals("pending", details.state)
+            assertBetween(details.runAt, before + 30, after + 30, "runAt")
+            assertTrue(details.runAt > unixNow(db), "a delayed job runs in the future")
+            assertTrue(queue.claimOne("too-early").isEmpty, "a delayed job is not claimable yet")
+        }
+    }
+
+    @Test
+    fun typedQueueDetailsDecodePayloadAndKeepEveryField() {
+        honker(tmp.resolve("typed-fields.db")) {
+            fallbackPollInterval(Duration.ofMillis(2))
+        }.use { db ->
+            val typed = db.queue("typed-fields", queueOptions {
+                visibilityTimeout(Duration.ofSeconds(60))
+                maxAttempts(2)
+            }).typed(stringCodec)
+
+            val runAt = unixNow(db) - 1
+            val enqueuedBefore = unixNow(db)
+            val id = typed.enqueue("welcome", enqueueOptions {
+                runAt(Instant.ofEpochSecond(runAt))
+                priority(4)
+                expires(Duration.ofSeconds(900))
+            })
+            val enqueuedAfter = unixNow(db)
+
+            val pending = assertNotNull(typed.jobDetails(id))
+            assertEquals("welcome", pending.payload)
+            assertEquals(""""welcome"""", pending.payloadJson)
+            assertEquals("pending", pending.state)
+            assertEquals(4, pending.priority)
+            assertEquals(runAt, pending.runAt)
+            assertEquals(0, pending.attempts)
+            assertEquals(2, pending.maxAttempts)
+            assertNull(pending.workerId)
+            assertNull(pending.claimExpiresAt)
+            assertBetween(pending.createdAt, enqueuedBefore, enqueuedAfter, "createdAt")
+            assertBetween(assertNotNull(pending.expiresAt), enqueuedBefore + 900, enqueuedAfter + 900, "expiresAt")
+
+            val claimedBefore = unixNow(db)
+            val claimed = typed.claimOne("typed-worker").orElseThrow()
+            val claimedAfter = unixNow(db)
+
+            val job = claimed.details()
+            assertEquals(id, job.id)
+            assertEquals("typed-fields", job.queue)
+            assertEquals("welcome", job.payload)
+            assertEquals(""""welcome"""", job.payloadJson)
+            assertEquals("processing", job.state)
+            assertEquals(4, job.priority)
+            assertEquals(runAt, job.runAt)
+            assertEquals("typed-worker", job.workerId)
+            assertEquals(1, job.attempts)
+            assertEquals(2, job.maxAttempts)
+            assertBetween(job.createdAt, enqueuedBefore, enqueuedAfter, "createdAt")
+            assertBetween(assertNotNull(job.expiresAt), enqueuedBefore + 900, enqueuedAfter + 900, "expiresAt")
+            assertBetween(assertNotNull(job.claimExpiresAt), claimedBefore + 60, claimedAfter + 60, "claimExpiresAt")
+
+            assertTrue(claimed.ack())
+            assertNull(typed.jobDetails(id))
+        }
+    }
+
+    @Test
+    fun jobDetailsAreScopedToTheirQueueWhileDatabaseLookupIsGlobal() {
+        honker(tmp.resolve("scoped.db")) {
+            fallbackPollInterval(Duration.ofMillis(2))
+        }.use { db ->
+            val emails = db.queue("scoped-emails")
+            val reports = db.queue("scoped-reports")
+            val id = emails.enqueueJson("""{"to":"alice@example.com"}""")
+
+            assertNull(reports.jobDetails(id), "another queue must not see this job")
+            assertEquals("scoped-emails", assertNotNull(emails.jobDetails(id)).queue)
+            assertEquals("scoped-emails", assertNotNull(db.jobDetails(id)).queue)
+            assertNull(db.jobDetails(id + 10_000), "an unknown id has no snapshot")
+        }
+    }
+
+    private fun unixNow(db: Database): Long =
+        db.query("SELECT unixepoch() AS t").first().getLong("t")
+
+    private fun assertBetween(actual: Long, low: Long, high: Long, field: String) {
+        assertTrue(
+            actual in low..high,
+            "$field should be within [$low, $high] but was $actual",
+        )
     }
 
     @Test

--- a/packages/honker-kotlin/src/test/kotlin/dev/honker/kotlin/HonkerKotlinTest.kt
+++ b/packages/honker-kotlin/src/test/kotlin/dev/honker/kotlin/HonkerKotlinTest.kt
@@ -3,7 +3,11 @@ package dev.honker.kotlin
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.Timeout.ThreadMode
 import org.junit.jupiter.api.io.TempDir
 import dev.honker.Database
 import dev.honker.HonkerInvalidOptionException
@@ -20,6 +24,10 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.assertFailsWith
 
+// The whole suite runs in well under a second. The cap exists so a flow
+// wrapper that stops producing fails by name instead of parking the
+// runner until the CI job's own 20-minute timeout kills it.
+@Timeout(value = 60, threadMode = ThreadMode.SEPARATE_THREAD)
 class HonkerKotlinTest {
     @TempDir
     lateinit var tmp: Path
@@ -310,6 +318,30 @@ class HonkerKotlinTest {
             assertEquals("scoped-emails", assertNotNull(db.jobDetails(id)).queue)
             assertNull(db.jobDetails(id + 10_000), "an unknown id has no snapshot")
         }
+    }
+
+    @Test
+    // `runBlocking<Unit>` is deliberate: an expression-bodied test whose
+    // last expression is not Unit compiles to a non-void method and JUnit
+    // silently never runs it.
+    fun queueFlowEndsWhenTheDatabaseClosesInsteadOfParkingTheCollector() = runBlocking<Unit> {
+        val db = honker(tmp.resolve("flow-close.db")) {
+            fallbackPollInterval(Duration.ofMillis(2))
+        }
+        val jobs = db.queue("flow-close").asFlow("flow-close-worker", workerOptions {
+            idlePollInterval(Duration.ofMillis(20))
+        })
+        val drained = async { runCatching { jobs.collect { } } }
+        delay(200)
+
+        // The producer thread is now inside its claim loop. Closing the
+        // database makes every call it depends on throw. It must end the
+        // flow — normally or with the failure — never leave the collector
+        // parked on a producer that already died.
+        db.close()
+        val finished = withTimeoutOrNull(15_000) { drained.await() }
+        drained.cancel()
+        assertNotNull(finished, "closing the database must end the queue flow")
     }
 
     private fun unixNow(db: Database): Long =

--- a/packages/honker-kotlin/src/test/kotlin/dev/honker/kotlin/HonkerKotlinTest.kt
+++ b/packages/honker-kotlin/src/test/kotlin/dev/honker/kotlin/HonkerKotlinTest.kt
@@ -321,6 +321,100 @@ class HonkerKotlinTest {
     }
 
     @Test
+    fun codecOverloadsDecodeOnEveryReceiver() {
+        honker(tmp.resolve("codecs.db")) {
+            fallbackPollInterval(Duration.ofMillis(2))
+        }.use { db ->
+            val emails = db.queue("codec-emails")
+            val reports = db.queue("codec-reports")
+            val id = emails.enqueue("alice@example.com", stringCodec)
+
+            val fromQueue = assertNotNull(emails.jobDetails(id, stringCodec))
+            assertEquals("alice@example.com", fromQueue.payload)
+            assertEquals(""""alice@example.com"""", fromQueue.payloadJson)
+            assertEquals("codec-emails", fromQueue.queue)
+            assertNull(
+                reports.jobDetails(id, stringCodec),
+                "the codec overload is scoped to its queue like the raw one",
+            )
+
+            val fromDatabase = assertNotNull(db.jobDetails(id, stringCodec))
+            assertEquals("alice@example.com", fromDatabase.payload)
+            assertEquals(""""alice@example.com"""", fromDatabase.payloadJson)
+
+            val snapshot = emails.getJob(id).orElseThrow()
+            assertEquals("alice@example.com", snapshot.details(stringCodec).payload)
+            assertEquals(""""alice@example.com"""", snapshot.details().payload)
+
+            val claimed = emails.claimOne("codec-worker").orElseThrow()
+            val decoded = claimed.details(stringCodec)
+            assertEquals("alice@example.com", decoded.payload)
+            assertEquals(""""alice@example.com"""", decoded.payloadJson)
+            assertEquals("processing", decoded.state)
+            assertEquals("codec-worker", decoded.workerId)
+            // The raw overload on the same job leaves the payload as JSON.
+            assertEquals(""""alice@example.com"""", claimed.details().payload)
+
+            assertTrue(claimed.ack())
+            assertNull(db.jobDetails(id, stringCodec))
+        }
+    }
+
+    @Test
+    fun retriedJobDetailsDropBackToPendingWithNoWorker() {
+        honker(tmp.resolve("retried.db")) {
+            fallbackPollInterval(Duration.ofMillis(2))
+        }.use { db ->
+            val queue = db.queue("retries", queueOptions {
+                visibilityTimeout(Duration.ofSeconds(60))
+                maxAttempts(3)
+            })
+            val id = queue.enqueueJson("""{"n":1}""")
+
+            val claimed = queue.claimOne("worker-a").orElseThrow()
+            val processing = assertNotNull(queue.jobDetails(id))
+            assertEquals("processing", processing.state)
+            assertEquals("worker-a", processing.workerId)
+            assertNotNull(processing.claimExpiresAt, "a claimed job has a claim deadline")
+
+            val retriedBefore = unixNow(db)
+            assertTrue(claimed.retry(Duration.ofSeconds(45), "boom"))
+            val retriedAfter = unixNow(db)
+
+            // The only path where a non-null worker and claim deadline go
+            // back to null on the same row.
+            val pending = assertNotNull(queue.jobDetails(id))
+            assertEquals("pending", pending.state)
+            assertNull(pending.workerId, "a retried job releases its worker")
+            assertNull(pending.claimExpiresAt, "a retried job releases its claim deadline")
+            assertEquals(1, pending.attempts, "the spent attempt still counts")
+            assertEquals(3, pending.maxAttempts)
+            assertEquals(processing.createdAt, pending.createdAt)
+            assertBetween(pending.runAt, retriedBefore + 45, retriedAfter + 45, "runAt")
+        }
+    }
+
+    @Test
+    fun deadLetteredJobDetailsAreGoneFromBothLookups() {
+        honker(tmp.resolve("dead.db")) {
+            fallbackPollInterval(Duration.ofMillis(2))
+        }.use { db ->
+            val queue = db.queue("dead-letters", queueOptions {
+                visibilityTimeout(Duration.ofSeconds(60))
+                maxAttempts(1)
+            })
+            val id = queue.enqueueJson("""{"n":1}""")
+
+            val claimed = queue.claimOne("worker-b").orElseThrow()
+            assertEquals("processing", assertNotNull(queue.jobDetails(id)).state)
+
+            assertTrue(claimed.fail("nope"))
+            assertNull(queue.jobDetails(id), "a dead-lettered job leaves no live row")
+            assertNull(db.jobDetails(id), "the global lookup does not see dead letters either")
+        }
+    }
+
+    @Test
     // `runBlocking<Unit>` is deliberate: an expression-bodied test whose
     // last expression is not Unit compiles to a non-void method and JUnit
     // silently never runs it.


### PR DESCRIPTION
Part of #136 — the Kotlin half of the binding checklist.

**Stacked twice. Merge order: #124 → #141 → this PR.**
`honker-kotlin` is a thin wrapper over `dev.honker:honker`, so this
branch is based on #141 (the JVM half), which is itself based on
`feat/node-typed-jobs` (#124) because the widened `honker_claim_batch`
RETURNING clause exists only there. The diff below is Kotlin-only; the
JVM commits show up because of the stack.

## What changed

`packages/honker-kotlin` plus one CI step. No core, no SQL ABI, no other
binding.

- New `JobDetails<T>` data class in `dev.honker.kotlin`. It carries every
  field the core returns — `id`, `queue`, `payload`, `payloadJson`,
  `state`, `priority`, `runAt`, `workerId`, `claimExpiresAt`, `attempts`,
  `maxAttempts`, `createdAt`, `expiresAt` — restated with Kotlin
  nullability, so the compiler knows a pending job has no `workerId` or
  `claimExpiresAt` and an unexpiring job has no `expiresAt`. Times are
  unix epoch seconds.
- Data only. Ack, retry, fail and heartbeat stay on the claimed `Job`.
- `Job.details()`, `TypedJob<T>.details()`, `JobSnapshot.details()` and
  `TypedJobSnapshot<T>.details()` build one.
- `Queue.jobDetails(id)`, `TypedQueue<T>.jobDetails(id)` and
  `Database.jobDetails(id)` look one up and return Kotlin `null` rather
  than `Optional.empty()`. The queue lookups stay scoped to their queue;
  the database lookup is global.

It is named `JobDetails`, not `JobSnapshot`, on purpose: `dev.honker.JobSnapshot`
already exists and users routinely star-import both packages, so a
same-named Kotlin class would be an ambiguity error at every use site.

`claimed_at` is deliberately not here; that is #135.

## Typing is compile-time only

The payload type is the JVM generic. Honker does not validate payload
shape in the database and this PR adds no runtime validation. README and
CHANGELOG both say so.

## CI

The Kotlin binding had **no CI job at all** — `make test-kotlin` was the
only way to run it. Added a `Run honker-kotlin tests` step to the
existing `jvm` job, which already builds the extension and installs
`dev.honker:honker`. The stale dependabot comment claiming neither JVM
nor Kotlin is gated is updated to match.

## Tests

Five new tests in `HonkerKotlinTest`, all asserting values rather than
presence:

- `claimedJobDetailsCarryEveryCoreField` — enqueues with an explicit
  `runAt`, `priority(7)`, `maxAttempts(5)` and `expires(600s)`, claims,
  and checks all twelve fields. The clock-derived three are bounded by
  `unixepoch()` readings taken around the write and the claim.
- `jobDetailsFollowPendingProcessingAndAckedStates` — a second `Database`
  on the same file reads the job pending (`workerId` and
  `claimExpiresAt` null, 0 attempts), then processing (worker id,
  attempts 1, claim deadline in the visibility window), then null after
  ack.
- `delayedJobDetailsReportItsRunAt`
- `typedQueueDetailsDecodePayloadAndKeepEveryField`
- `jobDetailsAreScopedToTheirQueueWhileDatabaseLookupIsGlobal`

Local run: `mvn -B test` → 10/10 pass (5 existing + 5 new), extension
built `--release`, `dev.honker:honker` installed from this branch.

### The tests are load-bearing

Swapped `attempts` and `maxAttempts` in `JobSnapshot.toDetails` — the
classic mixup — and reran:

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0
HonkerKotlinTest.claimedJobDetailsCarryEveryCoreField:144
  expected: <1> but was: <5>
HonkerKotlinTest.jobDetailsFollowPendingProcessingAndAckedStates:191
  expected: <0> but was: <4>
```

Restored, reran: 10/10 pass.

## Not touched

`honker-core`, the SQL ABI, `packages/honker-node`, `packages/honker-jvm`
(beyond what the stack carries), every other binding.

https://claude.ai/code/session_01YMCFasvKC52r37DDKSTeMC

---

## Snapshot payload encoding (cross-binding note, no change requested)

Flagging for a later deliberate decision across all bindings, per the
#136 coordination: **the Kotlin binding returns snapshot payloads as raw
JSON text by default.** `JobDetails.payloadJson` is always the string the
row holds. `JobDetails.payload` is decoded only when the caller asked for
it — `jobDetails(id, codec)` or `TypedQueue<T>.jobDetails(id)`. The
untyped `Queue.jobDetails(id)` returns `JobDetails<String>` whose
`payload` is that same raw JSON.

That matches the JVM binding it wraps, and matches Go's `JobRow.Payload`
and Python's `get_job()["payload"]`. Node #124 returns a decoded payload
instead. Three bindings, two conventions. Not resolved here — changing it
would be a breaking API change #136 did not ask for.
