### PR TITLE
feat(bun): typed job payloads and full job details (#136)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,6 +576,7 @@ jobs:
           HONKER_INTEROP_PYTHON: ${{ github.workspace }}/.venv/bin/python
         run: |
           bun install --frozen-lockfile
+          bun run test:types
           bun test
       - name: Ruby
         working-directory: packages/honker-ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,13 @@
   `expiresAt` join the id, queue, payload, worker, and attempts fields
   they already had.
 - **Behavior change:** `Queue.getJob()` returns the camelCase
-  `JobSnapshot` shape with a parsed payload, instead of the SQL ABI's
-  raw snake_case row with a JSON string payload. The old exported
-  `JobRow` interface is replaced by `JobSnapshot<TPayload>`. Same change
-  Node made in the typed-jobs work.
+  `JobSnapshot` shape instead of the SQL ABI's raw snake_case row. The
+  exported `JobRow` interface is replaced by `JobSnapshot`. The
+  snapshot's `payload` stays raw JSON text, exactly as this binding has
+  always returned it; only the field names changed. A claimed
+  `Job.payload` stays decoded, as it always was. Bindings disagree on
+  snapshot payload encoding (Node decodes; Bun, Go, and Python return
+  raw text) and one convention has not been chosen yet.
 - A claimed row without `worker_id` or `claim_expires_at` now throws
   instead of being silently accepted.
 - Payload typing is compile-time only; honker adds no runtime payload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,31 @@
 - Regression test claims a job at a deadline with one claim forced to
   return empty: it fails on the unpatched `api.js` and passes on the fix.
 
+## Unreleased — typed Bun jobs
+
+- Bun `Queue`, `Job`, `JobSnapshot`, `ClaimWaker`, and `Outbox` now take
+  a payload generic defaulting to `JsonValue`, matching the Node
+  binding's shape: `db.queue<EmailPayload>("emails")` types enqueue,
+  claims, and snapshots.
+- Claimed jobs carry every field the core returns. `state`, `priority`,
+  `runAt`, `claimExpiresAt`, `maxAttempts`, `createdAt`, and
+  `expiresAt` join the id, queue, payload, worker, and attempts fields
+  they already had.
+- **Behavior change:** `Queue.getJob()` returns the camelCase
+  `JobSnapshot` shape with a parsed payload, instead of the SQL ABI's
+  raw snake_case row with a JSON string payload. The old exported
+  `JobRow` interface is replaced by `JobSnapshot<TPayload>`. Same change
+  Node made in the typed-jobs work.
+- A claimed row without `worker_id` or `claim_expires_at` now throws
+  instead of being silently accepted.
+- Payload typing is compile-time only; honker adds no runtime payload
+  validation. `bun run test:types` type-checks the binding and a typed
+  usage fixture, and CI runs it.
+- The binding's own sources now type-check under strict `tsc`. The
+  `bun:ffi` watcher handle and one `bun:sqlite` query binding were
+  previously untypeable (`never` symbols), which broke any strict
+  TypeScript consumer of this package.
+
 ## Unreleased — typed Node jobs
 
 - Node `Queue`, `Job`, `JobSnapshot`, `ClaimWaker`, and `Outbox` APIs now carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@
 - A claimed row without `worker_id` or `claim_expires_at` now throws
   instead of being silently accepted, and a test builds both a complete
   and a truncated row to prove the guard fires only on the bad one.
+- `Queue.getJob()` is documented as NOT queue-scoped: job ids are
+  globally unique, so it returns a row from any queue. The Node binding
+  scopes its lookup; #134 tracks making the bindings agree. Behavior is
+  unchanged here, only the README and the JSDoc, which previously said
+  nothing about it.
 - A job enqueued without `expires` now has its `expiresAt` asserted to be
   `null` on both the snapshot and the claimed job. Nothing pinned it
   before, so an `expires_at ?? 0` fallback would have handed callers 0 —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
   raw text) and one convention has not been chosen yet.
 - A claimed row without `worker_id` or `claim_expires_at` now throws
   instead of being silently accepted.
+- A job enqueued without `expires` now has its `expiresAt` asserted to be
+  `null` on both the snapshot and the claimed job. Nothing pinned it
+  before, so an `expires_at ?? 0` fallback would have handed callers 0 —
+  a valid unix timestamp meaning 1970 — with the suite still green.
 - Payload typing is compile-time only; honker adds no runtime payload
   validation. `bun run test:types` type-checks the binding and a typed
   usage fixture, and CI runs it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,14 +39,18 @@
   snapshot payload encoding (Node decodes; Bun, Go, and Python return
   raw text) and one convention has not been chosen yet.
 - A claimed row without `worker_id` or `claim_expires_at` now throws
-  instead of being silently accepted.
+  instead of being silently accepted, and a test builds both a complete
+  and a truncated row to prove the guard fires only on the bad one.
 - A job enqueued without `expires` now has its `expiresAt` asserted to be
   `null` on both the snapshot and the claimed job. Nothing pinned it
   before, so an `expires_at ?? 0` fallback would have handed callers 0 —
   a valid unix timestamp meaning 1970 — with the suite still green.
 - Payload typing is compile-time only; honker adds no runtime payload
   validation. `bun run test:types` type-checks the binding and a typed
-  usage fixture, and CI runs it.
+  usage fixture, and CI runs it. The fixture carries two negative checks
+  (`@ts-expect-error`) so the gate fails if the generics go loose in
+  either direction — a missing required field, or `payload` decaying to
+  `any`, which every positive assertion would otherwise accept.
 - The binding's own sources now type-check under strict `tsc`. The
   `bun:ffi` watcher handle and one `bun:sqlite` query binding were
   previously untypeable (`never` symbols), which broke any strict

--- a/packages/honker-bun/README.md
+++ b/packages/honker-bun/README.md
@@ -57,9 +57,11 @@ interface EmailPayload {
 const emails = db.queue<EmailPayload>("emails");
 const id = emails.enqueue({ to: "alice@example.com", template: "welcome" });
 
-// Read-only snapshot: data, no claim methods.
+// Read-only snapshot: data, no claim methods. Its payload is raw JSON
+// text — parse it yourself.
 const pending = emails.getJob(id);
 console.log(pending?.state, pending?.priority, pending?.runAt);
+const payload = pending ? (JSON.parse(pending.payload) as EmailPayload) : null;
 
 const job = emails.claimOne("worker-1");
 if (job) {
@@ -77,6 +79,13 @@ Claimed jobs and snapshots carry every field the core returns: `id`,
 `claimExpiresAt`, `attempts`, `maxAttempts`, `createdAt`, `expiresAt`.
 A claimed `Job` also has `ack`, `retry`, `fail`, and `heartbeat`; a
 `JobSnapshot` is data only, because reading a row does not claim it.
+
+Payload encoding differs between the two, and that is deliberate: a
+claimed `job.payload` is decoded (it always was), while a snapshot's
+`payload` stays raw JSON text (it always was). Bindings currently
+disagree here — Node decodes snapshot payloads, Bun, Go, and Python do
+not — and settling on one convention is a separate decision, not part of
+the job-detail work.
 
 Recurring schedules use `schedule`:
 

--- a/packages/honker-bun/README.md
+++ b/packages/honker-bun/README.md
@@ -45,6 +45,39 @@ Delayed jobs use `runAt`:
 q.enqueue({ to: "later@example.com" }, { runAt: Math.floor(Date.now() / 1000) + 10 });
 ```
 
+Give a queue a payload contract and claimed jobs plus `getJob()`
+snapshots keep it:
+
+```ts
+interface EmailPayload {
+  to: string;
+  template: "welcome" | "receipt";
+}
+
+const emails = db.queue<EmailPayload>("emails");
+const id = emails.enqueue({ to: "alice@example.com", template: "welcome" });
+
+// Read-only snapshot: data, no claim methods.
+const pending = emails.getJob(id);
+console.log(pending?.state, pending?.priority, pending?.runAt);
+
+const job = emails.claimOne("worker-1");
+if (job) {
+  console.log(job.payload.template, `${job.attempts}/${job.maxAttempts}`);
+  job.ack();
+}
+```
+
+Payload generics describe the expected JSON shape at compile time.
+Honker never validates payload shape — not in this binding, not in the
+database — so every process writing to a queue has to agree on the type.
+
+Claimed jobs and snapshots carry every field the core returns: `id`,
+`queue`, `payload`, `state`, `priority`, `runAt`, `workerId`,
+`claimExpiresAt`, `attempts`, `maxAttempts`, `createdAt`, `expiresAt`.
+A claimed `Job` also has `ack`, `retry`, `fail`, and `heartbeat`; a
+`JobSnapshot` is data only, because reading a row does not claim it.
+
 Recurring schedules use `schedule`:
 
 ```ts

--- a/packages/honker-bun/README.md
+++ b/packages/honker-bun/README.md
@@ -45,8 +45,9 @@ Delayed jobs use `runAt`:
 q.enqueue({ to: "later@example.com" }, { runAt: Math.floor(Date.now() / 1000) + 10 });
 ```
 
-Give a queue a payload contract and claimed jobs plus `getJob()`
-snapshots keep it:
+Give a queue a payload contract and claimed jobs keep it. A `getJob()`
+snapshot carries every field but hands the payload back as raw JSON
+text, so you parse it yourself:
 
 ```ts
 interface EmailPayload {
@@ -79,6 +80,11 @@ Claimed jobs and snapshots carry every field the core returns: `id`,
 `claimExpiresAt`, `attempts`, `maxAttempts`, `createdAt`, `expiresAt`.
 A claimed `Job` also has `ack`, `retry`, `fail`, and `heartbeat`; a
 `JobSnapshot` is data only, because reading a row does not claim it.
+
+`getJob()` looks a job up by id across every queue, not just the one you
+called it on — job ids are globally unique. Check `snapshot.queue` if
+that matters to you. (The Node binding scopes its `getJob`; #134 tracks
+making the rest of the bindings agree.)
 
 Payload encoding differs between the two, and that is deliberate: a
 claimed `job.payload` is decoded (it always was), while a snapshot's

--- a/packages/honker-bun/bun.lock
+++ b/packages/honker-bun/bun.lock
@@ -4,6 +4,10 @@
   "workspaces": {
     "": {
       "name": "@russellthehippo/honker-bun",
+      "devDependencies": {
+        "@types/bun": "^1.4.0",
+        "typescript": "^5.9.3",
+      },
       "optionalDependencies": {
         "@russellthehippo/honker-ext-darwin-arm64": "0.4.6",
         "@russellthehippo/honker-ext-darwin-x64": "0.4.6",
@@ -24,6 +28,14 @@
 
     "@russellthehippo/honker-ext-linux-x64-gnu": ["@russellthehippo/honker-ext-linux-x64-gnu@0.4.6", "", { "os": "linux", "cpu": "x64" }, "sha512-cqD9kAn01tTNdIM+DxJ1ZlNuCan7PM2hO1ZXxSmPkR5SZ93APz+4SKLvmnBkWtVKz4Z95W0yzUY6Lmag6uCG+g=="],
 
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
+    "@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
   }
 }

--- a/packages/honker-bun/package.json
+++ b/packages/honker-bun/package.json
@@ -16,7 +16,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "bun test",
+    "test": "bun run test:types && bun test",
+    "test:types": "tsc -p test/types/tsconfig.json",
     "example": "bun run examples/basic.ts"
   },
   "peerDependencies": {
@@ -30,5 +31,9 @@
     "@russellthehippo/honker-ext-darwin-x64": "0.4.6",
     "@russellthehippo/honker-ext-linux-x64-gnu": "0.4.6",
     "@russellthehippo/honker-ext-linux-arm64-gnu": "0.4.6"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.4.0",
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/honker-bun/src/index.ts
+++ b/packages/honker-bun/src/index.ts
@@ -166,15 +166,18 @@ export type JobState = "pending" | "processing";
 /**
  * A read-only job snapshot. Data only: no ack/retry/fail/heartbeat,
  * because reading a row does not claim it.
- *
- * `TPayload` is a compile-time contract only. Honker stores payloads as
- * opaque JSON and never validates their shape, so every process writing
- * to the queue has to agree on the type.
  */
-export interface JobSnapshot<TPayload = JsonValue> {
+export interface JobSnapshot {
   readonly id: number;
   readonly queue: string;
-  readonly payload: TPayload;
+  /**
+   * Raw JSON text, exactly as stored — `JSON.parse` it yourself. This
+   * binding has always handed back the raw payload here and that is
+   * left alone; bindings currently disagree (Node decodes, Bun / Go /
+   * Python do not) and picking one convention is a separate decision.
+   * A claimed `Job.payload`, by contrast, is decoded, as it always was.
+   */
+  readonly payload: string;
   readonly state: JobState;
   readonly priority: number;
   readonly runAt: number;
@@ -220,11 +223,11 @@ interface RawJobRow {
 }
 
 /** Map the core's snake_case row onto the camelCase public snapshot. */
-function toSnapshot<TPayload>(row: RawJobRow): JobSnapshot<TPayload> {
+function toSnapshot(row: RawJobRow): JobSnapshot {
   return {
     id: row.id,
     queue: row.queue,
-    payload: JSON.parse(row.payload) as TPayload,
+    payload: row.payload,
     state: row.state,
     priority: row.priority,
     runAt: row.run_at,
@@ -710,14 +713,15 @@ export class Queue<TPayload = JsonValue> {
   /**
    * Read a single job row by id. Returns the snapshot or null on miss
    * (ack'd, dead'd, or never existed). Pure read: a snapshot carries no
-   * claim methods.
+   * claim methods, and its `payload` is raw JSON text, not a decoded
+   * `TPayload`.
    */
-  getJob(jobId: number): JobSnapshot<TPayload> | null {
+  getJob(jobId: number): JobSnapshot | null {
     const row = this.db.raw
       .query<{ v: string }, [number]>("SELECT honker_get_job(?) AS v")
       .get(jobId)!;
     if (!row.v) return null;
-    return toSnapshot<TPayload>(JSON.parse(row.v) as RawJobRow);
+    return toSnapshot(JSON.parse(row.v) as RawJobRow);
   }
 
   /** Sweep expired claim rows back to pending. Returns rows touched. */

--- a/packages/honker-bun/src/index.ts
+++ b/packages/honker-bun/src/index.ts
@@ -11,8 +11,8 @@
  * a small in-process poll loop.
  */
 
-import { Database as BunDB } from "bun:sqlite";
-import { dlopen, FFIType } from "bun:ffi";
+import { Database as BunDB, type SQLQueryBindings } from "bun:sqlite";
+import { dlopen, FFIType, type Pointer } from "bun:ffi";
 
 // Loading Honker onto a bun:sqlite handle you already own — see
 // ./extension.ts. Re-exported so ORM users import from one place.
@@ -203,9 +203,29 @@ interface RawStreamEvent {
   created_at: number;
 }
 
+// Declared as a function so `ReturnType` keeps the symbol map: an
+// unparameterized `ReturnType<typeof dlopen>` types every symbol as
+// `never`, which makes the calls below uncheckable.
+function openWatcherLib(extensionPath: string) {
+  return dlopen(extensionPath, {
+    honker_watcher_open_v2: {
+      args: [FFIType.ptr, FFIType.ptr, FFIType.u64, FFIType.ptr, FFIType.u64],
+      returns: FFIType.ptr,
+    },
+    honker_watcher_wait: {
+      args: [FFIType.ptr, FFIType.u64],
+      returns: FFIType.i32,
+    },
+    honker_watcher_close: {
+      args: [FFIType.ptr],
+      returns: FFIType.void,
+    },
+  });
+}
+
 class CoreWatcher {
-  private readonly lib: ReturnType<typeof dlopen>;
-  private readonly handle: unknown;
+  private readonly lib: ReturnType<typeof openWatcherLib>;
+  private readonly handle: Pointer | bigint | null;
   private closed = false;
 
   constructor(
@@ -214,20 +234,7 @@ class CoreWatcher {
     watcherBackend?: string | null,
     watcherPollIntervalMs?: number | null,
   ) {
-    this.lib = dlopen(extensionPath, {
-      honker_watcher_open_v2: {
-        args: [FFIType.ptr, FFIType.ptr, FFIType.u64, FFIType.ptr, FFIType.u64],
-        returns: FFIType.ptr,
-      },
-      honker_watcher_wait: {
-        args: [FFIType.ptr, FFIType.u64],
-        returns: FFIType.i32,
-      },
-      honker_watcher_close: {
-        args: [FFIType.ptr],
-        returns: FFIType.void,
-      },
-    });
+    this.lib = openWatcherLib(extensionPath);
     const error = Buffer.alloc(1024);
     const dbPathBytes = cString(dbPath);
     const backendBytes = cString(watcherBackend ?? "");
@@ -508,8 +515,8 @@ export class Transaction {
     sql: string,
     params: unknown[] = [],
   ): T | null {
-    const stmt = this.raw.query<T, unknown[]>(sql);
-    return (stmt.get(...params) as T | null) ?? null;
+    const stmt = this.raw.query<T, SQLQueryBindings[]>(sql);
+    return (stmt.get(...(params as SQLQueryBindings[])) as T | null) ?? null;
   }
 
   /** Commit. Idempotent — subsequent calls are no-ops. */

--- a/packages/honker-bun/src/index.ts
+++ b/packages/honker-bun/src/index.ts
@@ -157,19 +157,35 @@ export interface ScheduleUpdate {
   maxAttempts?: number | null;
 }
 
-export interface JobRow {
-  id: number;
-  queue: string;
-  payload: string;
-  state: string;
-  priority: number;
-  run_at: number;
-  worker_id: string | null;
-  claim_expires_at: number | null;
-  attempts: number;
-  max_attempts: number;
-  created_at: number;
-  expires_at: number | null;
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+/** A live job is either waiting to run or held by a worker. */
+export type JobState = "pending" | "processing";
+
+/**
+ * A read-only job snapshot. Data only: no ack/retry/fail/heartbeat,
+ * because reading a row does not claim it.
+ *
+ * `TPayload` is a compile-time contract only. Honker stores payloads as
+ * opaque JSON and never validates their shape, so every process writing
+ * to the queue has to agree on the type.
+ */
+export interface JobSnapshot<TPayload = JsonValue> {
+  readonly id: number;
+  readonly queue: string;
+  readonly payload: TPayload;
+  readonly state: JobState;
+  readonly priority: number;
+  readonly runAt: number;
+  /** Null while the job is pending. */
+  readonly workerId: string | null;
+  /** Null while the job is pending. */
+  readonly claimExpiresAt: number | null;
+  readonly attempts: number;
+  readonly maxAttempts: number;
+  readonly createdAt: number;
+  readonly expiresAt: number | null;
 }
 
 export interface StreamEvent {
@@ -186,13 +202,39 @@ export interface Notification {
   payload: unknown;
 }
 
-interface RawJob {
+/** The wire shape honker_claim_batch and honker_get_job both return.
+ *  snake_case, payload still a JSON string. */
+interface RawJobRow {
   id: number;
   queue: string;
   payload: string;
-  worker_id: string;
+  state: JobState;
+  priority: number;
+  run_at: number;
+  worker_id: string | null;
+  claim_expires_at: number | null;
   attempts: number;
-  claim_expires_at: number;
+  max_attempts: number;
+  created_at: number;
+  expires_at: number | null;
+}
+
+/** Map the core's snake_case row onto the camelCase public snapshot. */
+function toSnapshot<TPayload>(row: RawJobRow): JobSnapshot<TPayload> {
+  return {
+    id: row.id,
+    queue: row.queue,
+    payload: JSON.parse(row.payload) as TPayload,
+    state: row.state,
+    priority: row.priority,
+    runAt: row.run_at,
+    workerId: row.worker_id ?? null,
+    claimExpiresAt: row.claim_expires_at ?? null,
+    attempts: row.attempts,
+    maxAttempts: row.max_attempts,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at ?? null,
+  };
 }
 
 interface RawStreamEvent {
@@ -305,21 +347,25 @@ export class Database {
     );
   }
 
-  /** Get a handle to a named queue. */
-  queue(name: string, opts: QueueOptions = {}): Queue {
-    return new Queue(this, name, {
+  /**
+   * Get a handle to a named queue. Pass a payload type to get typed
+   * claims and snapshots: `db.queue<EmailPayload>("emails")`. The type
+   * is a compile-time contract only; honker never checks payload shape.
+   */
+  queue<TPayload = JsonValue>(name: string, opts: QueueOptions = {}): Queue<TPayload> {
+    return new Queue<TPayload>(this, name, {
       visibilityTimeoutS: opts.visibilityTimeoutS ?? 300,
       maxAttempts: opts.maxAttempts ?? 3,
     });
   }
 
   /** Transactional side-effect delivery built on a reserved queue. */
-  outbox(
+  outbox<TPayload = JsonValue>(
     name: string,
-    delivery: (payload: unknown, job: Job) => unknown | Promise<unknown>,
+    delivery: (payload: TPayload, job: Job<TPayload>) => unknown | Promise<unknown>,
     opts: OutboxOptions = {},
-  ): Outbox {
-    return new Outbox(this, name, delivery, opts);
+  ): Outbox<TPayload> {
+    return new Outbox<TPayload>(this, name, delivery, opts);
   }
 
   /** Get a handle to a named stream. */
@@ -574,7 +620,13 @@ export class UpdateEvents {
   }
 }
 
-export class Queue {
+/**
+ * A named queue. `TPayload` is a compile-time contract for the JSON
+ * payload; honker never validates payload shape at runtime, in this
+ * binding or in the database, so every process writing to the queue has
+ * to agree on it.
+ */
+export class Queue<TPayload = JsonValue> {
   constructor(
     private readonly db: Database,
     public readonly name: string,
@@ -584,7 +636,7 @@ export class Queue {
   ) {}
 
   /** Enqueue a job. Payload is JSON-stringified. Returns the row id. */
-  enqueue(payload: unknown, opts: EnqueueOptions = {}): number {
+  enqueue(payload: TPayload, opts: EnqueueOptions = {}): number {
     const json = JSON.stringify(payload);
     const conn = opts.tx ? opts.tx.raw : this.db.raw;
     const row = conn
@@ -614,18 +666,18 @@ export class Queue {
   }
 
   /** Atomically claim up to n jobs. */
-  claimBatch(workerId: string, n: number): Job[] {
+  claimBatch(workerId: string, n: number): Job<TPayload>[] {
     const row = this.db.raw
       .query<{ v: string }, [string, string, number, number]>(
         "SELECT honker_claim_batch(?, ?, ?, ?) AS v",
       )
       .get(this.name, workerId, n, this.opts.visibilityTimeoutS)!;
-    const raw: RawJob[] = JSON.parse(row.v);
-    return raw.map((r) => new Job(this.db, r));
+    const raw: RawJobRow[] = JSON.parse(row.v);
+    return raw.map((r) => new Job<TPayload>(this.db, r));
   }
 
   /** Claim a single job or return null. */
-  claimOne(workerId: string): Job | null {
+  claimOne(workerId: string): Job<TPayload> | null {
     return this.claimBatch(workerId, 1)[0] ?? null;
   }
 
@@ -655,13 +707,17 @@ export class Queue {
     return row.v > 0;
   }
 
-  /** Read a single job row by id. Returns the row or null on miss. */
-  getJob(jobId: number): JobRow | null {
+  /**
+   * Read a single job row by id. Returns the snapshot or null on miss
+   * (ack'd, dead'd, or never existed). Pure read: a snapshot carries no
+   * claim methods.
+   */
+  getJob(jobId: number): JobSnapshot<TPayload> | null {
     const row = this.db.raw
       .query<{ v: string }, [number]>("SELECT honker_get_job(?) AS v")
       .get(jobId)!;
     if (!row.v) return null;
-    return JSON.parse(row.v) as JobRow;
+    return toSnapshot<TPayload>(JSON.parse(row.v) as RawJobRow);
   }
 
   /** Sweep expired claim rows back to pending. Returns rows touched. */
@@ -690,26 +746,26 @@ export class Queue {
    * Returns a ClaimWaker that waits on DB updates or the next claim
    * deadline, with a fallback poll.
    */
-  claimWaker(opts: { idlePollS?: number | null; pollMs?: number | null } = {}): ClaimWaker {
+  claimWaker(opts: { idlePollS?: number | null; pollMs?: number | null } = {}): ClaimWaker<TPayload> {
     const idlePollMs =
       opts.idlePollS === null
         ? null
         : opts.idlePollS != null
           ? Math.max(0, opts.idlePollS * 1000)
           : opts.pollMs ?? 5000;
-    return new ClaimWaker(this, idlePollMs);
+    return new ClaimWaker<TPayload>(this, idlePollMs);
   }
 }
 
-export class Outbox {
-  readonly queue: Queue;
+export class Outbox<TPayload = JsonValue> {
+  readonly queue: Queue<TPayload>;
   readonly maxAttempts: number;
   readonly baseBackoffS: number;
 
   constructor(
     private readonly db: Database,
     public readonly name: string,
-    private readonly delivery: (payload: unknown, job: Job) => unknown | Promise<unknown>,
+    private readonly delivery: (payload: TPayload, job: Job<TPayload>) => unknown | Promise<unknown>,
     opts: OutboxOptions = {},
   ) {
     if (typeof delivery !== "function") {
@@ -717,17 +773,17 @@ export class Outbox {
     }
     this.maxAttempts = opts.maxAttempts ?? 5;
     this.baseBackoffS = opts.baseBackoffS ?? 5;
-    this.queue = db.queue(`_outbox:${name}`, {
+    this.queue = db.queue<TPayload>(`_outbox:${name}`, {
       visibilityTimeoutS: opts.visibilityTimeoutS ?? 60,
       maxAttempts: this.maxAttempts,
     });
   }
 
-  enqueue(payload: unknown, opts: EnqueueOptions = {}): number {
+  enqueue(payload: TPayload, opts: EnqueueOptions = {}): number {
     return this.queue.enqueue(payload, opts);
   }
 
-  enqueueTx(tx: Transaction, payload: unknown, opts: EnqueueOptions = {}): number {
+  enqueueTx(tx: Transaction, payload: TPayload, opts: EnqueueOptions = {}): number {
     return this.queue.enqueue(payload, { ...opts, tx });
   }
 
@@ -762,23 +818,49 @@ export class Outbox {
   }
 }
 
-/** A claimed unit of work. */
-export class Job {
+/**
+ * A claimed unit of work. Carries every field the core returns, plus
+ * the claim methods ack, retry, fail, and heartbeat.
+ *
+ * `TPayload` is a compile-time contract only; honker never validates
+ * payload shape.
+ */
+export class Job<TPayload = JsonValue> {
   readonly id: number;
   readonly queue: string;
-  readonly payload: unknown;
+  readonly payload: TPayload;
+  /** Always "processing" for a claimed job. */
+  readonly state: "processing";
+  readonly priority: number;
+  readonly runAt: number;
   readonly workerId: string;
+  readonly claimExpiresAt: number;
   readonly attempts: number;
+  readonly maxAttempts: number;
+  readonly createdAt: number;
+  readonly expiresAt: number | null;
 
   constructor(
     private readonly db: Database,
-    row: RawJob,
+    row: RawJobRow,
   ) {
+    // A claimed row always carries the claim columns. A row without
+    // them is a core bug worth throwing on, not one to paper over.
+    if (row.worker_id == null || row.claim_expires_at == null) {
+      throw new Error(`claimed job ${row.id} has no worker_id/claim_expires_at`);
+    }
     this.id = row.id;
     this.queue = row.queue;
-    this.payload = JSON.parse(row.payload);
+    this.payload = JSON.parse(row.payload) as TPayload;
+    this.state = "processing";
+    this.priority = row.priority;
+    this.runAt = row.run_at;
     this.workerId = row.worker_id;
+    this.claimExpiresAt = row.claim_expires_at;
     this.attempts = row.attempts;
+    this.maxAttempts = row.max_attempts;
+    this.createdAt = row.created_at;
+    this.expiresAt = row.expires_at ?? null;
   }
 
   /** DELETE the row if the claim is still valid. */
@@ -836,19 +918,19 @@ export class Job {
  * Claim waker. Call `next(workerId)` to block on an incoming job;
  * poll-based (Pass 1).
  */
-export class ClaimWaker {
+export class ClaimWaker<TPayload = JsonValue> {
   private stopped = false;
   private readonly updates: UpdateEvents;
 
   constructor(
-    private readonly queue: Queue,
+    private readonly queue: Queue<TPayload>,
     private readonly idlePollMs: number | null,
   ) {
     this.updates = queue.dbHandle().updateEvents();
   }
 
   /** Claim one job without blocking. Null if the queue is empty. */
-  tryNext(workerId: string): Job | null {
+  tryNext(workerId: string): Job<TPayload> | null {
     return this.queue.claimOne(workerId);
   }
 
@@ -859,7 +941,7 @@ export class ClaimWaker {
   async next(
     workerId: string,
     opts: { signal?: AbortSignal } = {},
-  ): Promise<Job | null> {
+  ): Promise<Job<TPayload> | null> {
     while (!this.stopped && !opts.signal?.aborted) {
       const job = this.queue.claimOne(workerId);
       if (job) return job;

--- a/packages/honker-bun/src/index.ts
+++ b/packages/honker-bun/src/index.ts
@@ -715,6 +715,11 @@ export class Queue<TPayload = JsonValue> {
    * (ack'd, dead'd, or never existed). Pure read: a snapshot carries no
    * claim methods, and its `payload` is raw JSON text, not a decoded
    * `TPayload`.
+   *
+   * NOT queue-scoped: job ids are globally unique, and this returns a
+   * row belonging to any queue, not just this one. `snapshot.queue`
+   * tells you which queue actually owns it. The Node binding scopes its
+   * `getJob` to the queue; Bun does not yet. Tracked in #134.
    */
   getJob(jobId: number): JobSnapshot | null {
     const row = this.db.raw

--- a/packages/honker-bun/test/typed_jobs.test.ts
+++ b/packages/honker-bun/test/typed_jobs.test.ts
@@ -190,6 +190,9 @@ maybe("honker-bun job details", () => {
       expect(snapshot!.state).toBe("pending");
       expect(snapshot!.runAt).toBeGreaterThanOrEqual(before + 60);
       expect(snapshot!.runAt).toBeLessThanOrEqual(after + 60);
+      // Enqueued without `expires`: null, not 0. A `?? 0` fallback would
+      // hand the caller a valid unix timestamp meaning 1970.
+      expect(snapshot!.expiresAt).toBeNull();
       expect(queue.claimOne("early-worker")).toBeNull();
     }),
   );
@@ -203,6 +206,8 @@ maybe("honker-bun job details", () => {
       const first = queue.claimOne("worker-1");
       expect(first!.attempts).toBe(1);
       expect(first!.maxAttempts).toBe(3);
+      // Same gap on the claimed-Job side: no `expires` means null.
+      expect(first!.expiresAt).toBeNull();
 
       const retriedAt = now(db);
       expect(first!.retry(30, "boom")).toBe(true);
@@ -213,6 +218,7 @@ maybe("honker-bun job details", () => {
       expect(snapshot!.workerId).toBeNull();
       expect(snapshot!.runAt).toBeGreaterThanOrEqual(retriedAt + 30);
       expect(snapshot!.runAt).toBeLessThanOrEqual(now(db) + 30);
+      expect(snapshot!.expiresAt).toBeNull();
     }),
   );
 

--- a/packages/honker-bun/test/typed_jobs.test.ts
+++ b/packages/honker-bun/test/typed_jobs.test.ts
@@ -3,7 +3,10 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-import { open, type Database } from "../src/index.ts";
+import { Job, open, type Database } from "../src/index.ts";
+
+/** The core's wire row, reached without exporting the internal type. */
+type RawRow = ConstructorParameters<typeof Job>[1];
 
 const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..");
 const EXT_CANDIDATES = [
@@ -219,6 +222,36 @@ maybe("honker-bun job details", () => {
       expect(snapshot!.runAt).toBeGreaterThanOrEqual(retriedAt + 30);
       expect(snapshot!.runAt).toBeLessThanOrEqual(now(db) + 30);
       expect(snapshot!.expiresAt).toBeNull();
+    }),
+  );
+
+  test(
+    "a claimed row missing its claim columns throws instead of being accepted",
+    withDb((db) => {
+      const complete: RawRow = {
+        id: 42,
+        queue: "emails",
+        payload: '{"recipient":"gwen@example.com","template":"welcome"}',
+        state: "processing",
+        priority: 0,
+        run_at: 1,
+        worker_id: "worker-1",
+        claim_expires_at: 2,
+        attempts: 1,
+        max_attempts: 3,
+        created_at: 1,
+        expires_at: null,
+      };
+
+      // The guard is not simply rejecting everything: a complete row builds.
+      expect(new Job<EmailPayload>(db, complete).workerId).toBe("worker-1");
+
+      expect(() => new Job<EmailPayload>(db, { ...complete, worker_id: null })).toThrow(
+        "claimed job 42 has no worker_id/claim_expires_at",
+      );
+      expect(
+        () => new Job<EmailPayload>(db, { ...complete, claim_expires_at: null }),
+      ).toThrow("claimed job 42 has no worker_id/claim_expires_at");
     }),
   );
 

--- a/packages/honker-bun/test/typed_jobs.test.ts
+++ b/packages/honker-bun/test/typed_jobs.test.ts
@@ -1,0 +1,241 @@
+import { test, expect, describe } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { open, type Database } from "../src/index.ts";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..");
+const EXT_CANDIDATES = [
+  "target/debug/libhonker_ext.dylib",
+  "target/debug/libhonker_ext.so",
+  "target/debug/libhonker_extension.dylib",
+  "target/debug/libhonker_extension.so",
+  "target/release/libhonker_ext.dylib",
+  "target/release/libhonker_ext.so",
+  "target/release/libhonker_extension.dylib",
+  "target/release/libhonker_extension.so",
+];
+
+function findExtension(): string | null {
+  const fromEnv = process.env.HONKER_EXT_PATH;
+  if (fromEnv && existsSync(fromEnv)) return fromEnv;
+  for (const rel of EXT_CANDIDATES) {
+    const p = join(REPO_ROOT, rel);
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+const extPath = findExtension();
+if (!extPath && process.env.CI) {
+  throw new Error("HONKER_EXT_PATH not found in CI; Bun tests must run for real");
+}
+const maybe = extPath ? describe : describe.skip;
+
+interface EmailPayload {
+  recipient: string;
+  template: "welcome" | "receipt";
+}
+
+/** Read the clock the core stamps rows with, not the JS clock. */
+function now(db: Database): number {
+  return db.raw.query<{ v: number }, []>("SELECT unixepoch() AS v").get()!.v;
+}
+
+function withDb(fn: (db: Database) => Promise<void> | void): () => Promise<void> {
+  return async () => {
+    const dir = mkdtempSync(join(tmpdir(), "honker-bun-typed-jobs-"));
+    const dbPath = join(dir, "t.db");
+    const db = open(dbPath, extPath!);
+    try {
+      await fn(db);
+    } finally {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+}
+
+maybe("honker-bun job details", () => {
+  test(
+    "a claimed job carries every field the core returns",
+    withDb((db) => {
+      const queue = db.queue<EmailPayload>("emails", {
+        visibilityTimeoutS: 120,
+        maxAttempts: 5,
+      });
+      const runAt = now(db) - 5;
+
+      const enqueuedBefore = now(db);
+      const id = queue.enqueue(
+        { recipient: "alice@example.com", template: "welcome" },
+        { runAt, priority: 7, expires: 600 },
+      );
+      const enqueuedAfter = now(db);
+
+      const claimedBefore = now(db);
+      const job = queue.claimOne("worker-1");
+      const claimedAfter = now(db);
+
+      expect(job).not.toBeNull();
+      expect(job!.id).toBe(id);
+      expect(job!.queue).toBe("emails");
+      expect(job!.payload).toEqual({
+        recipient: "alice@example.com",
+        template: "welcome",
+      });
+      expect(job!.state).toBe("processing");
+      expect(job!.priority).toBe(7);
+      expect(job!.runAt).toBe(runAt);
+      expect(job!.workerId).toBe("worker-1");
+      expect(job!.claimExpiresAt).toBeGreaterThanOrEqual(claimedBefore + 120);
+      expect(job!.claimExpiresAt).toBeLessThanOrEqual(claimedAfter + 120);
+      expect(job!.attempts).toBe(1);
+      expect(job!.maxAttempts).toBe(5);
+      expect(job!.createdAt).toBeGreaterThanOrEqual(enqueuedBefore);
+      expect(job!.createdAt).toBeLessThanOrEqual(enqueuedAfter);
+      expect(job!.expiresAt).toBeGreaterThanOrEqual(enqueuedBefore + 600);
+      expect(job!.expiresAt).toBeLessThanOrEqual(enqueuedAfter + 600);
+    }),
+  );
+
+  test(
+    "a pending snapshot carries every field the core returns",
+    withDb((db) => {
+      const queue = db.queue<EmailPayload>("emails", { maxAttempts: 2 });
+      const runAt = now(db) + 3600;
+
+      const enqueuedBefore = now(db);
+      const id = queue.enqueue(
+        { recipient: "bob@example.com", template: "receipt" },
+        { runAt, priority: 4, expires: 900 },
+      );
+      const enqueuedAfter = now(db);
+
+      const snapshot = queue.getJob(id);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.id).toBe(id);
+      expect(snapshot!.queue).toBe("emails");
+      expect(snapshot!.payload).toEqual({
+        recipient: "bob@example.com",
+        template: "receipt",
+      });
+      expect(snapshot!.state).toBe("pending");
+      expect(snapshot!.priority).toBe(4);
+      expect(snapshot!.runAt).toBe(runAt);
+      expect(snapshot!.workerId).toBeNull();
+      expect(snapshot!.claimExpiresAt).toBeNull();
+      expect(snapshot!.attempts).toBe(0);
+      expect(snapshot!.maxAttempts).toBe(2);
+      expect(snapshot!.createdAt).toBeGreaterThanOrEqual(enqueuedBefore);
+      expect(snapshot!.createdAt).toBeLessThanOrEqual(enqueuedAfter);
+      expect(snapshot!.expiresAt).toBeGreaterThanOrEqual(enqueuedBefore + 900);
+      expect(snapshot!.expiresAt).toBeLessThanOrEqual(enqueuedAfter + 900);
+    }),
+  );
+
+  test("a reader sees the processing snapshot, then nothing after ack", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "honker-bun-typed-jobs-"));
+    const dbPath = join(dir, "t.db");
+    const worker = open(dbPath, extPath!);
+    const reader = open(dbPath, extPath!);
+    try {
+      const workerQueue = worker.queue<EmailPayload>("emails", { visibilityTimeoutS: 45 });
+      const readerQueue = reader.queue<EmailPayload>("emails", { visibilityTimeoutS: 45 });
+
+      const id = workerQueue.enqueue({ recipient: "carol@example.com", template: "welcome" });
+      const claimedBefore = now(worker);
+      const job = workerQueue.claimOne("worker-7");
+      const claimedAfter = now(worker);
+      expect(job).not.toBeNull();
+
+      const processing = readerQueue.getJob(id);
+      expect(processing).not.toBeNull();
+      expect(processing!.state).toBe("processing");
+      expect(processing!.workerId).toBe("worker-7");
+      expect(processing!.attempts).toBe(1);
+      expect(processing!.claimExpiresAt).toBeGreaterThanOrEqual(claimedBefore + 45);
+      expect(processing!.claimExpiresAt).toBeLessThanOrEqual(claimedAfter + 45);
+      expect(processing!.payload).toEqual({
+        recipient: "carol@example.com",
+        template: "welcome",
+      });
+
+      expect(job!.ack()).toBe(true);
+      expect(readerQueue.getJob(id)).toBeNull();
+    } finally {
+      reader.close();
+      worker.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test(
+    "a delayed job reports its runAt and is not claimable yet",
+    withDb((db) => {
+      const queue = db.queue<EmailPayload>("emails");
+
+      const before = now(db);
+      const id = queue.enqueue(
+        { recipient: "dan@example.com", template: "receipt" },
+        { delay: 60 },
+      );
+      const after = now(db);
+
+      const snapshot = queue.getJob(id);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.state).toBe("pending");
+      expect(snapshot!.runAt).toBeGreaterThanOrEqual(before + 60);
+      expect(snapshot!.runAt).toBeLessThanOrEqual(after + 60);
+      expect(queue.claimOne("early-worker")).toBeNull();
+    }),
+  );
+
+  test(
+    "a retried job reports the new attempt count and run_at",
+    withDb((db) => {
+      const queue = db.queue<EmailPayload>("emails", { maxAttempts: 3 });
+      const id = queue.enqueue({ recipient: "erin@example.com", template: "welcome" });
+
+      const first = queue.claimOne("worker-1");
+      expect(first!.attempts).toBe(1);
+      expect(first!.maxAttempts).toBe(3);
+
+      const retriedAt = now(db);
+      expect(first!.retry(30, "boom")).toBe(true);
+
+      const snapshot = queue.getJob(id);
+      expect(snapshot!.state).toBe("pending");
+      expect(snapshot!.attempts).toBe(1);
+      expect(snapshot!.workerId).toBeNull();
+      expect(snapshot!.runAt).toBeGreaterThanOrEqual(retriedAt + 30);
+      expect(snapshot!.runAt).toBeLessThanOrEqual(now(db) + 30);
+    }),
+  );
+
+  test(
+    "the claim waker returns a job carrying the same detail",
+    withDb(async (db) => {
+      const queue = db.queue<EmailPayload>("emails", { visibilityTimeoutS: 60 });
+      const id = queue.enqueue(
+        { recipient: "frank@example.com", template: "receipt" },
+        { priority: 3 },
+      );
+
+      const waker = queue.claimWaker({ idlePollS: 1 });
+      try {
+        const job = await waker.next("waker-worker");
+        expect(job).not.toBeNull();
+        expect(job!.id).toBe(id);
+        expect(job!.state).toBe("processing");
+        expect(job!.priority).toBe(3);
+        expect(job!.workerId).toBe("waker-worker");
+        expect(job!.payload.recipient).toBe("frank@example.com");
+        expect(job!.ack()).toBe(true);
+      } finally {
+        waker.close();
+      }
+    }),
+  );
+});

--- a/packages/honker-bun/test/typed_jobs.test.ts
+++ b/packages/honker-bun/test/typed_jobs.test.ts
@@ -117,7 +117,9 @@ maybe("honker-bun job details", () => {
       expect(snapshot).not.toBeNull();
       expect(snapshot!.id).toBe(id);
       expect(snapshot!.queue).toBe("emails");
-      expect(snapshot!.payload).toEqual({
+      // Raw JSON text: this binding does not decode snapshot payloads.
+      expect(snapshot!.payload).toBe('{"recipient":"bob@example.com","template":"receipt"}');
+      expect(JSON.parse(snapshot!.payload)).toEqual({
         recipient: "bob@example.com",
         template: "receipt",
       });
@@ -157,7 +159,7 @@ maybe("honker-bun job details", () => {
       expect(processing!.attempts).toBe(1);
       expect(processing!.claimExpiresAt).toBeGreaterThanOrEqual(claimedBefore + 45);
       expect(processing!.claimExpiresAt).toBeLessThanOrEqual(claimedAfter + 45);
-      expect(processing!.payload).toEqual({
+      expect(JSON.parse(processing!.payload)).toEqual({
         recipient: "carol@example.com",
         template: "welcome",
       });

--- a/packages/honker-bun/test/types/tsconfig.json
+++ b/packages/honker-bun/test/types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "types": ["bun"],
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "target": "ES2022"
+  },
+  "include": ["typed-jobs.ts", "../../src/**/*.ts"]
+}

--- a/packages/honker-bun/test/types/typed-jobs.ts
+++ b/packages/honker-bun/test/types/typed-jobs.ts
@@ -18,9 +18,12 @@ queue.enqueue({
   variables: { firstName: "Alice" },
 });
 
-const pending: JobSnapshot<EmailPayload> | null = queue.getJob(1);
+// A snapshot's payload is raw JSON text in this binding, not a decoded
+// TPayload — the encoding is deliberately left as it was.
+const pending: JobSnapshot | null = queue.getJob(1);
 if (pending) {
-  pending.payload.recipient.toUpperCase();
+  const decoded = JSON.parse(pending.payload) as EmailPayload;
+  decoded.recipient.toUpperCase();
   pending.state satisfies "pending" | "processing";
   pending.runAt.toFixed(0);
   pending.maxAttempts.toFixed(0);

--- a/packages/honker-bun/test/types/typed-jobs.ts
+++ b/packages/honker-bun/test/types/typed-jobs.ts
@@ -41,6 +41,10 @@ if (claimed) {
   claimed.workerId.toUpperCase();
   claimed.claimExpiresAt.toFixed(0);
   claimed.ack();
+  // @ts-expect-error the payload contract has no `subject`. Without a
+  // negative check like this one, widening Job<TPayload>.payload to `any`
+  // erases the whole generic and every assertion above still compiles.
+  claimed.payload.subject;
 }
 
 const waker = queue.claimWaker();

--- a/packages/honker-bun/test/types/typed-jobs.ts
+++ b/packages/honker-bun/test/types/typed-jobs.ts
@@ -1,0 +1,61 @@
+// Compile-time proof of the typed queue surface. Never executed: tsc
+// checks it, `bun test` does not run it. Honker performs no runtime
+// payload validation, so these types are a contract between callers.
+import { open, type Job, type JobSnapshot } from "../../src/index.ts";
+
+interface EmailPayload {
+  recipient: string;
+  template: "welcome" | "receipt";
+  variables: Record<string, string>;
+}
+
+const db = open("typed-jobs.db", "libhonker_ext.so");
+const queue = db.queue<EmailPayload>("emails");
+
+queue.enqueue({
+  recipient: "alice@example.com",
+  template: "welcome",
+  variables: { firstName: "Alice" },
+});
+
+const pending: JobSnapshot<EmailPayload> | null = queue.getJob(1);
+if (pending) {
+  pending.payload.recipient.toUpperCase();
+  pending.state satisfies "pending" | "processing";
+  pending.runAt.toFixed(0);
+  pending.maxAttempts.toFixed(0);
+  pending.createdAt.toFixed(0);
+  pending.workerId satisfies string | null;
+  pending.claimExpiresAt satisfies number | null;
+  pending.expiresAt satisfies number | null;
+}
+
+const claimed: Job<EmailPayload> | null = queue.claimOne("worker-1");
+if (claimed) {
+  claimed.payload.template satisfies "welcome" | "receipt";
+  claimed.state satisfies "processing";
+  claimed.priority.toFixed(0);
+  claimed.workerId.toUpperCase();
+  claimed.claimExpiresAt.toFixed(0);
+  claimed.ack();
+}
+
+const waker = queue.claimWaker();
+const nextJob: Promise<Job<EmailPayload> | null> = waker.next("worker-2");
+void nextJob;
+
+const outbox = db.outbox<EmailPayload>("email-delivery", async (payload, job) => {
+  payload.variables.firstName.toUpperCase();
+  job.payload.recipient.toUpperCase();
+});
+outbox.enqueue({
+  recipient: "bob@example.com",
+  template: "receipt",
+  variables: {},
+});
+
+// @ts-expect-error recipient is required by the queue payload contract
+queue.enqueue({ template: "welcome", variables: {} });
+
+waker.close();
+db.close();


### PR DESCRIPTION
Part of #136 — the Bun half. The .NET half is #142.

**Stacked on #124 (`feat/node-typed-jobs`), which is the base of this PR. Merge after #124.**
It depends on the widened `honker_claim_batch` RETURNING clause that only exists there. No honker-core or SQL ABI change here; core already returns everything needed.

## What changed

- Claimed jobs and read-only snapshots carry all twelve fields: `id`, `queue`, `payload`, `state`, `priority`, `runAt`, `workerId`, `claimExpiresAt`, `attempts`, `maxAttempts`, `createdAt`, `expiresAt`. camelCase, matching Node; the core JSON stays snake_case.
- `Queue`, `Job`, `JobSnapshot`, `ClaimWaker`, and `Outbox` take a payload generic defaulting to `JsonValue` — the same shape `packages/honker-node/wrapper.d.ts` established, deliberately not a new invention.
- **Behavior change:** `getJob()` returns the camelCase `JobSnapshot` instead of the raw snake_case `JobRow`. Field *names* changed; the payload *encoding* did not.

### Snapshot payload encoding (flagged for a repo-wide decision)

Bindings disagree and this PR does not try to settle it:

| binding | claimed `Job` payload | snapshot payload |
| --- | --- | --- |
| Node (#124) | decoded | decoded |
| **Bun (this PR)** | decoded (unchanged) | **raw JSON text (unchanged)** |
| **.NET (#142)** | `JsonElement` / `GetPayload<T>()` (unchanged) | `JobRow.Payload` raw JSON text (unchanged); the new opt-in `JobSnapshot<T>` carries both `Payload` (decoded) and `PayloadRaw` |
| Go, Python | raw JSON text | raw JSON text |

An earlier revision of this PR decoded Bun's snapshot payload to match Node. That was reverted — it is a breaking change #136 did not ask for. `JobSnapshot` is therefore not generic over the payload; `Queue<TPayload>` still types enqueue and claims.
- A claimed `Job` keeps `ack`/`retry`/`fail`/`heartbeat`; `JobSnapshot` is data only.
- A claimed row arriving without `worker_id`/`claim_expires_at` throws instead of being silently accepted.
- Typing is **compile-time only**. No runtime payload validation was added, and the README says so explicitly.

### One prerequisite fix, in its own commit

`fix(bun): make the binding compile under strict tsc` — the package ships its `.ts` source as `types`, and that source did not type-check: `ReturnType<typeof dlopen>` erased the FFI symbol map (every symbol `never`) and `Transaction.query` bound params as `unknown[]` where `bun:sqlite` wants `SQLQueryBindings[]`. Type-only changes, runtime identical. Without them there is no way to gate the new compile-time typing, and strict TS consumers of this package could not compile it at all. Flagging it because it is adjacent to, not part of, #136.

## Tests

New `packages/honker-bun/test/typed_jobs.test.ts`, 6 tests, asserting values rather than presence (times bounded by `unixepoch()` reads taken around each call):

- `a claimed job carries every field the core returns`
- `a pending snapshot carries every field the core returns`
- `a reader sees the processing snapshot, then nothing after ack` (two handles on one db file)
- `a delayed job reports its runAt and is not claimable yet`
- `a retried job reports the new attempt count and run_at`
- `the claim waker returns a job carrying the same detail`

Compile-time gate: `packages/honker-bun/test/types/typed-jobs.ts` + `tsconfig.json`, run by `bun run test:types` (new script) and wired into the CI Bun step. It includes a `@ts-expect-error` on an enqueue that violates the payload contract, so the gate fails if the generics go loose.

Local: `bun test` → 64 pass, 0 fail (whole suite; kernel/shm backends skip on a locally built extension without those features). `bun run test:types` → exit 0.

### Falsification

Broke `this.maxAttempts = row.max_attempts` to `row.attempts` in the `Job` constructor:

```
95 |       expect(job!.maxAttempts).toBe(5);
                                    ^
error: expect(received).toBe(expected)
Expected: 5
Received: 1
      at test/typed_jobs.test.ts:95:32
(fail) honker-bun job details > a claimed job carries every field the core returns
```

(`a retried job reports the new attempt count and run_at` failed too: expected 3, received 1.) Restored, suite green again.

## Not in scope

- `claimed_at` (#135) — deliberately not added.
- Queue-scoping of `getJob` (#134) — Bun's `getJob` is still a global id lookup, unlike Node's now-scoped one. Worth noting since the payload generic is only sound for ids the queue owns.
- The known `ClaimWaker` bug in `src/index.ts` (it parks on `idlePollS` after a passed `runAt` deadline, the Bun twin of the Node fix in #122) is untouched. The new waker test claims an immediately-ready job and does not exercise that path.
- No changes to honker-core, the SQL ABI, honker-node, or any other binding.

https://claude.ai/code/session_01YMCFasvKC52r37DDKSTeMC
