### PR TITLE
feat(rust): full job details and typed queue payloads (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@
   `db.typed_outbox::<T>()`, and `Queue::typed::<T>()` produce typed
   handles; `payload_typed()` decodes into the handle's `T` and the
   existing `payload_as::<U>()` still decodes into anything you name.
+  A default type parameter cannot go on a function, so `Database::queue`
+  stays non-generic (otherwise `let q = db.queue(..)` would stop
+  inferring) and `typed_queue` is a separate constructor. The cost is
+  that `db.queue::<Email>(..)` is `error[E0107]: method takes 0 generic
+  arguments` — with a "remove the unnecessary generics" hint pointing
+  the wrong way — and `let q: Queue<Email> = db.queue(..)` is an E0308.
+  Neither message mentions `typed_queue`, so `Database::queue`'s and
+  `Queue`'s rustdoc now say where to go.
 - Payload encoding is unchanged: `Job::payload` stays raw JSON bytes and
   `JobRow::payload` stays a raw JSON string. The type parameter is
   compile-time only — honker never validates payload shape in the
@@ -50,12 +58,21 @@
   - Two different payload types through one handle — you now need one
     typed handle per type, or keep the handle at `serde_json::Value` and
     `serde_json::to_value(..)` at the call site.
-  - **A generic helper has no drop-in migration.**
-    `fn helper<P: Serialize>(q: &Queue, p: &P)` no longer compiles; the
-    signature must become `fn helper<P: Serialize>(q: &Queue<P>, p: &P)`,
-    which changes every call site of the helper too, not just the body.
-    If you cannot change the call sites, keep `q: &Queue` and pass
-    `&serde_json::to_value(p)?` instead.
+  - A generic helper, `fn helper<P: Serialize>(q: &Queue, p: &P)`, no
+    longer compiles as written, but the migration is body-only —
+    `Queue::typed` reinterprets the handle in place, so the signature
+    and every call site stay as they are:
+    ```rust
+    fn helper<P: Serialize>(q: &Queue, p: &P) -> honker::Result<i64> {
+        q.typed::<P>().enqueue(p, EnqueueOpts::default())
+    }
+    ```
+    `typed()` clones the handle (an `Arc` and the queue name); it does
+    not touch the database. Widening the signature to
+    `fn helper<P: Serialize>(q: &Queue<P>, p: &P)` also works but
+    changes the helper's call sites too, and
+    `q.enqueue(&serde_json::to_value(p)?, ..)` works at the cost of an
+    intermediate `Value`. Prefer `typed::<P>()`.
 - **Breaking (source), 2 of 2 — `JobRow` is no longer constructible with
   struct literal syntax.** `JobRow<T>` needs a private `PhantomData`
   field to carry `T`, and a private field disables struct literals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,32 @@
 - Regression test claims a job at a deadline with one claim forced to
   return empty: it fails on the unpatched `api.js` and passes on the fix.
 
+## Unreleased — typed Rust jobs
+
+- `honker` (Rust): claimed `Job` and the `JobRow` snapshot now carry all
+  twelve fields core returns — `id`, `queue`, `payload`, `state`,
+  `priority`, `run_at`, `worker_id`, `claim_expires_at`, `attempts`,
+  `max_attempts`, `created_at`, `expires_at`. `Job` keeps `ack`, `retry`,
+  `fail`, `heartbeat`; `JobRow` stays data only.
+- `Queue`, `Job`, `JobRow`, `ClaimWaker`, and `Outbox` gained a payload
+  type parameter defaulting to `serde_json::Value`, so `db.queue(..)`
+  and `db.outbox(..)` behave exactly as before. `db.typed_queue::<T>()`,
+  `db.typed_outbox::<T>()`, and `Queue::typed::<T>()` produce typed
+  handles; `payload_typed()` decodes into the handle's `T` and the
+  existing `payload_as::<U>()` still decodes into anything you name.
+- Payload encoding is unchanged: `Job::payload` stays raw JSON bytes and
+  `JobRow::payload` stays a raw JSON string. The type parameter is
+  compile-time only — honker never validates payload shape in the
+  database, and a mismatch surfaces only as a `serde` error at decode.
+- **Breaking (source):** `Queue::enqueue` / `enqueue_tx` and
+  `Outbox::enqueue` / `enqueue_tx` now take `&T` instead of any
+  `&impl Serialize`, and `Outbox::run_once`'s delivery closure takes `T`
+  instead of `serde_json::Value`. On the default handles `T` is
+  `serde_json::Value`, so `q.enqueue(&json!(..))` is untouched; callers
+  who passed a custom struct to an untyped queue now take a typed handle.
+- A claimed row that comes back without a `worker_id` or
+  `claim_expires_at` is now an error instead of a silent default.
+
 ## Unreleased — typed Node jobs
 
 - Node `Queue`, `Job`, `JobSnapshot`, `ClaimWaker`, and `Outbox` APIs now carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,52 @@
   `JobRow::payload` stays a raw JSON string. The type parameter is
   compile-time only — honker never validates payload shape in the
   database, and a mismatch surfaces only as a `serde` error at decode.
-- **Breaking (source):** `Queue::enqueue` / `enqueue_tx` and
-  `Outbox::enqueue` / `enqueue_tx` now take `&T` instead of any
-  `&impl Serialize`, and `Outbox::run_once`'s delivery closure takes `T`
-  instead of `serde_json::Value`. On the default handles `T` is
-  `serde_json::Value`, so `q.enqueue(&json!(..))` is untouched; callers
-  who passed a custom struct to an untyped queue now take a typed handle.
+- **Breaking (source), 1 of 2 — `enqueue` takes `&T`.**
+  `Queue::enqueue` / `enqueue_tx` and `Outbox::enqueue` / `enqueue_tx`
+  now take `&T` instead of any `&impl Serialize`, and
+  `Outbox::run_once`'s delivery closure takes `T` instead of
+  `serde_json::Value`. On the default handles `T` is `serde_json::Value`,
+  so `q.enqueue(&json!(..))` is untouched. Everything else is
+  `error[E0308]: mismatched types / expected &Value, found &X`:
+  - `q.enqueue(&MyStruct { .. })`, `q.enqueue(&"hello")`,
+    `q.enqueue(&vec![1u8, 2, 3])` — migrate the handle:
+    `db.typed_queue::<MyStruct>(..)` or `q.typed::<MyStruct>()`.
+  - Two different payload types through one handle — you now need one
+    typed handle per type, or keep the handle at `serde_json::Value` and
+    `serde_json::to_value(..)` at the call site.
+  - **A generic helper has no drop-in migration.**
+    `fn helper<P: Serialize>(q: &Queue, p: &P)` no longer compiles; the
+    signature must become `fn helper<P: Serialize>(q: &Queue<P>, p: &P)`,
+    which changes every call site of the helper too, not just the body.
+    If you cannot change the call sites, keep `q: &Queue` and pass
+    `&serde_json::to_value(p)?` instead.
+- **Breaking (source), 2 of 2 — `JobRow` is no longer constructible with
+  struct literal syntax.** `JobRow<T>` needs a private `PhantomData`
+  field to carry `T`, and a private field disables struct literals
+  outside the crate:
+  ```
+  error: cannot construct `JobRow<_>` with struct literal syntax due to private fields
+    = note: ...and other private field `_payload` that was not provided
+  ```
+  There is no form of the type parameter that keeps struct literals
+  working, so this one is kept, not fixed. Build the row through
+  `Deserialize` instead — `serde_json::from_value(json!({ .. }))` or
+  `serde_json::from_str(..)` with the twelve snake_case keys — which is
+  what a fake in your own tests should do anyway.
+- **Not breaking after all:** `JobRow` keeps `Debug`, `Clone`, and
+  `Deserialize`. The generic briefly dropped all three; `Debug` and
+  `Clone` are hand-written (so they no longer require `T: Debug` /
+  `T: Clone`), and `Deserialize` is re-derived with `#[serde(bound = "")]`
+  plus `#[serde(skip)]` on the phantom field. Deserializing a raw
+  `honker_get_job()` blob straight into `JobRow` still compiles and is
+  covered by a test.
+- **Not breaking after all:** `Outbox::new(&db, name, opts)` still infers
+  its payload type. Making `Outbox` generic had moved `new` onto
+  `impl<T>`, which broke a bare `let ob = Outbox::new(..)` with
+  `error[E0282]: type annotations needed for Outbox<_>`. `new` is back on
+  an inherent `impl Outbox<serde_json::Value>`; the generic constructor
+  is the new `Outbox::new_typed`, which is what `Database::typed_outbox`
+  calls.
 - A claimed row that comes back without a `worker_id` or
   `claim_expires_at` is now an error instead of a silent default.
 

--- a/packages/honker-rs/README.md
+++ b/packages/honker-rs/README.md
@@ -27,6 +27,52 @@ if let Some(job) = q.claim_one("worker-1")? {
 
 Delayed jobs use `run_at` / `RunAt`-style options in the binding API.
 
+## Job details
+
+`Job` (a claimed unit of work) and `JobRow` (the read-only snapshot from
+`Queue::get_job`) both carry every field the core claim/lookup returns:
+`id`, `queue`, `payload`, `state`, `priority`, `run_at`, `worker_id`,
+`claim_expires_at`, `attempts`, `max_attempts`, `created_at`, and
+`expires_at`.
+
+`Job` also holds a claim, so it has `ack`, `retry`, `fail`, and
+`heartbeat`, and its `worker_id` / `claim_expires_at` are non-optional.
+`JobRow` is data only: no claim methods, and `worker_id` /
+`claim_expires_at` are `Option` because a pending row has neither.
+
+Payload encoding is unchanged: `Job::payload` is `Vec<u8>` of raw JSON
+bytes and `JobRow::payload` is the raw JSON `String`.
+
+## Typed payloads
+
+`Queue<T>` carries the payload type. `db.queue(..)` still hands back a
+`Queue<serde_json::Value>`; `db.typed_queue::<T>(..)` (or
+`queue.typed::<T>()`) gives you your own type:
+
+```rust
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Email { to: String }
+
+let q = db.typed_queue::<Email>("emails", QueueOpts::default());
+q.enqueue(&Email { to: "alice@example.com".into() }, EnqueueOpts::default())?;
+
+if let Some(job) = q.claim_one("worker-1")? {
+    let email: Email = job.payload_typed()?;
+    job.ack()?;
+}
+```
+
+`payload_typed()` decodes into the queue's `T`; `payload_as::<U>()`
+decodes into anything you name. Both are plain `serde` deserialization.
+
+**honker never checks payload shape.** The type parameter is a
+compile-time convenience for your code only. The database stores the
+payload as opaque JSON text and nothing on the write path validates it,
+so two processes writing the same queue with different types will
+produce rows the other cannot decode. The only error you get is a
+`serde` failure at decode time. Keeping producers and consumers in
+agreement is your job.
+
 Recurring schedules use schedule expressions:
 
 ```rust

--- a/packages/honker-rs/README.md
+++ b/packages/honker-rs/README.md
@@ -65,6 +65,23 @@ if let Some(job) = q.claim_one("worker-1")? {
 `payload_typed()` decodes into the queue's `T`; `payload_as::<U>()`
 decodes into anything you name. Both are plain `serde` deserialization.
 
+There is no `db.queue::<Email>(..)`. Rust cannot put a default on a
+function's type parameter, so making `queue` generic would break every
+bare `let q = db.queue(..)`; `typed_queue` is a separate constructor
+instead. `db.queue::<Email>(..)` therefore fails with `error[E0107]:
+method takes 0 generic arguments` and the compiler's "remove the
+unnecessary generics" hint points the wrong way — reach for
+`db.typed_queue::<Email>(..)` or `q.typed::<Email>()`.
+
+A generic helper that used to take a plain `&Queue` keeps its
+signature — and so its call sites — by reinterpreting inside the body:
+
+```rust
+fn helper<P: serde::Serialize>(q: &honker::Queue, p: &P) -> honker::Result<i64> {
+    q.typed::<P>().enqueue(p, EnqueueOpts::default())
+}
+```
+
 **honker never checks payload shape.** The type parameter is a
 compile-time convenience for your code only. The database stores the
 payload as opaque JSON text and nothing on the write path validates it,

--- a/packages/honker-rs/README.md
+++ b/packages/honker-rs/README.md
@@ -9,21 +9,31 @@ Full docs:
 
 ## Install
 
-Add the crate, and make sure the Honker SQLite extension is available at runtime.
+Add the crate. `honker-core` is linked in and bootstraps the schema, so
+there is no `.dylib` to load at runtime. Use the loadable extension
+(`honker-extension`) only when other SQLite clients share the file.
 
 ## Quick start
 
 ```rust
-let db = honker::Database::open("app.db", "./libhonker_ext.dylib")?;
-let q = db.queue("emails");
+use honker::{Database, EnqueueOpts, QueueOpts};
+use serde_json::json;
 
-q.enqueue(serde_json::json!({ "to": "alice@example.com" }))?;
+let db = Database::open("app.db")?;
+let q = db.queue("emails", QueueOpts::default());
+
+q.enqueue(&json!({ "to": "alice@example.com" }), EnqueueOpts::default())?;
 
 if let Some(job) = q.claim_one("worker-1")? {
-    send_email(&job.payload);
+    let body: serde_json::Value = job.payload_as()?;
+    send_email(&body);
     job.ack()?;
 }
 ```
+
+Runnable versions of this live in
+[`examples/basic.rs`](examples/basic.rs) and
+[`examples/atomic.rs`](examples/atomic.rs), which CI compiles.
 
 Delayed jobs use `run_at` / `RunAt`-style options in the binding API.
 
@@ -93,8 +103,17 @@ agreement is your job.
 Recurring schedules use schedule expressions:
 
 ```rust
+use honker::ScheduledTask;
+
 let sched = db.scheduler();
-sched.add("fast", "emails", "@every 1s", serde_json::json!({ "kind": "tick" }))?;
+sched.add(ScheduledTask {
+    name: "fast".into(),
+    queue: "emails".into(),
+    schedule: "@every 1s".into(),
+    payload: json!({ "kind": "tick" }),
+    priority: 0,
+    expires_s: None,
+})?;
 ```
 
 Supported schedule forms:

--- a/packages/honker-rs/src/lib.rs
+++ b/packages/honker-rs/src/lib.rs
@@ -864,6 +864,8 @@ impl RawJob {
 ///
 /// `payload` stays the raw JSON text exactly as stored. Use
 /// [`JobRow::payload_typed`] to decode it into the queue's `T`.
+#[derive(Deserialize)]
+#[serde(bound = "")]
 pub struct JobRow<T = serde_json::Value> {
     pub id: i64,
     pub queue: String,
@@ -879,6 +881,7 @@ pub struct JobRow<T = serde_json::Value> {
     pub max_attempts: i64,
     pub created_at: i64,
     pub expires_at: Option<i64>,
+    #[serde(skip)]
     _payload: PhantomData<fn(T) -> T>,
 }
 

--- a/packages/honker-rs/src/lib.rs
+++ b/packages/honker-rs/src/lib.rs
@@ -210,7 +210,7 @@ impl Database {
 
     /// Get a named transactional outbox handle carrying `T` payloads.
     pub fn typed_outbox<T>(&self, name: &str, opts: OutboxOpts) -> Outbox<T> {
-        Outbox::new(self, name, opts)
+        Outbox::new_typed(self, name, opts)
     }
 
     /// Get a named stream handle.
@@ -554,8 +554,21 @@ impl<T> Clone for Outbox<T> {
     }
 }
 
-impl<T> Outbox<T> {
+impl Outbox<serde_json::Value> {
+    /// Build an outbox handle carrying `serde_json::Value` payloads.
+    ///
+    /// Deliberately *not* generic: a generic `new` would leave `T`
+    /// uninferrable in `let ob = Outbox::new(..)`. Use
+    /// [`Outbox::new_typed`] or [`Database::typed_outbox`] for a typed
+    /// handle.
     pub fn new(db: &Database, name: &str, opts: OutboxOpts) -> Self {
+        Self::new_typed(db, name, opts)
+    }
+}
+
+impl<T> Outbox<T> {
+    /// Build an outbox handle carrying `T` payloads.
+    pub fn new_typed(db: &Database, name: &str, opts: OutboxOpts) -> Self {
         let queue = db.typed_queue(
             &format!("_outbox:{name}"),
             QueueOpts {

--- a/packages/honker-rs/src/lib.rs
+++ b/packages/honker-rs/src/lib.rs
@@ -2059,6 +2059,71 @@ mod raw_job_mapping {
         assert_eq!(row.expires_at, Some(41), "expires_at");
     }
 
+    /// The wire row minus one key, so the null cases can be built
+    /// without repeating the whole blob.
+    fn raw_without(key: &str) -> RawJob {
+        let mut v = serde_json::json!({
+            "id": 11,
+            "queue": "mapping",
+            "payload": "{\"k\":1}",
+            "state": "processing",
+            "priority": 13,
+            "run_at": 17,
+            "worker_id": "w-19",
+            "claim_expires_at": 23,
+            "attempts": 29,
+            "max_attempts": 31,
+            "created_at": 37,
+            "expires_at": 41
+        });
+        v[key] = serde_json::Value::Null;
+        serde_json::from_value(v).unwrap()
+    }
+
+    #[test]
+    fn into_job_errors_on_a_claim_with_no_worker_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(tmp.path().join("m.db")).unwrap();
+        let err = raw_without("worker_id")
+            .into_job::<serde_json::Value>(db.inner.clone())
+            .expect_err("a claimed row without a holder must not default past");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("worker_id") && msg.contains("11"),
+            "the error should name the field and the job id, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn into_job_errors_on_a_claim_with_no_claim_expires_at() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(tmp.path().join("m.db")).unwrap();
+        let err = raw_without("claim_expires_at")
+            .into_job::<serde_json::Value>(db.inner.clone())
+            .expect_err("a claimed row without a deadline must not default past");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("claim_expires_at") && msg.contains("11"),
+            "the error should name the field and the job id, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn into_row_keeps_the_same_nulls_as_none() {
+        // The snapshot path is the mirror image: a pending row
+        // legitimately has neither, and they must arrive as `None` —
+        // never `Some("")` or `Some(0)`.
+        let row: JobRow = raw_without("worker_id").into_row();
+        assert_eq!(row.worker_id, None, "worker_id null stays None");
+        let row: JobRow = raw_without("claim_expires_at").into_row();
+        assert_eq!(
+            row.claim_expires_at, None,
+            "claim_expires_at null stays None"
+        );
+        let row: JobRow = raw_without("expires_at").into_row();
+        assert_eq!(row.expires_at, None, "expires_at null stays None");
+    }
+
     #[test]
     fn job_row_still_deserializes_from_a_raw_get_job_blob() {
         // Regression guard for the restored `Deserialize` derive: this

--- a/packages/honker-rs/src/lib.rs
+++ b/packages/honker-rs/src/lib.rs
@@ -20,7 +20,41 @@
 //! bootstraps the schema. No `.dylib` load needed at runtime.
 //! Use the loadable extension (`honker-extension`) only when mixing
 //! with other SQLite clients on the same file.
+//!
+//! # Typed payloads
+//!
+//! [`Queue`] carries a payload type parameter. `db.queue(..)` gives
+//! you a [`Queue<serde_json::Value>`]; [`Database::typed_queue`] (or
+//! [`Queue::typed`]) gives you a `Queue<T>` for your own type:
+//!
+//! ```no_run
+//! use honker::{Database, EnqueueOpts, QueueOpts};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct Email { to: String }
+//!
+//! let db = Database::open("app.db").unwrap();
+//! let q = db.typed_queue::<Email>("emails", QueueOpts::default());
+//!
+//! q.enqueue(&Email { to: "alice@example.com".into() }, EnqueueOpts::default()).unwrap();
+//!
+//! if let Some(job) = q.claim_one("worker-1").unwrap() {
+//!     let email: Email = job.payload_typed().unwrap();
+//!     println!("{}", email.to);
+//!     job.ack().unwrap();
+//! }
+//! ```
+//!
+//! The type parameter is a compile-time convenience for **your**
+//! code. honker never checks payload shape: the database stores the
+//! payload as opaque JSON text, and nothing on the write path
+//! validates it. Two processes writing the same queue with different
+//! `T` will happily produce rows the other cannot decode; the only
+//! error you get is a `serde` failure at `payload_typed()` time.
+//! Keeping producers and consumers in agreement is your job.
 
+use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
@@ -146,18 +180,36 @@ impl Database {
         })
     }
 
-    /// Get a named queue handle. Defaults: 300s visibility timeout,
+    /// Get a named queue handle whose payload type is
+    /// `serde_json::Value`. Defaults: 300s visibility timeout,
     /// 3 max attempts.
     pub fn queue(&self, name: &str, opts: QueueOpts) -> Queue {
+        self.typed_queue(name, opts)
+    }
+
+    /// Get a named queue handle whose payloads are your own type.
+    ///
+    /// `T` only constrains this handle's `enqueue` argument and the
+    /// type `payload_typed()` decodes into. honker stores the payload
+    /// as opaque JSON and never validates its shape — see the crate
+    /// docs.
+    pub fn typed_queue<T>(&self, name: &str, opts: QueueOpts) -> Queue<T> {
         Queue {
             inner: self.inner.clone(),
             name: name.to_string(),
             opts,
+            _payload: PhantomData,
         }
     }
 
-    /// Get a named transactional outbox handle.
+    /// Get a named transactional outbox handle carrying
+    /// `serde_json::Value` payloads.
     pub fn outbox(&self, name: &str, opts: OutboxOpts) -> Outbox {
+        Outbox::new(self, name, opts)
+    }
+
+    /// Get a named transactional outbox handle carrying `T` payloads.
+    pub fn typed_outbox<T>(&self, name: &str, opts: OutboxOpts) -> Outbox<T> {
         Outbox::new(self, name, opts)
     }
 
@@ -443,11 +495,27 @@ pub struct EnqueueOpts {
     pub expires: Option<i64>,
 }
 
-#[derive(Clone)]
-pub struct Queue {
+/// A named queue handle. `T` is the payload type this handle
+/// enqueues and decodes; it defaults to `serde_json::Value`.
+///
+/// The parameter is compile-time only. honker does not validate
+/// payload shape in the database — see the crate docs.
+pub struct Queue<T = serde_json::Value> {
     inner: Arc<Inner>,
     name: String,
     opts: QueueOpts,
+    _payload: PhantomData<fn(T) -> T>,
+}
+
+impl<T> Clone for Queue<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            name: self.name.clone(),
+            opts: self.opts.clone(),
+            _payload: PhantomData,
+        }
+    }
 }
 
 /// Transactional side-effect delivery options.
@@ -468,16 +536,27 @@ impl Default for OutboxOpts {
     }
 }
 
-#[derive(Clone)]
-pub struct Outbox {
+/// A transactional outbox handle. `T` is the payload type, and
+/// defaults to `serde_json::Value`.
+pub struct Outbox<T = serde_json::Value> {
     name: String,
-    queue: Queue,
+    queue: Queue<T>,
     base_backoff_s: i64,
 }
 
-impl Outbox {
+impl<T> Clone for Outbox<T> {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            queue: self.queue.clone(),
+            base_backoff_s: self.base_backoff_s,
+        }
+    }
+}
+
+impl<T> Outbox<T> {
     pub fn new(db: &Database, name: &str, opts: OutboxOpts) -> Self {
-        let queue = db.queue(
+        let queue = db.typed_queue(
             &format!("_outbox:{name}"),
             QueueOpts {
                 visibility_timeout_s: opts.visibility_timeout_s,
@@ -495,33 +574,35 @@ impl Outbox {
         &self.name
     }
 
-    pub fn queue(&self) -> &Queue {
+    pub fn queue(&self) -> &Queue<T> {
         &self.queue
     }
 
-    pub fn enqueue<P: Serialize>(&self, payload: &P, opts: EnqueueOpts) -> Result<i64> {
+    pub fn enqueue(&self, payload: &T, opts: EnqueueOpts) -> Result<i64>
+    where
+        T: Serialize,
+    {
         self.queue.enqueue(payload, opts)
     }
 
-    pub fn enqueue_tx<P: Serialize>(
-        &self,
-        tx: &Transaction<'_>,
-        payload: &P,
-        opts: EnqueueOpts,
-    ) -> Result<i64> {
+    pub fn enqueue_tx(&self, tx: &Transaction<'_>, payload: &T, opts: EnqueueOpts) -> Result<i64>
+    where
+        T: Serialize,
+    {
         self.queue.enqueue_tx(tx, payload, opts)
     }
 
     /// Claim and deliver one outbox job. Returns false if no job was ready.
     pub fn run_once<F, E>(&self, worker_id: &str, mut delivery: F) -> Result<bool>
     where
-        F: FnMut(serde_json::Value) -> std::result::Result<(), E>,
+        T: DeserializeOwned,
+        F: FnMut(T) -> std::result::Result<(), E>,
         E: std::fmt::Display,
     {
         let Some(job) = self.queue.claim_one(worker_id)? else {
             return Ok(false);
         };
-        let payload: serde_json::Value = serde_json::from_slice(&job.payload)?;
+        let payload: T = job.payload_typed()?;
         match delivery(payload) {
             Ok(()) => {
                 if !job.ack()? {
@@ -549,13 +630,30 @@ impl Outbox {
     }
 }
 
-impl Queue {
+impl<T> Queue<T> {
     pub fn name(&self) -> &str {
         &self.name
     }
 
+    /// Reinterpret this handle's payload type. Same queue, same
+    /// options, different compile-time payload type. Nothing is
+    /// re-encoded or re-validated — rows already on disk are
+    /// untouched, and a mismatched `U` only surfaces as a `serde`
+    /// error when you call `payload_typed()`.
+    pub fn typed<U>(&self) -> Queue<U> {
+        Queue {
+            inner: self.inner.clone(),
+            name: self.name.clone(),
+            opts: self.opts.clone(),
+            _payload: PhantomData,
+        }
+    }
+
     /// Enqueue on a freshly acquired connection.
-    pub fn enqueue<P: Serialize>(&self, payload: &P, opts: EnqueueOpts) -> Result<i64> {
+    pub fn enqueue(&self, payload: &T, opts: EnqueueOpts) -> Result<i64>
+    where
+        T: Serialize,
+    {
         let json = serde_json::to_string(payload)?;
         Ok(self
             .inner
@@ -564,12 +662,10 @@ impl Queue {
 
     /// Enqueue inside an open transaction. Atomic with whatever else
     /// ran on the same `tx`.
-    pub fn enqueue_tx<P: Serialize>(
-        &self,
-        tx: &Transaction<'_>,
-        payload: &P,
-        opts: EnqueueOpts,
-    ) -> Result<i64> {
+    pub fn enqueue_tx(&self, tx: &Transaction<'_>, payload: &T, opts: EnqueueOpts) -> Result<i64>
+    where
+        T: Serialize,
+    {
         let json = serde_json::to_string(payload)?;
         Ok(enqueue_on(
             tx.conn(),
@@ -581,7 +677,7 @@ impl Queue {
     }
 
     /// Atomically claim up to `n` jobs.
-    pub fn claim_batch(&self, worker_id: &str, n: i64) -> Result<Vec<Job>> {
+    pub fn claim_batch(&self, worker_id: &str, n: i64) -> Result<Vec<Job<T>>> {
         let rows_json: String = self.inner.with_conn(|c| {
             c.query_row(
                 "SELECT honker_claim_batch(?1, ?2, ?3, ?4)",
@@ -590,21 +686,13 @@ impl Queue {
             )
         })?;
         let raw: Vec<RawJob> = serde_json::from_str(&rows_json)?;
-        Ok(raw
-            .into_iter()
-            .map(|r| Job {
-                inner: self.inner.clone(),
-                id: r.id,
-                queue: r.queue,
-                payload: r.payload.into_bytes(),
-                worker_id: r.worker_id,
-                attempts: r.attempts,
-            })
-            .collect())
+        raw.into_iter()
+            .map(|r| r.into_job(self.inner.clone()))
+            .collect()
     }
 
     /// Claim a single job, or `None` if the queue is empty.
-    pub fn claim_one(&self, worker_id: &str) -> Result<Option<Job>> {
+    pub fn claim_one(&self, worker_id: &str) -> Result<Option<Job<T>>> {
         Ok(self.claim_batch(worker_id, 1)?.into_iter().next())
     }
 
@@ -639,14 +727,18 @@ impl Queue {
 
     /// Read a single job row by id. Returns `Some(JobRow)` or `None`
     /// on miss (ack'd, dead'd, or never existed). Pure read.
-    pub fn get_job(&self, job_id: i64) -> Result<Option<JobRow>> {
+    ///
+    /// NOT queue-scoped: job ids are globally unique and this lookup
+    /// hits any queue's row. Scoping is tracked in #134.
+    pub fn get_job(&self, job_id: i64) -> Result<Option<JobRow<T>>> {
         let json: String = self.inner.with_conn(|c| {
             c.query_row("SELECT honker_get_job(?1)", params![job_id], |r| r.get(0))
         })?;
         if json.is_empty() {
             return Ok(None);
         }
-        Ok(Some(serde_json::from_str(&json)?))
+        let raw: RawJob = serde_json::from_str(&json)?;
+        Ok(Some(raw.into_row()))
     }
 
     /// Sweep expired processing rows back to pending. Returns rows touched.
@@ -662,7 +754,7 @@ impl Queue {
     /// by dropping the `Database` or calling `stop()` on a shared
     /// `Arc<AtomicBool>` you thread in yourself — this helper is the
     /// minimum that actually replaces a polling loop.
-    pub fn claim_waker(&self) -> ClaimWaker {
+    pub fn claim_waker(&self) -> ClaimWaker<T> {
         let (sub_id, rx) = self.inner.updates.subscribe();
         ClaimWaker {
             inner: self.inner.clone(),
@@ -670,6 +762,7 @@ impl Queue {
             visibility_timeout_s: self.opts.visibility_timeout_s,
             sub_id,
             rx,
+            _payload: PhantomData,
         }
     }
 }
@@ -696,25 +789,87 @@ fn enqueue_on(
     )
 }
 
+/// The wire shape shared by `honker_claim_batch()` and
+/// `honker_get_job()`. Both return the same twelve snake_case keys.
 #[derive(Deserialize)]
 struct RawJob {
     id: i64,
     queue: String,
     payload: String,
-    worker_id: String,
+    state: String,
+    priority: i64,
+    run_at: i64,
+    worker_id: Option<String>,
+    claim_expires_at: Option<i64>,
     attempts: i64,
-    #[serde(rename = "claim_expires_at")]
-    #[allow(dead_code)]
-    claim_expires_at: i64,
+    max_attempts: i64,
+    created_at: i64,
+    expires_at: Option<i64>,
 }
 
-/// One row from `Queue::get_job()`. Pure data, no claim semantics.
-#[derive(Debug, Deserialize, Clone)]
-pub struct JobRow {
+impl RawJob {
+    /// A claimed row always carries a holder and a claim deadline. If
+    /// core ever hands one back without them, that is a bug worth
+    /// crashing the claim on, not defaulting past.
+    fn into_job<T>(self, inner: Arc<Inner>) -> Result<Job<T>> {
+        let id = self.id;
+        let worker_id = self.worker_id.ok_or_else(|| {
+            Error::Core(format!("claimed job {id} came back without a worker_id"))
+        })?;
+        let claim_expires_at = self.claim_expires_at.ok_or_else(|| {
+            Error::Core(format!(
+                "claimed job {id} came back without a claim_expires_at"
+            ))
+        })?;
+        Ok(Job {
+            inner,
+            id,
+            queue: self.queue,
+            payload: self.payload.into_bytes(),
+            state: self.state,
+            priority: self.priority,
+            run_at: self.run_at,
+            worker_id,
+            claim_expires_at,
+            attempts: self.attempts,
+            max_attempts: self.max_attempts,
+            created_at: self.created_at,
+            expires_at: self.expires_at,
+            _payload: PhantomData,
+        })
+    }
+
+    fn into_row<T>(self) -> JobRow<T> {
+        JobRow {
+            id: self.id,
+            queue: self.queue,
+            payload: self.payload,
+            state: self.state,
+            priority: self.priority,
+            run_at: self.run_at,
+            worker_id: self.worker_id,
+            claim_expires_at: self.claim_expires_at,
+            attempts: self.attempts,
+            max_attempts: self.max_attempts,
+            created_at: self.created_at,
+            expires_at: self.expires_at,
+            _payload: PhantomData,
+        }
+    }
+}
+
+/// One row from `Queue::get_job()`. Pure data, no claim semantics —
+/// there is no ack/retry/fail/heartbeat here because a snapshot does
+/// not hold a claim.
+///
+/// `payload` stays the raw JSON text exactly as stored. Use
+/// [`JobRow::payload_typed`] to decode it into the queue's `T`.
+pub struct JobRow<T = serde_json::Value> {
     pub id: i64,
     pub queue: String,
     /// JSON-serialized payload string.
     pub payload: String,
+    /// `"pending"` or `"processing"`.
     pub state: String,
     pub priority: i64,
     pub run_at: i64,
@@ -724,20 +879,119 @@ pub struct JobRow {
     pub max_attempts: i64,
     pub created_at: i64,
     pub expires_at: Option<i64>,
+    _payload: PhantomData<fn(T) -> T>,
+}
+
+impl<T> JobRow<T> {
+    /// Decode `payload` into the queue's payload type. Pure `serde`
+    /// deserialization — honker performs no shape check of its own.
+    pub fn payload_typed(&self) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        Ok(serde_json::from_str(&self.payload)?)
+    }
+
+    /// Decode `payload` into any type you name.
+    pub fn payload_as<U: DeserializeOwned>(&self) -> Result<U> {
+        Ok(serde_json::from_str(&self.payload)?)
+    }
+}
+
+impl<T> Clone for JobRow<T> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            queue: self.queue.clone(),
+            payload: self.payload.clone(),
+            state: self.state.clone(),
+            priority: self.priority,
+            run_at: self.run_at,
+            worker_id: self.worker_id.clone(),
+            claim_expires_at: self.claim_expires_at,
+            attempts: self.attempts,
+            max_attempts: self.max_attempts,
+            created_at: self.created_at,
+            expires_at: self.expires_at,
+            _payload: PhantomData,
+        }
+    }
+}
+
+impl<T> std::fmt::Debug for JobRow<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JobRow")
+            .field("id", &self.id)
+            .field("queue", &self.queue)
+            .field("payload", &self.payload)
+            .field("state", &self.state)
+            .field("priority", &self.priority)
+            .field("run_at", &self.run_at)
+            .field("worker_id", &self.worker_id)
+            .field("claim_expires_at", &self.claim_expires_at)
+            .field("attempts", &self.attempts)
+            .field("max_attempts", &self.max_attempts)
+            .field("created_at", &self.created_at)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
 }
 
 /// A claimed unit of work. `payload` is raw JSON bytes.
-pub struct Job {
+///
+/// Carries the same twelve fields as [`JobRow`] plus the claim
+/// methods: `ack`, `retry`, `fail`, `heartbeat`. `state` is always
+/// `"processing"` and `worker_id` / `claim_expires_at` are never null
+/// because holding a claim is what makes this a `Job`.
+pub struct Job<T = serde_json::Value> {
     inner: Arc<Inner>,
     pub id: i64,
     pub queue: String,
     pub payload: Vec<u8>,
+    /// Always `"processing"` for a claimed job.
+    pub state: String,
+    pub priority: i64,
+    pub run_at: i64,
     pub worker_id: String,
+    pub claim_expires_at: i64,
     pub attempts: i64,
+    pub max_attempts: i64,
+    pub created_at: i64,
+    pub expires_at: Option<i64>,
+    _payload: PhantomData<fn(T) -> T>,
 }
 
-impl Job {
-    pub fn payload_as<T: DeserializeOwned>(&self) -> Result<T> {
+impl<T> std::fmt::Debug for Job<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Job")
+            .field("id", &self.id)
+            .field("queue", &self.queue)
+            .field("payload", &String::from_utf8_lossy(&self.payload))
+            .field("state", &self.state)
+            .field("priority", &self.priority)
+            .field("run_at", &self.run_at)
+            .field("worker_id", &self.worker_id)
+            .field("claim_expires_at", &self.claim_expires_at)
+            .field("attempts", &self.attempts)
+            .field("max_attempts", &self.max_attempts)
+            .field("created_at", &self.created_at)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+impl<T> Job<T> {
+    /// Decode `payload` into the queue's payload type. Pure `serde`
+    /// deserialization — honker performs no shape check of its own.
+    pub fn payload_typed(&self) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        Ok(serde_json::from_slice(&self.payload)?)
+    }
+
+    /// Decode `payload` into any type you name.
+    pub fn payload_as<U: DeserializeOwned>(&self) -> Result<U> {
         Ok(serde_json::from_slice(&self.payload)?)
     }
 
@@ -794,18 +1048,19 @@ impl Job {
 
 /// WAL-wake claim helper. Call `next(worker_id)` to claim the next
 /// available job; blocks until one arrives.
-pub struct ClaimWaker {
+pub struct ClaimWaker<T = serde_json::Value> {
     inner: Arc<Inner>,
     name: String,
     visibility_timeout_s: i64,
     sub_id: u64,
     rx: Receiver<()>,
+    _payload: PhantomData<fn(T) -> T>,
 }
 
-impl ClaimWaker {
+impl<T> ClaimWaker<T> {
     /// Block until a job is claimable, then claim and return it.
     /// Returns `None` only if the shared update watcher is dropped.
-    pub fn next(&self, worker_id: &str) -> Result<Option<Job>> {
+    pub fn next(&self, worker_id: &str) -> Result<Option<Job<T>>> {
         loop {
             let rows_json: String = self.inner.with_conn(|c| {
                 c.query_row(
@@ -816,14 +1071,7 @@ impl ClaimWaker {
             })?;
             let raw: Vec<RawJob> = serde_json::from_str(&rows_json)?;
             if let Some(r) = raw.into_iter().next() {
-                return Ok(Some(Job {
-                    inner: self.inner.clone(),
-                    id: r.id,
-                    queue: r.queue,
-                    payload: r.payload.into_bytes(),
-                    worker_id: r.worker_id,
-                    attempts: r.attempts,
-                }));
+                return Ok(Some(r.into_job(self.inner.clone())?));
             }
             let next_at: i64 = self.inner.with_conn(|c| {
                 c.query_row(
@@ -846,7 +1094,7 @@ impl ClaimWaker {
 
     /// Try to claim without blocking. Returns `None` if the queue is
     /// empty right now.
-    pub fn try_next(&self, worker_id: &str) -> Result<Option<Job>> {
+    pub fn try_next(&self, worker_id: &str) -> Result<Option<Job<T>>> {
         let rows_json: String = self.inner.with_conn(|c| {
             c.query_row(
                 "SELECT honker_claim_batch(?1, ?2, ?3, ?4)",
@@ -855,18 +1103,14 @@ impl ClaimWaker {
             )
         })?;
         let raw: Vec<RawJob> = serde_json::from_str(&rows_json)?;
-        Ok(raw.into_iter().next().map(|r| Job {
-            inner: self.inner.clone(),
-            id: r.id,
-            queue: r.queue,
-            payload: r.payload.into_bytes(),
-            worker_id: r.worker_id,
-            attempts: r.attempts,
-        }))
+        raw.into_iter()
+            .next()
+            .map(|r| r.into_job(self.inner.clone()))
+            .transpose()
     }
 }
 
-impl Drop for ClaimWaker {
+impl<T> Drop for ClaimWaker<T> {
     fn drop(&mut self) {
         self.inner.updates.unsubscribe(self.sub_id);
     }

--- a/packages/honker-rs/src/lib.rs
+++ b/packages/honker-rs/src/lib.rs
@@ -1964,3 +1964,85 @@ impl Drop for Lock {
         }
     }
 }
+
+#[cfg(test)]
+mod raw_job_mapping {
+    //! `state` on a claimed job is always `"processing"` end-to-end, so
+    //! no integration test can tell a real read from a hardcoded
+    //! `"processing"`. These tests drive `RawJob`'s two conversions
+    //! directly with a synthetic wire row whose every value is
+    //! distinct, so neither a swap nor a constant survives.
+    use super::*;
+
+    fn raw(state: &str) -> RawJob {
+        serde_json::from_value(serde_json::json!({
+            "id": 11,
+            "queue": "mapping",
+            "payload": "{\"k\":1}",
+            "state": state,
+            "priority": 13,
+            "run_at": 17,
+            "worker_id": "w-19",
+            "claim_expires_at": 23,
+            "attempts": 29,
+            "max_attempts": 31,
+            "created_at": 37,
+            "expires_at": 41
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn into_job_reads_every_field_from_the_row() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Database::open(tmp.path().join("m.db")).unwrap();
+        let job: Job = raw("sentinel-state").into_job(db.inner.clone()).unwrap();
+
+        assert_eq!(job.state, "sentinel-state", "state, not a constant");
+        assert_eq!(job.id, 11, "id");
+        assert_eq!(job.queue, "mapping", "queue");
+        assert_eq!(job.payload, br#"{"k":1}"#.to_vec(), "payload");
+        assert_eq!(job.priority, 13, "priority");
+        assert_eq!(job.run_at, 17, "run_at");
+        assert_eq!(job.worker_id, "w-19", "worker_id");
+        assert_eq!(job.claim_expires_at, 23, "claim_expires_at");
+        assert_eq!(job.attempts, 29, "attempts");
+        assert_eq!(job.max_attempts, 31, "max_attempts");
+        assert_eq!(job.created_at, 37, "created_at");
+        assert_eq!(job.expires_at, Some(41), "expires_at");
+    }
+
+    #[test]
+    fn into_row_reads_every_field_from_the_row() {
+        let row: JobRow = raw("sentinel-state").into_row();
+
+        assert_eq!(row.state, "sentinel-state", "state, not a constant");
+        assert_eq!(row.id, 11, "id");
+        assert_eq!(row.queue, "mapping", "queue, not a constant");
+        assert_eq!(row.payload, r#"{"k":1}"#, "payload");
+        assert_eq!(row.priority, 13, "priority, not a constant");
+        assert_eq!(row.run_at, 17, "run_at");
+        assert_eq!(row.worker_id.as_deref(), Some("w-19"), "worker_id");
+        assert_eq!(row.claim_expires_at, Some(23), "claim_expires_at");
+        assert_eq!(row.attempts, 29, "attempts");
+        assert_eq!(row.max_attempts, 31, "max_attempts, not a constant");
+        assert_eq!(row.created_at, 37, "created_at");
+        assert_eq!(row.expires_at, Some(41), "expires_at");
+    }
+
+    #[test]
+    fn job_row_still_deserializes_from_a_raw_get_job_blob() {
+        // Regression guard for the restored `Deserialize` derive: this
+        // is the documented way to build a `JobRow` outside the crate.
+        let row: JobRow = serde_json::from_str(
+            r#"{"id":11,"queue":"mapping","payload":"{}","state":"pending",
+                "priority":13,"run_at":17,"worker_id":null,
+                "claim_expires_at":null,"attempts":0,"max_attempts":31,
+                "created_at":37,"expires_at":null}"#,
+        )
+        .unwrap();
+        assert_eq!(row.id, 11);
+        assert_eq!(row.priority, 13);
+        assert_eq!(row.worker_id, None);
+    }
+}

--- a/packages/honker-rs/src/lib.rs
+++ b/packages/honker-rs/src/lib.rs
@@ -183,6 +183,16 @@ impl Database {
     /// Get a named queue handle whose payload type is
     /// `serde_json::Value`. Defaults: 300s visibility timeout,
     /// 3 max attempts.
+    ///
+    /// **For your own payload type, use
+    /// [`typed_queue`](Database::typed_queue) — not this method.**
+    /// `queue` is deliberately non-generic so that
+    /// `let q = db.queue(..)` keeps inferring, which means
+    /// `db.queue::<Email>(..)` is a compile error ("method takes 0
+    /// generic arguments") and `let q: Queue<Email> = db.queue(..)`
+    /// is a type mismatch. Neither message will point you here.
+    /// Reach for `db.typed_queue::<Email>(..)`, or
+    /// [`Queue::typed`] on a handle you already hold.
     pub fn queue(&self, name: &str, opts: QueueOpts) -> Queue {
         self.typed_queue(name, opts)
     }
@@ -498,6 +508,12 @@ pub struct EnqueueOpts {
 /// A named queue handle. `T` is the payload type this handle
 /// enqueues and decodes; it defaults to `serde_json::Value`.
 ///
+/// Build one with [`Database::queue`] for the `serde_json::Value`
+/// default, or [`Database::typed_queue`] / [`Queue::typed`] for your
+/// own type. A default type parameter cannot live on a function, so
+/// `Database::queue` is not generic and there is a separate
+/// constructor rather than one inferring `queue::<T>()`.
+///
 /// The parameter is compile-time only. honker does not validate
 /// payload shape in the database — see the crate docs.
 pub struct Queue<T = serde_json::Value> {
@@ -653,6 +669,19 @@ impl<T> Queue<T> {
     /// re-encoded or re-validated — rows already on disk are
     /// untouched, and a mismatched `U` only surfaces as a `serde`
     /// error when you call `payload_typed()`.
+    ///
+    /// This is also how a generic helper keeps taking a plain
+    /// `&Queue` after `enqueue` narrowed to `&T`: change the body,
+    /// not the signature, so the helper's own call sites are
+    /// untouched.
+    ///
+    /// ```no_run
+    /// # use honker::{EnqueueOpts, Queue};
+    /// # use serde::Serialize;
+    /// fn helper<P: Serialize>(q: &Queue, p: &P) -> honker::Result<i64> {
+    ///     q.typed::<P>().enqueue(p, EnqueueOpts::default())
+    /// }
+    /// ```
     pub fn typed<U>(&self) -> Queue<U> {
         Queue {
             inner: self.inner.clone(),

--- a/packages/honker-rs/tests/job_details.rs
+++ b/packages/honker-rs/tests/job_details.rs
@@ -435,6 +435,157 @@ fn typed_queue_reads_a_payload_another_writer_produced() {
 }
 
 #[test]
+fn typed_outbox_delivers_the_payload_type() {
+    // `db.typed_outbox`, `Outbox<T>::enqueue_tx` and `run_once`'s
+    // `FnMut(T)` closure are all new surface. `run_once`'s closure
+    // argument changing from `serde_json::Value` to `T` is one of the
+    // disclosed source breaks, so it needs a test that actually runs
+    // a typed delivery.
+    let (_tmp, db) = open_db();
+    let ob = db.typed_outbox::<Email>("mail", honker::OutboxOpts::default());
+    assert_eq!(ob.queue().name(), "_outbox:mail", "outbox queue naming");
+
+    let sent = Email {
+        version: 3,
+        to: "frank@example.com".into(),
+        subject: "typed outbox".into(),
+    };
+    {
+        let tx = db.transaction().unwrap();
+        ob.enqueue_tx(&tx, &sent, EnqueueOpts::default()).unwrap();
+        tx.rollback().unwrap();
+    }
+    assert!(
+        !ob.run_once("w", |_: Email| Ok::<(), String>(())).unwrap(),
+        "a rolled-back outbox enqueue delivers nothing"
+    );
+
+    {
+        let tx = db.transaction().unwrap();
+        ob.enqueue_tx(&tx, &sent, EnqueueOpts::default()).unwrap();
+        tx.commit().unwrap();
+    }
+    let mut delivered: Option<Email> = None;
+    assert!(
+        ob.run_once("w", |e: Email| {
+            delivered = Some(e);
+            Ok::<(), String>(())
+        })
+        .unwrap(),
+        "the committed row delivers"
+    );
+    assert_eq!(
+        delivered.unwrap(),
+        sent,
+        "the delivery closure receives the queue's payload type, decoded"
+    );
+    assert!(
+        !ob.run_once("w", |_: Email| Ok::<(), String>(())).unwrap(),
+        "nothing left after the ack"
+    );
+}
+
+#[test]
+fn typed_claim_waker_hands_back_a_typed_job() {
+    // `ClaimWaker<T>` carries the parameter through to `Job<T>`, and
+    // `try_next` routes through the same `RawJob::into_job` as
+    // `claim_batch`, so the full field set has to survive that path
+    // too.
+    let (_tmp, db) = open_db();
+    let q = db.typed_queue::<Email>(
+        "waker",
+        QueueOpts {
+            visibility_timeout_s: VISIBILITY_TIMEOUT_S,
+            max_attempts: MAX_ATTEMPTS,
+        },
+    );
+    let sent = Email {
+        version: 4,
+        to: "grace@example.com".into(),
+        subject: "woken".into(),
+    };
+    q.enqueue(
+        &sent,
+        EnqueueOpts {
+            priority: LOW_PRIORITY,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let waker = q.claim_waker();
+    let job = waker.try_next("w-waker").unwrap().expect("claim");
+    assert_eq!(job.payload_typed().unwrap(), sent, "typed payload");
+    assert_eq!(job.state, "processing", "state");
+    assert_eq!(job.worker_id, "w-waker", "worker_id");
+    assert_eq!(
+        job.priority, LOW_PRIORITY,
+        "priority survives the waker path"
+    );
+    assert_eq!(
+        job.max_attempts, MAX_ATTEMPTS,
+        "max_attempts survives the waker path"
+    );
+    assert_eq!(job.attempts, 1, "attempts");
+    assert!(job.ack().unwrap());
+    assert!(
+        waker.try_next("w-waker").unwrap().is_none(),
+        "nothing left after the ack"
+    );
+}
+
+/// A generic helper that took a plain `&Queue` before `enqueue`
+/// narrowed to `&T`. `typed::<P>()` keeps its signature — and so
+/// every one of its call sites — unchanged. This is the migration the
+/// CHANGELOG points at, compiled.
+fn generic_helper<P: Serialize>(q: &honker::Queue, p: &P) -> honker::Result<i64> {
+    q.typed::<P>().enqueue(p, EnqueueOpts::default())
+}
+
+#[test]
+fn a_generic_helper_migrates_without_touching_its_call_sites() {
+    let (_tmp, db) = open_db();
+    let q = db.queue("helper", QueueOpts::default());
+    let sent = Email {
+        version: 5,
+        to: "heidi@example.com".into(),
+        subject: "body-only migration".into(),
+    };
+    // Call site is byte-identical to the pre-generic one: a plain
+    // `db.queue(..)` handle passed by reference.
+    let id = generic_helper(&q, &sent).unwrap();
+    // The `serde_json::to_value` escape hatch also still compiles.
+    let id2 = q
+        .enqueue(
+            &serde_json::to_value(&sent).unwrap(),
+            EnqueueOpts::default(),
+        )
+        .unwrap();
+
+    let typed = q.typed::<Email>();
+    let helper_row = typed.get_job(id).unwrap().expect("helper row");
+    assert_eq!(
+        helper_row.payload_typed().unwrap(),
+        sent,
+        "the helper wrote a decodable row"
+    );
+    // `get_job` is not queue-scoped (#134), so the payload assertion
+    // alone would pass even if `typed()` had sent the row to some
+    // other queue. Pin the queue name too.
+    assert_eq!(
+        helper_row.queue, "helper",
+        "typed() must keep the handle's queue, not retarget it"
+    );
+    let hatch_row = typed.get_job(id2).unwrap().expect("escape-hatch row");
+    assert_eq!(
+        hatch_row.payload_typed().unwrap(),
+        sent,
+        "so did the escape hatch"
+    );
+    assert_eq!(hatch_row.queue, "helper", "escape hatch stays on the queue");
+}
+
+#[test]
 fn payload_shape_is_never_validated_by_honker() {
     // The type parameter is a compile-time convenience only. honker
     // stores whatever JSON you hand it; the mismatch only surfaces

--- a/packages/honker-rs/tests/job_details.rs
+++ b/packages/honker-rs/tests/job_details.rs
@@ -1,0 +1,414 @@
+//! Issue #136: claimed jobs and read-only snapshots must carry every
+//! field `honker_claim_batch()` / `honker_get_job()` return, and the
+//! typed `Queue<T>` must decode payloads into the caller's type.
+//!
+//! Every value asserted here is chosen to be distinguishable from the
+//! others. Defaults (`priority` 0, `max_attempts` 3, a 300s
+//! visibility timeout, `run_at` == `created_at`) would let a wrong
+//! field pass for the right one, so the fixture uses odd constants
+//! and back-dates `run_at` well away from `created_at`.
+
+use honker::{Database, EnqueueOpts, QueueOpts};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn open_db() -> (tempfile::TempDir, Database) {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = Database::open(tmp.path().join("t.db")).unwrap();
+    (tmp, db)
+}
+
+fn now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+/// Fixture constants. All distinct, none a default, none derivable
+/// from another by accident.
+const VISIBILITY_TIMEOUT_S: i64 = 137;
+const MAX_ATTEMPTS: i64 = 9;
+const HIGH_PRIORITY: i64 = 42;
+const LOW_PRIORITY: i64 = 7;
+const RUN_AT_BACKDATE_S: i64 = 300;
+const EXPIRES_S: i64 = 9_000;
+
+fn parity_queue(db: &Database) -> honker::Queue {
+    db.queue(
+        "details",
+        QueueOpts {
+            visibility_timeout_s: VISIBILITY_TIMEOUT_S,
+            max_attempts: MAX_ATTEMPTS,
+        },
+    )
+}
+
+#[test]
+fn claimed_job_carries_every_core_field() {
+    let (_tmp, db) = open_db();
+    let q = parity_queue(&db);
+
+    let enqueued_at_lo = now();
+    // Back-dated run_at: claimable immediately, but far enough from
+    // created_at that swapping the two fields cannot pass.
+    let high_run_at = enqueued_at_lo - RUN_AT_BACKDATE_S;
+    let high_id = q
+        .enqueue(
+            &json!({"to": "alice@example.com", "v": 1}),
+            EnqueueOpts {
+                run_at: Some(high_run_at),
+                priority: HIGH_PRIORITY,
+                expires: Some(EXPIRES_S),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let low_run_at = enqueued_at_lo - (RUN_AT_BACKDATE_S / 2);
+    let low_id = q
+        .enqueue(
+            &json!({"to": "bob@example.com", "v": 1}),
+            EnqueueOpts {
+                run_at: Some(low_run_at),
+                priority: LOW_PRIORITY,
+                // No expires: proves expires_at is read per-row and
+                // not filled from a constant.
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let enqueued_at_hi = now();
+
+    let claim_lo = now();
+    let jobs = q.claim_batch("worker-parity", 2).unwrap();
+    let claim_hi = now();
+    assert_eq!(jobs.len(), 2, "both jobs should claim");
+
+    // priority DESC decides the order, so the high-priority row is first.
+    let high = &jobs[0];
+    let low = &jobs[1];
+
+    assert_eq!(high.id, high_id, "id");
+    assert_eq!(low.id, low_id, "id of the second row");
+    assert_eq!(high.queue, "details", "queue");
+
+    assert_eq!(
+        String::from_utf8(high.payload.clone()).unwrap(),
+        r#"{"to":"alice@example.com","v":1}"#,
+        "payload stays the raw JSON text as enqueued"
+    );
+    let decoded: serde_json::Value = high.payload_as().unwrap();
+    assert_eq!(decoded["to"], "alice@example.com", "decoded payload");
+
+    assert_eq!(high.state, "processing", "state");
+
+    assert_eq!(high.priority, HIGH_PRIORITY, "priority");
+    assert_eq!(
+        low.priority, LOW_PRIORITY,
+        "priority is per-row, not a constant"
+    );
+
+    assert_eq!(high.run_at, high_run_at, "run_at");
+    assert_eq!(low.run_at, low_run_at, "run_at is per-row");
+    assert_ne!(
+        high.run_at, high.created_at,
+        "run_at must not be created_at"
+    );
+
+    assert_eq!(high.worker_id, "worker-parity", "worker_id");
+
+    assert!(
+        high.claim_expires_at >= claim_lo + VISIBILITY_TIMEOUT_S
+            && high.claim_expires_at <= claim_hi + VISIBILITY_TIMEOUT_S,
+        "claim_expires_at should be the claim instant + {VISIBILITY_TIMEOUT_S}s, \
+         got {} against a claim window of [{claim_lo}, {claim_hi}]",
+        high.claim_expires_at
+    );
+
+    assert_eq!(high.attempts, 1, "attempts after the first claim");
+    assert_eq!(high.max_attempts, MAX_ATTEMPTS, "max_attempts");
+
+    assert!(
+        high.created_at >= enqueued_at_lo && high.created_at <= enqueued_at_hi,
+        "created_at should sit inside the enqueue window \
+         [{enqueued_at_lo}, {enqueued_at_hi}], got {}",
+        high.created_at
+    );
+
+    let expires_at = high.expires_at.expect("expires_at set for the high row");
+    assert!(
+        expires_at >= enqueued_at_lo + EXPIRES_S && expires_at <= enqueued_at_hi + EXPIRES_S,
+        "expires_at should be the enqueue instant + {EXPIRES_S}s, got {expires_at} \
+         against an enqueue window of [{enqueued_at_lo}, {enqueued_at_hi}]"
+    );
+    assert_eq!(
+        low.expires_at, None,
+        "expires_at stays null when the enqueue set no expiry"
+    );
+}
+
+#[test]
+fn claimed_job_attempts_counts_up_across_retries() {
+    let (_tmp, db) = open_db();
+    let q = parity_queue(&db);
+    q.enqueue(&json!({"n": 1}), EnqueueOpts::default()).unwrap();
+
+    let first = q.claim_one("w1").unwrap().expect("first claim");
+    assert_eq!(first.attempts, 1, "attempts on the first claim");
+    assert!(first.retry(0, "boom").unwrap());
+
+    let second = q.claim_one("w2").unwrap().expect("second claim");
+    assert_eq!(
+        second.attempts, 2,
+        "attempts must advance with the retry, not stick at 1"
+    );
+    assert_eq!(second.worker_id, "w2", "worker_id follows the new holder");
+    assert_eq!(second.id, first.id, "same row, re-claimed");
+    assert_eq!(
+        second.created_at, first.created_at,
+        "created_at is stable across claims"
+    );
+}
+
+#[test]
+fn snapshot_shows_pending_then_processing_then_misses() {
+    let (_tmp, db) = open_db();
+    let q = parity_queue(&db);
+
+    let enqueued_at_lo = now();
+    let id = q
+        .enqueue(
+            &json!({"to": "carol@example.com"}),
+            EnqueueOpts {
+                priority: HIGH_PRIORITY,
+                expires: Some(EXPIRES_S),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let enqueued_at_hi = now();
+
+    let pending = q.get_job(id).unwrap().expect("pending snapshot");
+    assert_eq!(pending.id, id, "id");
+    assert_eq!(pending.queue, "details", "queue");
+    assert_eq!(
+        pending.payload, r#"{"to":"carol@example.com"}"#,
+        "snapshot payload stays raw JSON text"
+    );
+    assert_eq!(pending.state, "pending", "state before any claim");
+    assert_eq!(pending.priority, HIGH_PRIORITY, "priority");
+    assert!(
+        pending.run_at >= enqueued_at_lo && pending.run_at <= enqueued_at_hi,
+        "an undelayed run_at is the enqueue instant, got {}",
+        pending.run_at
+    );
+    assert_eq!(pending.worker_id, None, "no holder while pending");
+    assert_eq!(
+        pending.claim_expires_at, None,
+        "no claim deadline while pending"
+    );
+    assert_eq!(pending.attempts, 0, "attempts before any claim");
+    assert_eq!(pending.max_attempts, MAX_ATTEMPTS, "max_attempts");
+    assert!(
+        pending.created_at >= enqueued_at_lo && pending.created_at <= enqueued_at_hi,
+        "created_at inside the enqueue window, got {}",
+        pending.created_at
+    );
+    let pending_expires = pending.expires_at.expect("expires_at set");
+    assert!(
+        pending_expires >= enqueued_at_lo + EXPIRES_S
+            && pending_expires <= enqueued_at_hi + EXPIRES_S,
+        "expires_at is the enqueue instant + {EXPIRES_S}s, got {pending_expires}"
+    );
+
+    // A second reader sees the processing details of someone else's claim.
+    let claim_lo = now();
+    let job = q.claim_one("worker-reader").unwrap().expect("claim");
+    let claim_hi = now();
+
+    let reader = Database::open(_tmp.path().join("t.db")).unwrap();
+    let processing = parity_queue(&reader)
+        .get_job(id)
+        .unwrap()
+        .expect("processing snapshot");
+    assert_eq!(processing.state, "processing", "state while claimed");
+    assert_eq!(
+        processing.worker_id.as_deref(),
+        Some("worker-reader"),
+        "worker_id names the holder"
+    );
+    assert_eq!(processing.attempts, 1, "attempts after the claim");
+    let deadline = processing
+        .claim_expires_at
+        .expect("claim_expires_at set while processing");
+    assert!(
+        deadline >= claim_lo + VISIBILITY_TIMEOUT_S && deadline <= claim_hi + VISIBILITY_TIMEOUT_S,
+        "claim_expires_at is the claim instant + {VISIBILITY_TIMEOUT_S}s, got {deadline}"
+    );
+    // Unchanged by the claim.
+    assert_eq!(processing.priority, HIGH_PRIORITY, "priority survives");
+    assert_eq!(
+        processing.max_attempts, MAX_ATTEMPTS,
+        "max_attempts survives"
+    );
+    assert_eq!(
+        processing.created_at, pending.created_at,
+        "created_at survives"
+    );
+    assert_eq!(
+        processing.expires_at, pending.expires_at,
+        "expires_at survives"
+    );
+
+    assert!(job.ack().unwrap());
+    assert!(
+        parity_queue(&reader).get_job(id).unwrap().is_none(),
+        "the reader sees no job after ack"
+    );
+}
+
+#[test]
+fn delayed_job_snapshot_reports_the_future_run_at() {
+    let (_tmp, db) = open_db();
+    let q = parity_queue(&db);
+
+    const DELAY_S: i64 = 600;
+    let lo = now();
+    let id = q
+        .enqueue(
+            &json!({"later": true}),
+            EnqueueOpts {
+                delay: Some(DELAY_S),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let hi = now();
+
+    let row = q.get_job(id).unwrap().expect("snapshot");
+    assert!(
+        row.run_at >= lo + DELAY_S && row.run_at <= hi + DELAY_S,
+        "delayed run_at should be the enqueue instant + {DELAY_S}s, got {} \
+         against an enqueue window of [{lo}, {hi}]",
+        row.run_at
+    );
+    assert_eq!(
+        row.run_at - row.created_at,
+        DELAY_S,
+        "run_at must sit exactly {DELAY_S}s after created_at"
+    );
+    assert_eq!(row.state, "pending", "a delayed job stays pending");
+    assert!(
+        q.claim_one("w").unwrap().is_none(),
+        "a delayed job is not claimable yet"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Typed payloads
+// ---------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct Email {
+    version: u32,
+    to: String,
+    subject: String,
+}
+
+#[test]
+fn typed_queue_round_trips_the_payload_type() {
+    let (_tmp, db) = open_db();
+    let q = db.typed_queue::<Email>("typed", QueueOpts::default());
+
+    let sent = Email {
+        version: 2,
+        to: "dave@example.com".into(),
+        subject: "quarterly honk".into(),
+    };
+    let id = q.enqueue(&sent, EnqueueOpts::default()).unwrap();
+
+    let snapshot = q.get_job(id).unwrap().expect("snapshot");
+    assert_eq!(
+        snapshot.payload_typed().unwrap(),
+        sent,
+        "the snapshot decodes into the queue's payload type"
+    );
+
+    let job = q.claim_one("w").unwrap().expect("claim");
+    assert_eq!(job.id, id, "id");
+    assert_eq!(
+        job.payload_typed().unwrap(),
+        sent,
+        "the claimed job decodes into the queue's payload type"
+    );
+    // A typed queue still carries the full field set.
+    assert_eq!(job.state, "processing", "state");
+    assert_eq!(job.worker_id, "w", "worker_id");
+    assert_eq!(job.max_attempts, 3, "max_attempts from QueueOpts::default");
+    assert!(job.ack().unwrap());
+}
+
+#[test]
+fn typed_queue_reads_a_payload_another_writer_produced() {
+    // Versioned payload written through one type, read through another.
+    // honker does not check payload shape, so this only works because
+    // the two shapes agree on the wire.
+    #[derive(Serialize)]
+    struct EmailV2Writer {
+        version: u32,
+        to: String,
+        subject: String,
+    }
+
+    let (_tmp, db) = open_db();
+    let writer = db.typed_queue::<EmailV2Writer>("versioned", QueueOpts::default());
+    writer
+        .enqueue(
+            &EmailV2Writer {
+                version: 2,
+                to: "erin@example.com".into(),
+                subject: "cross-type read".into(),
+            },
+            EnqueueOpts::default(),
+        )
+        .unwrap();
+
+    let reader = writer.typed::<Email>();
+    let job = reader.claim_one("w").unwrap().expect("claim");
+    assert_eq!(
+        job.payload_typed().unwrap(),
+        Email {
+            version: 2,
+            to: "erin@example.com".into(),
+            subject: "cross-type read".into(),
+        },
+        "the reader decodes the writer's payload"
+    );
+}
+
+#[test]
+fn payload_shape_is_never_validated_by_honker() {
+    // The type parameter is a compile-time convenience only. honker
+    // stores whatever JSON you hand it; the mismatch only surfaces
+    // when serde tries to decode.
+    let (_tmp, db) = open_db();
+    let untyped = db.queue("mismatch", QueueOpts::default());
+    let id = untyped
+        .enqueue(&json!({"not": "an email"}), EnqueueOpts::default())
+        .unwrap();
+
+    let typed = untyped.typed::<Email>();
+    let row = typed
+        .get_job(id)
+        .unwrap()
+        .expect("the row is stored regardless of shape");
+    assert_eq!(
+        row.payload, r#"{"not":"an email"}"#,
+        "honker stored the mismatched payload without complaint"
+    );
+    assert!(
+        row.payload_typed().is_err(),
+        "the mismatch surfaces as a serde error, not a honker error"
+    );
+}

--- a/packages/honker-rs/tests/job_details.rs
+++ b/packages/honker-rs/tests/job_details.rs
@@ -146,6 +146,40 @@ fn claimed_job_carries_every_core_field() {
         low.expires_at, None,
         "expires_at stays null when the enqueue set no expiry"
     );
+
+    // Snapshot read-back of BOTH rows. The claimed-job asserts above
+    // already read two rows; the snapshot mapping needs the same
+    // treatment, or a `get_job` that returned a constant would pass.
+    let high_row = q.get_job(high_id).unwrap().expect("high snapshot");
+    let low_row = q.get_job(low_id).unwrap().expect("low snapshot");
+    assert_eq!(high_row.id, high_id, "snapshot id, high row");
+    assert_eq!(low_row.id, low_id, "snapshot id, low row");
+    assert_eq!(high_row.priority, HIGH_PRIORITY, "snapshot priority");
+    assert_eq!(
+        low_row.priority, LOW_PRIORITY,
+        "snapshot priority is per-row, not a constant"
+    );
+    assert_ne!(
+        high_row.priority, low_row.priority,
+        "the two snapshot priorities must differ, or a constant passes"
+    );
+    assert_eq!(high_row.run_at, high_run_at, "snapshot run_at, high row");
+    assert_eq!(
+        low_row.run_at, low_run_at,
+        "snapshot run_at is per-row, not a constant"
+    );
+    assert_ne!(
+        high_row.run_at, low_row.run_at,
+        "the two snapshot run_ats must differ, or a constant passes"
+    );
+    assert!(
+        high_row.expires_at.is_some(),
+        "snapshot expires_at set on the high row"
+    );
+    assert_eq!(
+        low_row.expires_at, None,
+        "snapshot expires_at is per-row: null on the row with no expiry"
+    );
 }
 
 #[test]
@@ -333,6 +367,19 @@ fn typed_queue_round_trips_the_payload_type() {
         snapshot.payload_typed().unwrap(),
         sent,
         "the snapshot decodes into the queue's payload type"
+    );
+    // This queue is deliberately NOT the `parity_queue` fixture, so
+    // every value here differs from the fixture's. A snapshot mapping
+    // that returned the fixture constants (queue "details",
+    // max_attempts 9, priority 42) fails on these three lines.
+    assert_eq!(snapshot.queue, "typed", "snapshot queue is read per-row");
+    assert_eq!(
+        snapshot.max_attempts, 3,
+        "snapshot max_attempts is QueueOpts::default's 3, not the fixture's 9"
+    );
+    assert_eq!(
+        snapshot.priority, 0,
+        "snapshot priority is the default 0, not the fixture's 42"
     );
 
     let job = q.claim_one("w").unwrap().expect("claim");


### PR DESCRIPTION
Part of #136 (Rust binding checklist item).

## Stacked on #124

**This PR targets `feat/node-typed-jobs` (#124), not `main`, and must merge after #124.** It depends on the widened `honker_claim_batch` RETURNING clause that exists only on that branch. `honker-core` is unchanged here.

## What changed

`packages/honker-rs/src/lib.rs`:

- **All twelve fields on claimed jobs.** `Job` gained `state`, `priority`, `run_at`, `claim_expires_at`, `max_attempts`, `created_at`, `expires_at` alongside the existing `id`, `queue`, `payload`, `worker_id`, `attempts`. `JobRow` (the read-only snapshot from `get_job`) already had all twelve and keeps them.
- `Job` keeps `ack` / `retry` / `fail` / `heartbeat`. `JobRow` is data only. On `Job`, `worker_id` and `claim_expires_at` are non-optional (holding a claim is what makes it a `Job`); on `JobRow` they are `Option` because a pending row has neither.
- **One raw wire struct.** `RawJob` now decodes the full twelve-key snake_case shape that `honker_claim_batch()` and `honker_get_job()` both return, with `into_job()` / `into_row()` conversions. A claimed row that comes back without a `worker_id` or `claim_expires_at` is now an error, not a silent default.
- **Typed payloads.** `Queue`, `Job`, `JobRow`, `ClaimWaker`, and `Outbox` carry a payload type parameter defaulting to `serde_json::Value`.
  - `db.queue(..)` and `db.outbox(..)` still return the `serde_json::Value` handles, so existing call sites are untouched (every test and example in the repo compiled unmodified).
  - `db.typed_queue::<T>(..)`, `db.typed_outbox::<T>(..)`, and `queue.typed::<T>()` give typed handles.
  - `payload_typed()` decodes into the handle's `T`; the existing `payload_as::<U>()` still decodes into anything you name.
  - `Database::queue` could not itself be made generic with a default: Rust does not allow default type parameters on functions, and type-parameter defaults do not participate in function-return inference, so a generic `queue()` would break every `let q = db.queue(..)`. Hence the separate `typed_queue` constructor.

## Payload encoding (please read: cross-binding divergence)

Per the coordination note, snapshot payload encoding is **unchanged** in this PR:

| binding | claimed job payload | snapshot (`getJob`/`get_job`) payload |
| --- | --- | --- |
| Rust (this PR) | raw JSON bytes (`Vec<u8>`) | raw JSON text (`String`) |
| Node (#124) | decoded value | **decoded value** |
| Go | raw JSON | raw JSON text |
| Python | raw JSON | raw JSON text |

Three bindings, two conventions. Rust hands back raw text on both paths and adds `payload_typed()` / `payload_as::<U>()` as the decode step; it does **not** silently start decoding to make the generic tidier. Worth one deliberate decision across all bindings later. Flagging, not resolving.

## No runtime payload validation

Documented in the crate docs, the README, and asserted by a test: the type parameter is a compile-time convenience for the caller's code. honker stores the payload as opaque JSON and never checks its shape. A mismatch surfaces only as a `serde` error at `payload_typed()` time.

## Source-breaking change

`Queue::enqueue` / `enqueue_tx` and `Outbox::enqueue` / `enqueue_tx` now take `&T` rather than any `&impl Serialize`, and `Outbox::run_once`'s delivery closure takes `T` rather than `serde_json::Value`. On the default handles `T` is `serde_json::Value`, so `q.enqueue(&json!(..))` is unaffected: every existing test, example, and doc example compiled without edits. A caller who passed a custom struct to an untyped queue now takes a typed handle. Noted in `CHANGELOG.md`.

## Tests

New `packages/honker-rs/tests/job_details.rs`, 7 tests, all passing:

- `claimed_job_carries_every_core_field`
- `claimed_job_attempts_counts_up_across_retries`
- `snapshot_shows_pending_then_processing_then_misses`
- `delayed_job_snapshot_reports_the_future_run_at`
- `typed_queue_round_trips_the_payload_type`
- `typed_queue_reads_a_payload_another_writer_produced`
- `payload_shape_is_never_validated_by_honker`

Every field is asserted against a value that could not be produced by another field. The fixture deliberately avoids defaults and same-second coincidences: visibility timeout 137s (not 300), `max_attempts` 9 (not 3), priorities 42 and 7 on two rows so `priority` cannot be a constant, `run_at` back-dated 300s so it is never equal to `created_at`, `expires_at` set on one row and null on the other, and `claim_expires_at` bracketed against the claim instant plus 137s.

The full existing suite (`cargo test`, 57 tests across `basic`, `surface`, `phase_mantle`, `python_interop`, doc tests) passes unmodified.

### Proof the tests are load-bearing

Two mutations, each reverted after:

**1. `run_at` sourced from `created_at`** in `RawJob::into_job`. `claimed_job_carries_every_core_field` fails:

```
thread 'claimed_job_carries_every_core_field' panicked at tests/job_details.rs:112:5:
assertion `left == right` failed: run_at
  left: 1788256131
 right: 1788255831
```

The 300-second gap is the deliberate `run_at` back-date.

**2. `created_at` sourced from `run_at`** in `RawJob::into_row`. `delayed_job_snapshot_reports_the_future_run_at` fails:

```
thread 'delayed_job_snapshot_reports_the_future_run_at' panicked at tests/job_details.rs:290:5:
assertion `left == right` failed: run_at must sit exactly 600s after created_at
  left: 0
 right: 600
```

This one is the interesting case: `snapshot_shows_pending_then_processing_then_misses` **passed** under that mutation, because an undelayed job legitimately has `run_at == created_at`. That is exactly the coincidence-equality false pass to watch for, and the delayed-job test is what discriminates it.

## Not in scope

- `claimed_at`: that is #135 / PR #140 on another branch, deliberately not added here.
- `honker-core` and the SQL ABI are untouched.
- Queue-scoped `get_job`: #134.
- No other binding touched.

https://claude.ai/code/session_01YMCFasvKC52r37DDKSTeMC
