### PR TITLE
feat(ruby): carry full job details on claims and snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,6 +587,7 @@ jobs:
           bundle exec ruby -Ilib spec/honker_spec.rb
           bundle exec ruby -Ilib spec/smoke_spec.rb
           bundle exec ruby -Ilib spec/job_fields_spec.rb
+          bundle exec ruby -Ilib spec/phase_mantle_spec.rb
           bundle exec ruby -Ilib spec/parity_spec.rb
           bundle exec ruby -Ilib spec/extension_resolution_spec.rb
           bundle exec ruby -Ilib spec/setup_helpers_spec.rb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,6 +586,7 @@ jobs:
           bundle exec ruby -e 'require "sqlite3"; db = SQLite3::Database.new(":memory:"); abort "sqlite3 gem lacks loadable-extension support" unless db.respond_to?(:enable_load_extension) && db.respond_to?(:load_extension)'
           bundle exec ruby -Ilib spec/honker_spec.rb
           bundle exec ruby -Ilib spec/smoke_spec.rb
+          bundle exec ruby -Ilib spec/job_fields_spec.rb
           bundle exec ruby -Ilib spec/parity_spec.rb
           bundle exec ruby -Ilib spec/extension_resolution_spec.rb
           bundle exec ruby -Ilib spec/setup_helpers_spec.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,23 @@
   unscoped lookup could hand back a payload that did not match the queue's
   declared `TPayload`. `cancel()` is unchanged and remains not queue-scoped.
 
+## Unreleased — Ruby job details
+
+- `Honker::Job` now exposes every field the claim ABI returns: `state`,
+  `priority`, `run_at`, `claim_expires_at`, `max_attempts`, `created_at`,
+  and `expires_at` join the existing `id`, `queue_name`, `payload`,
+  `worker_id`, and `attempts`.
+- `Queue#get_job` returns a `Honker::JobSnapshot` — the same twelve fields,
+  read-only, with no ack/retry/fail/heartbeat. **Behavior change:** it used
+  to return a plain `Hash` of the raw ABI row. `snapshot["state"]` still
+  works (`Struct#[]` takes member names), but `Hash` methods no longer do.
+- Snapshot `payload` stays the raw JSON text the row stores, matching the
+  Python and Go snapshots. `Job#payload` is still decoded. The bindings do
+  not yet agree on one snapshot payload encoding; Node decodes it.
+- `spec/job_fields_spec.rb` asserts every field against the value it was
+  enqueued or claimed with, across pending, delayed, processing, retried,
+  and acked jobs.
+
 ## Unreleased — Node checkpoint interoperability (Phase Robinson)
 
 - Node stream checkpoint calls now use the shared SQL ABI's canonical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,11 @@
   `worker_id`, and `attempts`.
 - `Queue#get_job` returns a `Honker::JobSnapshot` — the same twelve fields,
   read-only, with no ack/retry/fail/heartbeat. **Behavior change:** it used
-  to return a plain `Hash` of the raw ABI row. `snapshot["state"]` still
-  works (`Struct#[]` takes member names), but `Hash` methods no longer do.
+  to return a plain `Hash` of the raw ABI row. Reader access still works
+  (`snapshot["state"]`, `snapshot.dig("state")`), and `JSON.dump(snapshot)`
+  still emits the same JSON object, but Hash-only methods do not: `fetch`,
+  `key?` and `keys` raise `NoMethodError`, an unknown field name raises
+  `NameError` instead of returning `nil`, and `to_h` has Symbol keys.
 - `Job#queue` is a new alias for `Job#queue_name`, so the accessor name
   `JobSnapshot` uses works on a claimed job too.
 - Snapshot `payload` stays the raw JSON text the row stores, matching the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
   read-only, with no ack/retry/fail/heartbeat. **Behavior change:** it used
   to return a plain `Hash` of the raw ABI row. `snapshot["state"]` still
   works (`Struct#[]` takes member names), but `Hash` methods no longer do.
+- `Job#queue` is a new alias for `Job#queue_name`, so the accessor name
+  `JobSnapshot` uses works on a claimed job too.
 - Snapshot `payload` stays the raw JSON text the row stores, matching the
   Python and Go snapshots. `Job#payload` is still decoded. The bindings do
   not yet agree on one snapshot payload encoding; Node decodes it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,10 @@
   (`snapshot["state"]`, `snapshot.dig("state")`), and `JSON.dump(snapshot)`
   still emits the same JSON object, but Hash-only methods do not: `fetch`,
   `key?` and `keys` raise `NoMethodError`, an unknown field name raises
-  `NameError` instead of returning `nil`, and `to_h` has Symbol keys.
+  `NameError` instead of returning `nil`, and `to_h` has Symbol keys. One
+  break is silent: `each` and `map` yield the twelve values, not
+  `[key, value]` pairs, so a `|name, value|` block gets a value and `nil`
+  with no error. Iterate over `to_h` instead.
 - `Job#queue` is a new alias for `Job#queue_name`, so the accessor name
   `JobSnapshot` uses works on a claimed job too.
 - Snapshot `payload` stays the raw JSON text the row stores, matching the

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -303,7 +303,10 @@ still emits the same JSON object, but Hash-only methods do not: `fetch`,
 `NameError` instead of returning `nil`, and `to_h` gives you Symbol keys,
 not String ones.
 
-One break is silent rather than loud: iteration. A `Struct`'s `each` and `map` yield the twelve values, not `[key, value]` pairs, so a block written `|name, value|` against the old `Hash` now gets a value and `nil` with no error. Iterate over `snapshot.to_h` instead.
+One break is silent rather than loud: iteration. A `Struct`'s `each` and
+`map` yield the twelve values, not `[key, value]` pairs, so a block
+written `|name, value|` against the old `Hash` now gets a value and `nil`
+with no error. Iterate over `snapshot.to_h` instead.
 
 Honker never inspects a payload. The shape is a contract between the app
 that enqueues and the app that claims, and both sides have to agree on it

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -292,7 +292,8 @@ ack/retry/fail/heartbeat, because the reader holds no claim. `state` is
 `nil` until some worker claims the job. The snapshot's `payload` is the
 raw JSON *text* from the row, not a decoded value — call `JSON.parse` on
 it. `nil` means the job was ack'd, dead-lettered, cancelled, or never
-existed.
+existed. The lookup is by id alone, so an id belonging to another queue
+returns that queue's row rather than `nil`.
 
 `JobSnapshot` is a `Struct`, like `Honker::Notification`. It replaces the
 plain `Hash` older versions returned. Reader access still works
@@ -305,7 +306,14 @@ not String ones.
 Honker never inspects a payload. The shape is a contract between the app
 that enqueues and the app that claims, and both sides have to agree on it
 — including across languages, since another binding may write to the same
-queue. Version the payload if it will change:
+queue.
+
+The payload goes through `JSON.dump` on the way in and `JSON.parse` on
+the way out, so it must be JSON-serializable, and **Symbol keys come back
+as Strings**: `q.enqueue({to: "alice"})` claims as `{"to" => "alice"}`.
+Write `job.payload["to"]`, not `job.payload[:to]`.
+
+Version the payload if it will change:
 
 ```ruby
 q.enqueue({"v" => 2, "to" => "alice@example.com"})

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -294,6 +294,14 @@ raw JSON *text* from the row, not a decoded value — call `JSON.parse` on
 it. `nil` means the job was ack'd, dead-lettered, cancelled, or never
 existed.
 
+`JobSnapshot` is a `Struct`, like `Honker::Notification`. It replaces the
+plain `Hash` older versions returned. Reader access still works
+(`snapshot["state"]`, `snapshot.dig("state")`), and `JSON.dump(snapshot)`
+still emits the same JSON object, but Hash-only methods do not: `fetch`,
+`key?` and `keys` raise `NoMethodError`, an unknown field name raises
+`NameError` instead of returning `nil`, and `to_h` gives you Symbol keys,
+not String ones.
+
 Honker never inspects a payload. The shape is a contract between the app
 that enqueues and the app that claims, and both sides have to agree on it
 — including across languages, since another binding may write to the same

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -263,3 +263,47 @@ Supported schedule forms:
 - `@every 1s`
 
 `schedule:` is the canonical recurring name. `cron:` still works as a compatibility alias.
+
+## Job details
+
+A claimed `Honker::Job` carries the whole row as it stood at claim time:
+
+```ruby
+job = q.claim_one("worker-1")
+
+job.id                # row id
+job.queue_name        # queue this job came from
+job.payload           # decoded JSON value
+job.state             # "processing"
+job.priority          # higher runs first within the queue
+job.run_at            # unix seconds; when it became claimable
+job.worker_id         # "worker-1"
+job.claim_expires_at  # unix seconds; heartbeat before this
+job.attempts          # already incremented by this claim
+job.max_attempts      # dead-letters once attempts reaches this
+job.created_at        # unix seconds
+job.expires_at        # unix seconds, or nil when enqueued without expires:
+```
+
+`q.get_job(id)` returns a `Honker::JobSnapshot` — the same twelve fields,
+read-only, for a job you did not claim. It is data alone: no
+ack/retry/fail/heartbeat, because the reader holds no claim. `state` is
+`"pending"` or `"processing"`, and `worker_id` / `claim_expires_at` are
+`nil` until some worker claims the job. The snapshot's `payload` is the
+raw JSON *text* from the row, not a decoded value — call `JSON.parse` on
+it. `nil` means the job was ack'd, dead-lettered, cancelled, or never
+existed.
+
+Honker never inspects a payload. The shape is a contract between the app
+that enqueues and the app that claims, and both sides have to agree on it
+— including across languages, since another binding may write to the same
+queue. Version the payload if it will change:
+
+```ruby
+q.enqueue({"v" => 2, "to" => "alice@example.com"})
+
+case job.payload["v"]
+when 2 then send_email(job.payload["to"])
+else raise "unknown payload version #{job.payload["v"].inspect}"
+end
+```

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -303,6 +303,8 @@ still emits the same JSON object, but Hash-only methods do not: `fetch`,
 `NameError` instead of returning `nil`, and `to_h` gives you Symbol keys,
 not String ones.
 
+One break is silent rather than loud: iteration. A `Struct`'s `each` and `map` yield the twelve values, not `[key, value]` pairs, so a block written `|name, value|` against the old `Hash` now gets a value and `nil` with no error. Iterate over `snapshot.to_h` instead.
+
 Honker never inspects a payload. The shape is a contract between the app
 that enqueues and the app that claims, and both sides have to agree on it
 — including across languages, since another binding may write to the same

--- a/packages/honker-ruby/README.md
+++ b/packages/honker-ruby/README.md
@@ -272,7 +272,7 @@ A claimed `Honker::Job` carries the whole row as it stood at claim time:
 job = q.claim_one("worker-1")
 
 job.id                # row id
-job.queue_name        # queue this job came from
+job.queue_name        # queue this job came from (also job.queue)
 job.payload           # decoded JSON value
 job.state             # "processing"
 job.priority          # higher runs first within the queue

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -902,6 +902,11 @@ module Honker
   # same JSON object, but Hash-only methods do not: #fetch, #key? and
   # #keys raise NoMethodError, an unknown name raises NameError
   # instead of returning nil, and #to_h has Symbol keys, not String.
+  #
+  # One break is silent rather than loud: iteration. A Struct's #each
+  # and #map yield the twelve values, not [key, value] pairs, so a
+  # block written `|name, value|` against the old Hash now gets a
+  # value and nil with no error. Iterate over #to_h instead.
   JobSnapshot = Struct.new(
     :id, :queue, :payload, :state, :priority, :run_at, :worker_id,
     :claim_expires_at, :attempts, :max_attempts, :created_at, :expires_at

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -809,13 +809,16 @@ module Honker
       n.positive?
     end
 
-    # Read a single job row by id. Returns a Hash with the row fields,
-    # or nil if the job has been ack'd, dead'd, or never existed.
+    # Read a single job row by id. Returns a JobSnapshot, or nil if the
+    # job has been ack'd, dead'd, or never existed.
+    #
+    # The lookup is by id alone. Ids are globally unique but not scoped
+    # to this queue, so a foreign id returns that queue's row (#134).
     def get_job(job_id)
       raw = @db.db.get_first_row("SELECT honker_get_job(?)", [job_id])[0]
       return nil if raw.nil? || raw.empty?
 
-      JSON.parse(raw)
+      JobSnapshot.from_row(JSON.parse(raw))
     end
   end
 
@@ -878,19 +881,75 @@ module Honker
     end
   end
 
+  # A read-only view of a live job row, as returned by Queue#get_job.
+  # Data only — no ack/retry/fail/heartbeat, because the reader does
+  # not hold the claim.
+  #
+  # Fields match the row: `state` is "pending" or "processing";
+  # `worker_id` and `claim_expires_at` are nil until a worker claims
+  # the job; `expires_at` is nil unless the job was enqueued with
+  # `expires:`. All times are unix epoch seconds.
+  #
+  # NOTE: `payload` is the raw JSON *text* stored in the row, not a
+  # decoded value — unlike Job#payload, which is decoded. Call
+  # JSON.parse on it. That difference is inherited from the SQL ABI
+  # and is deliberately left alone here; the bindings do not yet agree
+  # on one snapshot payload encoding.
+  JobSnapshot = Struct.new(
+    :id, :queue, :payload, :state, :priority, :run_at, :worker_id,
+    :claim_expires_at, :attempts, :max_attempts, :created_at, :expires_at
+  ) do
+    # Build a snapshot from a decoded honker_get_job() row.
+    def self.from_row(row)
+      new(
+        row["id"],
+        row["queue"],
+        row["payload"],
+        row["state"],
+        row["priority"],
+        row["run_at"],
+        row["worker_id"],
+        row["claim_expires_at"],
+        row["attempts"],
+        row["max_attempts"],
+        row["created_at"],
+        row["expires_at"],
+      )
+    end
+
+    # Job exposes the same value as #queue_name; accept both here.
+    alias_method :queue_name, :queue
+  end
+
   # A claimed unit of work. `payload` is the decoded JSON value (Hash,
-  # Array, etc.). `id`, `worker_id`, and `attempts` are metadata from
-  # the claim result.
+  # Array, etc.). Honker never inspects the payload — the shape is a
+  # contract between the producer and the consumer, so every app
+  # writing to a queue has to agree on it.
+  #
+  # The rest of the readers are the job's row as it stood at claim
+  # time: `state` ("processing"), `priority`, `run_at`, `worker_id`,
+  # `claim_expires_at`, `attempts` (already incremented by this
+  # claim), `max_attempts`, `created_at`, and `expires_at` (nil unless
+  # enqueued with `expires:`). Times are unix epoch seconds.
   class Job
-    attr_reader :id, :queue_name, :payload, :worker_id, :attempts
+    attr_reader :id, :queue_name, :payload, :state, :priority, :run_at,
+                :worker_id, :claim_expires_at, :attempts, :max_attempts,
+                :created_at, :expires_at
 
     def initialize(queue, row)
       @queue = queue
       @id = row["id"]
       @queue_name = row["queue"]
       @payload = JSON.parse(row["payload"]) unless row["payload"].nil?
+      @state = row["state"]
+      @priority = row["priority"]
+      @run_at = row["run_at"]
       @worker_id = row["worker_id"]
+      @claim_expires_at = row["claim_expires_at"]
       @attempts = row["attempts"]
+      @max_attempts = row["max_attempts"]
+      @created_at = row["created_at"]
+      @expires_at = row["expires_at"]
     end
 
     # DELETEs the row if the claim is still valid. Returns true/false.

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -936,6 +936,10 @@ module Honker
                 :worker_id, :claim_expires_at, :attempts, :max_attempts,
                 :created_at, :expires_at
 
+    # JobSnapshot names this field #queue; accept both here too, so
+    # code written against one works on the other.
+    alias_method :queue, :queue_name
+
     def initialize(queue, row)
       @queue = queue
       @id = row["id"]

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -812,8 +812,9 @@ module Honker
     # Read a single job row by id. Returns a JobSnapshot, or nil if the
     # job has been ack'd, dead'd, or never existed.
     #
-    # The lookup is by id alone. Ids are globally unique but not scoped
-    # to this queue, so a foreign id returns that queue's row (#134).
+    # The lookup is by id alone: ids are globally unique, so an id
+    # from another queue returns that other queue's row rather than
+    # nil. Scoping it is #134.
     def get_job(job_id)
       raw = @db.db.get_first_row("SELECT honker_get_job(?)", [job_id])[0]
       return nil if raw.nil? || raw.empty?

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -895,6 +895,12 @@ module Honker
   # JSON.parse on it. That difference is inherited from the SQL ABI
   # and is deliberately left alone here; the bindings do not yet agree
   # on one snapshot payload encoding.
+  #
+  # get_job used to return a Hash of this row. Reader access
+  # (snapshot["state"]) still works, and JSON.dump still emits the
+  # same JSON object, but Hash-only methods do not: #fetch, #key? and
+  # #keys raise NoMethodError, an unknown name raises NameError
+  # instead of returning nil, and #to_h has Symbol keys, not String.
   JobSnapshot = Struct.new(
     :id, :queue, :payload, :state, :priority, :run_at, :worker_id,
     :claim_expires_at, :attempts, :max_attempts, :created_at, :expires_at
@@ -919,6 +925,13 @@ module Honker
 
     # Job exposes the same value as #queue_name; accept both here.
     alias_method :queue_name, :queue
+
+    # Serialize as the row's JSON object, the way the Hash this used
+    # to be did. Without this a Struct serializes to its #inspect
+    # string, which silently turns a logged snapshot into garbage.
+    def to_json(*args)
+      to_h.transform_keys(&:to_s).to_json(*args)
+    end
   end
 
   # A claimed unit of work. `payload` is the decoded JSON value (Hash,

--- a/packages/honker-ruby/spec/job_fields_spec.rb
+++ b/packages/honker-ruby/spec/job_fields_spec.rb
@@ -26,6 +26,31 @@ def find_ext
   nil
 end
 
+# Same helper the other specs use: under
+# HONKER_REQUIRE_RUBY_EXTENSION_LOADING=1 a missing capability is a
+# failure, not a silent pass.
+unless defined?(require_load_extension_support!)
+  def require_load_extension_support!
+    return if SQLite3::Database.new(":memory:").respond_to?(:enable_load_extension)
+
+    message = "sqlite3 gem lacks loadable-extension support"
+    flunk message if ENV["HONKER_REQUIRE_RUBY_EXTENSION_LOADING"] == "1"
+    skip message
+  end
+end
+
+# A missing build artifact must not let this acceptance spec pass while
+# asserting nothing. Locally it still skips; under the CI flag it fails.
+unless defined?(require_built_extension!)
+  def require_built_extension!(ext)
+    return if ext
+
+    message = "honker extension not built"
+    flunk message if ENV["HONKER_REQUIRE_RUBY_EXTENSION_LOADING"] == "1"
+    skip message
+  end
+end
+
 class HonkerJobFieldsTest < Minitest::Test
   # Distinct values so no assertion can pass by two numbers happening
   # to be equal: priority, max_attempts, visibility timeout, delay, and
@@ -37,8 +62,9 @@ class HonkerJobFieldsTest < Minitest::Test
   EXPIRES_S = 900
 
   def setup
+    require_load_extension_support!
     ext = find_ext
-    skip "honker extension not built" unless ext
+    require_built_extension!(ext)
     @tmpdir = Dir.mktmpdir("honker-job-fields-")
     @db = Honker::Database.new(File.join(@tmpdir, "t.db"), extension_path: ext)
     @q = @db.queue("details",

--- a/packages/honker-ruby/spec/job_fields_spec.rb
+++ b/packages/honker-ruby/spec/job_fields_spec.rb
@@ -120,6 +120,21 @@ class HonkerJobFieldsTest < Minitest::Test
     assert_nil @q.get_job(id).expires_at, "expires_at must be nil, not 0"
   end
 
+  # A snapshot names the queue #queue; a claimed Job named it
+  # #queue_name. Both answer to both, so code written against one
+  # works when handed the other.
+  def test_job_and_snapshot_agree_on_the_queue_accessor
+    id = @q.enqueue({ "x" => 1 })
+    snap = @q.get_job(id)
+    job = @q.claim_one("worker-a")
+
+    assert_equal id, job.id
+    assert_equal "details", snap.queue
+    assert_equal "details", snap.queue_name
+    assert_equal "details", job.queue
+    assert_equal "details", job.queue_name
+  end
+
   def test_delayed_job_reports_its_run_at
     id = @q.enqueue({ "x" => 1 }, delay: DELAY_S)
     snap = @q.get_job(id)

--- a/packages/honker-ruby/spec/job_fields_spec.rb
+++ b/packages/honker-ruby/spec/job_fields_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+#
+# Full job details on claimed jobs and read-only snapshots (issue #136).
+# Every one of the twelve fields the SQL ABI returns is asserted against
+# the value it was enqueued or claimed with — not merely for presence.
+#
+# Run: bundle exec ruby -Ilib spec/job_fields_spec.rb
+
+require "tmpdir"
+require "json"
+require "minitest/autorun"
+require "honker"
+
+REPO_ROOT = File.expand_path("../../..", __dir__) unless defined?(REPO_ROOT)
+
+def find_ext
+  %w[
+    target/debug/libhonker_ext.dylib
+    target/debug/libhonker_ext.so
+    target/release/libhonker_ext.dylib
+    target/release/libhonker_ext.so
+  ].each do |rel|
+    p = File.join(REPO_ROOT, rel)
+    return p if File.exist?(p)
+  end
+  nil
+end
+
+class HonkerJobFieldsTest < Minitest::Test
+  # Distinct values so no assertion can pass by two numbers happening
+  # to be equal: priority, max_attempts, visibility timeout, delay, and
+  # the expiry window all differ from each other and from the defaults.
+  PRIORITY = 7
+  MAX_ATTEMPTS = 5
+  VISIBILITY_S = 11
+  DELAY_S = 300
+  EXPIRES_S = 900
+
+  def setup
+    ext = find_ext
+    skip "honker extension not built" unless ext
+    @tmpdir = Dir.mktmpdir("honker-job-fields-")
+    @db = Honker::Database.new(File.join(@tmpdir, "t.db"), extension_path: ext)
+    @q = @db.queue("details",
+                   visibility_timeout_s: VISIBILITY_S,
+                   max_attempts: MAX_ATTEMPTS)
+  end
+
+  def teardown
+    @db&.close
+    FileUtils.remove_entry(@tmpdir) if @tmpdir && File.directory?(@tmpdir)
+  end
+
+  def db_now
+    @db.db.get_first_row("SELECT unixepoch()")[0]
+  end
+
+  def test_pending_snapshot_carries_every_field
+    payload = { "to" => "alice@example.com", "v" => 2 }
+    before = db_now
+    id = @q.enqueue(payload, priority: PRIORITY, expires: EXPIRES_S)
+    after = db_now
+
+    snap = @q.get_job(id)
+    refute_nil snap
+    assert_instance_of Honker::JobSnapshot, snap
+
+    assert_equal id, snap.id
+    assert_equal "details", snap.queue
+    # Snapshot payloads are raw JSON text (see JobSnapshot docs).
+    assert_equal JSON.dump(payload), snap.payload
+    assert_equal payload, JSON.parse(snap.payload)
+    assert_equal "pending", snap.state
+    assert_equal PRIORITY, snap.priority
+    assert_nil snap.worker_id, "an unclaimed job has no worker"
+    assert_nil snap.claim_expires_at, "an unclaimed job has no claim deadline"
+    assert_equal 0, snap.attempts
+    assert_equal MAX_ATTEMPTS, snap.max_attempts
+    assert_operator snap.created_at, :>=, before
+    assert_operator snap.created_at, :<=, after
+    # No delay: run_at is the enqueue instant, not a default of 0 and
+    # not a future deadline.
+    assert_operator snap.run_at, :>=, before
+    assert_operator snap.run_at, :<=, after
+    # expires_at is created_at + EXPIRES_S. enqueue() reads unixepoch()
+    # once for the offset and the row defaults created_at from a second
+    # read, so allow one second of skew — still far from any other
+    # constant in this test.
+    assert_in_delta snap.created_at + EXPIRES_S, snap.expires_at, 1
+  end
+
+  def test_snapshot_without_expiry_has_nil_expires_at
+    id = @q.enqueue({ "x" => 1 })
+    assert_nil @q.get_job(id).expires_at, "expires_at must be nil, not 0"
+  end
+
+  def test_delayed_job_reports_its_run_at
+    id = @q.enqueue({ "x" => 1 }, delay: DELAY_S)
+    snap = @q.get_job(id)
+
+    assert_equal "pending", snap.state
+    assert_in_delta snap.created_at + DELAY_S, snap.run_at, 1
+    # And it is genuinely in the future, not a stale creation stamp.
+    assert_operator snap.run_at, :>, db_now
+    assert_nil @q.claim_one("worker-early"), "a delayed job is not claimable"
+  end
+
+  def test_claimed_job_carries_every_field
+    payload = { "to" => "bob@example.com", "v" => 2 }
+    id = @q.enqueue(payload, priority: PRIORITY, expires: EXPIRES_S)
+    pending = @q.get_job(id)
+
+    before = db_now
+    job = @q.claim_one("worker-a")
+    after = db_now
+    refute_nil job
+
+    assert_equal id, job.id
+    assert_equal "details", job.queue_name
+    # Claimed payloads are decoded, unlike snapshot payloads.
+    assert_equal payload, job.payload
+    assert_equal "processing", job.state
+    assert_equal PRIORITY, job.priority
+    assert_equal pending.run_at, job.run_at
+    assert_equal "worker-a", job.worker_id
+    assert_equal 1, job.attempts, "the claim increments attempts"
+    assert_equal MAX_ATTEMPTS, job.max_attempts
+    assert_equal pending.created_at, job.created_at
+    assert_equal pending.expires_at, job.expires_at
+    # The claim deadline is the claim instant plus this queue's
+    # visibility timeout — not the default 300s.
+    assert_operator job.claim_expires_at, :>=, before + VISIBILITY_S
+    assert_operator job.claim_expires_at, :<=, after + VISIBILITY_S
+  end
+
+  def test_processing_snapshot_matches_the_claim_then_misses_after_ack
+    id = @q.enqueue({ "to" => "carol@example.com" }, priority: PRIORITY)
+    job = @q.claim_one("worker-b")
+
+    # A second reader sees the in-flight claim's details.
+    snap = @q.get_job(id)
+    assert_equal "processing", snap.state
+    assert_equal "worker-b", snap.worker_id
+    assert_equal job.claim_expires_at, snap.claim_expires_at
+    assert_operator snap.claim_expires_at, :>, snap.created_at
+    assert_equal 1, snap.attempts
+    assert_equal PRIORITY, snap.priority
+    assert_equal MAX_ATTEMPTS, snap.max_attempts
+
+    assert job.ack, "fresh claim should ack"
+    assert_nil @q.get_job(id), "the row is gone after ack"
+  end
+
+  def test_retry_bumps_attempts_and_pushes_run_at_out
+    id = @q.enqueue({ "x" => 1 })
+    job = @q.claim_one("worker-c")
+    assert_equal 1, job.attempts
+
+    assert job.retry(delay_s: DELAY_S, error: "boom")
+    snap = @q.get_job(id)
+    assert_equal "pending", snap.state
+    assert_equal 1, snap.attempts, "attempts survives the retry"
+    assert_operator snap.run_at, :>=, db_now + DELAY_S - 1
+    assert_nil snap.worker_id, "retry clears the worker"
+    assert_nil snap.claim_expires_at, "retry clears the claim deadline"
+  end
+end

--- a/packages/honker-ruby/spec/job_fields_spec.rb
+++ b/packages/honker-ruby/spec/job_fields_spec.rb
@@ -159,6 +159,27 @@ class HonkerJobFieldsTest < Minitest::Test
     assert_operator job.claim_expires_at, :<=, after + VISIBILITY_S
   end
 
+  # test_claimed_job_carries_every_field compares run_at against a
+  # snapshot of an *undelayed* enqueue, where run_at == created_at to the
+  # second, so it cannot tell the two fields apart. A delay will not fix
+  # that: a delayed job is not claimable (see the test above). Back-dating
+  # an absolute run_at keeps the job claimable and makes the two differ.
+  def test_claimed_job_reports_its_own_run_at_not_created_at
+    run_at = db_now - 100
+    id = @q.enqueue({ "x" => 1 }, run_at: run_at)
+
+    snap = @q.get_job(id)
+    assert_equal run_at, snap.run_at
+    refute_equal snap.created_at, snap.run_at
+
+    job = @q.claim_one("worker-a")
+    refute_nil job, "a back-dated job must still be claimable"
+    assert_equal id, job.id
+    assert_equal run_at, job.run_at
+    refute_equal job.created_at, job.run_at
+    assert_equal snap.created_at, job.created_at
+  end
+
   def test_processing_snapshot_matches_the_claim_then_misses_after_ack
     id = @q.enqueue({ "to" => "carol@example.com" }, priority: PRIORITY)
     job = @q.claim_one("worker-b")

--- a/packages/honker-ruby/spec/job_fields_spec.rb
+++ b/packages/honker-ruby/spec/job_fields_spec.rb
@@ -169,6 +169,18 @@ class HonkerJobFieldsTest < Minitest::Test
     assert_equal "details", job.queue_name
   end
 
+  # The payload goes through JSON.dump/JSON.parse, so Symbol keys come
+  # back as Strings. That is the trap the README warns about.
+  def test_payload_symbol_keys_come_back_as_strings
+    id = @q.enqueue({ to: "dana@example.com", v: 2 })
+    job = @q.claim_one("worker-a")
+
+    assert_equal id, job.id
+    assert_equal({ "to" => "dana@example.com", "v" => 2 }, job.payload)
+    refute job.payload.key?(:to), "Symbol keys do not survive the round trip"
+    assert_equal '{"to":"dana@example.com","v":2}', @q.get_job(id).payload
+  end
+
   def test_delayed_job_reports_its_run_at
     id = @q.enqueue({ "x" => 1 }, delay: DELAY_S)
     snap = @q.get_job(id)

--- a/packages/honker-ruby/spec/job_fields_spec.rb
+++ b/packages/honker-ruby/spec/job_fields_spec.rb
@@ -63,10 +63,10 @@ class HonkerJobFieldsTest < Minitest::Test
 
   def setup
     require_load_extension_support!
-    ext = find_ext
-    require_built_extension!(ext)
+    @ext = find_ext
+    require_built_extension!(@ext)
     @tmpdir = Dir.mktmpdir("honker-job-fields-")
-    @db = Honker::Database.new(File.join(@tmpdir, "t.db"), extension_path: ext)
+    @db = Honker::Database.new(File.join(@tmpdir, "t.db"), extension_path: @ext)
     @q = @db.queue("details",
                    visibility_timeout_s: VISIBILITY_S,
                    max_attempts: MAX_ATTEMPTS)
@@ -118,6 +118,12 @@ class HonkerJobFieldsTest < Minitest::Test
   def test_snapshot_without_expiry_has_nil_expires_at
     id = @q.enqueue({ "x" => 1 })
     assert_nil @q.get_job(id).expires_at, "expires_at must be nil, not 0"
+  end
+
+  def test_claimed_job_without_expiry_has_nil_expires_at
+    @q.enqueue({ "x" => 1 })
+    job = @q.claim_one("worker-a")
+    assert_nil job.expires_at, "expires_at must be nil, not 0"
   end
 
   # get_job used to return a Hash. These are the access patterns that
@@ -239,6 +245,33 @@ class HonkerJobFieldsTest < Minitest::Test
 
     assert job.ack, "fresh claim should ack"
     assert_nil @q.get_job(id), "the row is gone after ack"
+  end
+
+  # #136 asks for the details to be visible to a *different* reader,
+  # not just to the connection that claimed. A second Database proves
+  # the claim and the ack are committed, not merely visible to the
+  # writer.
+  def test_a_second_connection_sees_the_claim_and_then_the_ack
+    id = @q.enqueue({ "x" => 1 }, priority: PRIORITY)
+    job = @q.claim_one("worker-d")
+    refute_nil job
+
+    reader = Honker::Database.new(@db.path, extension_path: @ext)
+    begin
+      reader_queue = reader.queue("details")
+      snap = reader_queue.get_job(id)
+      refute_nil snap, "another connection must see the committed claim"
+      assert_equal "processing", snap.state
+      assert_equal "worker-d", snap.worker_id
+      assert_equal job.claim_expires_at, snap.claim_expires_at
+      assert_equal 1, snap.attempts
+      assert_equal PRIORITY, snap.priority
+
+      assert job.ack
+      assert_nil reader_queue.get_job(id), "the ack is visible to the other connection"
+    ensure
+      reader.close
+    end
   end
 
   def test_retry_bumps_attempts_and_pushes_run_at_out

--- a/packages/honker-ruby/spec/job_fields_spec.rb
+++ b/packages/honker-ruby/spec/job_fields_spec.rb
@@ -120,6 +120,34 @@ class HonkerJobFieldsTest < Minitest::Test
     assert_nil @q.get_job(id).expires_at, "expires_at must be nil, not 0"
   end
 
+  # get_job used to return a Hash. These are the access patterns that
+  # still have to work on the Struct, plus the JSON shape a caller who
+  # logs or ships a snapshot depends on. Without JobSnapshot#to_json a
+  # Struct serializes to its #inspect string, which parses back as a
+  # String, not a Hash.
+  def test_snapshot_keeps_the_reader_and_json_shape_the_hash_had
+    id = @q.enqueue({ "x" => 1 }, priority: PRIORITY)
+    snap = @q.get_job(id)
+
+    assert_equal id, snap["id"]
+    assert_equal "details", snap["queue"]
+    assert_equal "pending", snap["state"]
+    assert_equal PRIORITY, snap["priority"]
+    assert_equal "pending", snap.dig("state")
+
+    round_trip = JSON.parse(JSON.dump(snap))
+    assert_instance_of Hash, round_trip
+    assert_equal snap.to_h.transform_keys(&:to_s), round_trip
+    assert_equal 12, round_trip.size
+    assert_nil round_trip["worker_id"], "a JSON null, not a missing key"
+    assert round_trip.key?("worker_id")
+
+    # Documented breaks: Hash-only methods are gone, and an unknown
+    # field raises instead of quietly returning nil.
+    assert_raises(NoMethodError) { snap.fetch("state") }
+    assert_raises(NameError) { snap["claimed_at"] }
+  end
+
   # A snapshot names the queue #queue; a claimed Job named it
   # #queue_name. Both answer to both, so code written against one
   # works when handed the other.

--- a/packages/honker-ruby/spec/job_fields_spec.rb
+++ b/packages/honker-ruby/spec/job_fields_spec.rb
@@ -154,6 +154,25 @@ class HonkerJobFieldsTest < Minitest::Test
     assert_raises(NameError) { snap["claimed_at"] }
   end
 
+  # The one Hash break that does not raise. A Struct yields its values,
+  # so a block written `|name, value|` against the old Hash silently
+  # gets a value and nil. Pinned here so the docs cannot drift off it.
+  def test_snapshot_iteration_yields_values_not_key_value_pairs
+    id = @q.enqueue({ "x" => 1 })
+    snap = @q.get_job(id)
+
+    assert_equal snap.to_a, snap.map { |v| v }
+    assert_equal 12, snap.to_a.size
+
+    first_name, first_value = snap.each.first
+    assert_equal id, first_name, "the block's first argument is a value, not a field name"
+    assert_nil first_value, "there is no second argument to destructure"
+
+    # to_h is the way to iterate names and values.
+    assert_equal 12, snap.to_h.size
+    assert_equal :id, snap.to_h.keys.first
+  end
+
   # A snapshot names the queue #queue; a claimed Job named it
   # #queue_name. Both answer to both, so code written against one
   # works when handed the other.


### PR DESCRIPTION
Ruby half of #136. Stacked on #124 (`feat/node-typed-jobs`) and targets that branch: the widened `honker_claim_batch` RETURNING clause that exposes the full job snapshot only exists there. **Merge after #124.**

## What changed

- `Honker::Job` gains readers for `state`, `priority`, `run_at`, `claim_expires_at`, `max_attempts`, `created_at`, and `expires_at`, joining the existing `id`, `queue_name`, `payload`, `worker_id`, and `attempts` — the twelve fields the claim ABI already returned and the binding threw away.
- `Queue#get_job` returns a `Honker::JobSnapshot` (a `Struct`, matching `Honker::Notification` in the same file) instead of a bare `Hash`. Same twelve fields, data only: no ack/retry/fail/heartbeat, because the reader holds no claim.
- README documents the fields and the payload-shape contract. No runtime payload validation was added — Ruby has no static payload typing and Honker never checks payload shape.
- No change to honker-core or the SQL ABI.

### Behavior change

`get_job` used to return a `Hash` of the raw ABI row. `snapshot["state"]` still works (`Struct#[]` accepts member names, so the existing `phase_mantle_spec` assertions pass unchanged), but `Hash` methods no longer do.

### Snapshot payload encoding — needs one deliberate decision later

Read-only snapshots disagree across bindings today:

| binding | `get_job`/`getJob` payload |
| --- | --- |
| Ruby (this PR) | raw JSON **text** — unchanged from the old Hash |
| Elixir (sibling PR) | raw JSON **text** — unchanged |
| Python | raw JSON text |
| Go (`JobRow.Payload`) | raw JSON text |
| Node (#124) | **decoded** value |

This PR deliberately preserves Ruby's existing encoding rather than silently picking a side; changing it is a breaking API change #136 did not ask for. Claimed `Job#payload` is decoded in every binding, so Ruby is internally split between `Job#payload` (decoded) and `JobSnapshot#payload` (text) — documented in both the code and the README. Worth one repo-wide decision.

## Tests

New `packages/honker-ruby/spec/job_fields_spec.rb`, wired into the CI Ruby step. Every field is asserted against the value it was enqueued or claimed with, not for presence. Constants are deliberately distinct (priority 7, max_attempts 5, visibility 11s, delay 300s, expiry 900s) so no assertion can pass by two values coinciding, and timestamps are checked as differences (`created_at + 900 == expires_at`) or against a `unixepoch()` read taken around the call, never against a same-second sibling.

- `test_pending_snapshot_carries_every_field`
- `test_snapshot_without_expiry_has_nil_expires_at`
- `test_delayed_job_reports_its_run_at`
- `test_claimed_job_carries_every_field`
- `test_processing_snapshot_matches_the_claim_then_misses_after_ack`
- `test_retry_bumps_attempts_and_pushes_run_at_out`

Local: 6 runs, 52 assertions, 0 failures. Full Ruby suite green (honker 26, smoke 9, parity 25, phase_mantle 8, extension_resolution 8, setup_helpers 10, railtie 3).

### The tests were proven load-bearing

Mutating `Job#initialize` to read `@priority = row["max_attempts"]`:

```
1) Failure:
HonkerJobFieldsTest#test_claimed_job_carries_every_field [spec/job_fields_spec.rb:123]:
Expected: 7
  Actual: 5
```

Mutating `JobSnapshot.from_row` to pass `row["created_at"]` for `expires_at`:

```
2) Failure:
HonkerJobFieldsTest#test_pending_snapshot_carries_every_field [spec/job_fields_spec.rb:89]:
Expected |1788256899 - 1788255999| (900) to be <= 1.

3) Failure:
HonkerJobFieldsTest#test_snapshot_without_expiry_has_nil_expires_at [spec/job_fields_spec.rb:94]:
expires_at must be nil, not 0.
Expected 1788255999 to be nil.
```

Both mutations restored; suite green again.

## Not in this PR

- `claimed_at` — tracked separately in #135 / PR #140.
- Queue-scoped `get_job` — #134. Node scoped it in #124; Ruby's lookup stays global and the docstring now says so.
- `spec/phase_mantle_spec.rb` is not run by CI at all (pre-existing gap, unrelated to this change).

https://claude.ai/code/session_01YMCFasvKC52r37DDKSTeMC
