### PR TITLE
feat(cpp): full job details and a JobSnapshot type (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@
   that saved that offset replay the whole topic; a malformed
   `scheduler_tick` row used to become a fire with an empty name and
   `job_id = 0`. Both now throw `honker::Error`.
+- `StreamSubscription`'s checkpoint write now fails loudly too. It discarded
+  the return of `honker_cpp_stream_save_offset` and cleared its pending
+  counter regardless, so a checkpoint that failed — read-only volume, full
+  disk, `SQLITE_BUSY` — looked identical to one that succeeded, and the
+  consumer replayed the topic with nothing reporting why. `save_offset()`
+  and `next()` now throw `honker::Error`, and a failed write leaves the
+  position pending so the destructor and a manual retry try again. `next()`
+  rolls its in-memory position back on that throw, so the event is
+  redelivered rather than skipped.
 
 ## Unreleased — Node checkpoint interoperability (Phase Robinson)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,17 @@
 - Payload encoding is unchanged: `payload()` is the raw JSON text on both
   types. The binding stays dynamic — no templates, no codec — matching the
   issue's guidance for C++.
-- Claim and snapshot decoding now fails loudly. A malformed JSON blob or a
-  missing required field throws `honker::Error` instead of the previous
-  `catch (...) {}` that returned an empty result, and required fields no
-  longer fall back to `0` / `""` / `1` defaults.
+- Claim and snapshot decoding now fails loudly. A malformed JSON blob, a
+  missing required field, or a field of the wrong type throws
+  `honker::Error` instead of the previous `catch (...) {}` that returned an
+  empty result, and required fields no longer fall back to `0` / `""` / `1`
+  defaults. `nlohmann::json::type_error` is wrapped, so `honker::Error` is
+  the only exception type the decoders let out.
+- Stream and scheduler decoding fails loudly the same way. A malformed
+  `stream_read_since` row used to become `offset = 0`, which made a consumer
+  that saved that offset replay the whole topic; a malformed
+  `scheduler_tick` row used to become a fire with an empty name and
+  `job_id = 0`. Both now throw `honker::Error`.
 
 ## Unreleased — Node checkpoint interoperability (Phase Robinson)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@
 - `Queue::get_job_json()` and `Scheduler::list_json()` free the shim's
   string with `honker_cpp_free()` instead of `std::free()`, matching every
   other call that takes ownership of a `char*` from the shim.
+- `Job` and `JobSnapshot` string accessors return `const std::string&`
+  instead of a copy. They were marked `noexcept` while returning by value,
+  which allocates — a `std::bad_alloc` there would have called
+  `std::terminate` rather than propagating.
 
 ## Unreleased — Node checkpoint interoperability (Phase Robinson)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,26 @@
   unscoped lookup could hand back a payload that did not match the queue's
   declared `TPayload`. `cancel()` is unchanged and remains not queue-scoped.
 
+## Unreleased — C++ job details
+
+- C++ `honker::Job` now carries all twelve fields core returns. It gained
+  `queue()`, `state()`, `priority()`, `run_at()`, `claim_expires_at()`,
+  `max_attempts()`, `created_at()`, and `expires_at()` alongside the
+  existing `id()`, `payload()`, `worker_id()`, and `attempts()`, and keeps
+  `ack()` / `retry()` / `fail()` / `heartbeat()`.
+- New `honker::JobSnapshot`: the same twelve fields, data only, returned by
+  `Queue::get_job(id)` as `std::optional<JobSnapshot>`. `worker_id()` and
+  `claim_expires_at()` are `std::optional` there because a pending row has
+  neither. `Queue::get_job_json(id)` is unchanged and still returns the
+  undecoded blob.
+- Payload encoding is unchanged: `payload()` is the raw JSON text on both
+  types. The binding stays dynamic — no templates, no codec — matching the
+  issue's guidance for C++.
+- Claim and snapshot decoding now fails loudly. A malformed JSON blob or a
+  missing required field throws `honker::Error` instead of the previous
+  `catch (...) {}` that returned an empty result, and required fields no
+  longer fall back to `0` / `""` / `1` defaults.
+
 ## Unreleased — Node checkpoint interoperability (Phase Robinson)
 
 - Node stream checkpoint calls now use the shared SQL ABI's canonical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@
   position pending so the destructor and a manual retry try again. `next()`
   rolls its in-memory position back on that throw, so the event is
   redelivered rather than skipped.
+- `Queue::get_job_json()` and `Scheduler::list_json()` free the shim's
+  string with `honker_cpp_free()` instead of `std::free()`, matching every
+  other call that takes ownership of a `char*` from the shim.
 
 ## Unreleased — Node checkpoint interoperability (Phase Robinson)
 

--- a/packages/honker-cpp/README.md
+++ b/packages/honker-cpp/README.md
@@ -106,9 +106,11 @@ if (auto row = q.get_job(id)) {
 `Queue::get_job_json(id)` still returns the undecoded JSON blob for
 callers that want the bytes.
 
-A claim or lookup whose JSON is malformed, or that is missing a
-required field, throws `honker::Error` rather than returning a
-default-filled job.
+A claim or lookup whose JSON is malformed, that is missing a required
+field, or that carries a field of the wrong type throws `honker::Error`
+rather than returning a default-filled job. That is the only exception
+type honker's decoders let out — nlohmann's `type_error` is wrapped, so
+`catch (const honker::Error&)` is enough.
 
 Delayed jobs use `run_at` options on enqueue. Recurring schedules use schedule expressions:
 

--- a/packages/honker-cpp/README.md
+++ b/packages/honker-cpp/README.md
@@ -96,6 +96,10 @@ is `std::optional<int64_t>` on both.
 preferred JSON library. honker never checks the payload's shape; every
 process writing a queue must agree on it.
 
+The string accessors (`queue()`, `payload()`, `state()`, `worker_id()`)
+return a `const&` into the `Job` or `JobSnapshot`, so reading a payload
+costs nothing. Copy it if you need it to outlive the job.
+
 ```cpp
 if (auto row = q.get_job(id)) {
     row->state();                       // "pending" or "processing"

--- a/packages/honker-cpp/README.md
+++ b/packages/honker-cpp/README.md
@@ -71,6 +71,45 @@ int main() {
 }
 ```
 
+## Job details
+
+`honker::Job` (a claimed unit of work) and `honker::JobSnapshot` (the
+read-only row from `Queue::get_job`) both carry every field the core
+claim/lookup returns:
+
+```cpp
+auto job = q.claim_one("worker-1");
+job->id(); job->queue(); job->payload(); job->state();
+job->priority(); job->run_at(); job->worker_id(); job->claim_expires_at();
+job->attempts(); job->max_attempts(); job->created_at(); job->expires_at();
+```
+
+`Job` also holds a claim, so it has `ack()`, `retry()`, `fail()`, and
+`heartbeat()`. `JobSnapshot` is data only.
+
+On `Job`, `worker_id()` and `claim_expires_at()` are plain values
+because holding a claim is what makes it a `Job`. On `JobSnapshot` they
+are `std::optional` because a pending row has neither. `expires_at()`
+is `std::optional<int64_t>` on both.
+
+`payload()` is the raw JSON text exactly as stored — parse it with your
+preferred JSON library. honker never checks the payload's shape; every
+process writing a queue must agree on it.
+
+```cpp
+if (auto row = q.get_job(id)) {
+    row->state();                       // "pending" or "processing"
+    nlohmann::json::parse(row->payload());
+}
+```
+
+`Queue::get_job_json(id)` still returns the undecoded JSON blob for
+callers that want the bytes.
+
+A claim or lookup whose JSON is malformed, or that is missing a
+required field, throws `honker::Error` rather than returning a
+default-filled job.
+
 Delayed jobs use `run_at` options on enqueue. Recurring schedules use schedule expressions:
 
 ```cpp

--- a/packages/honker-cpp/build.zig
+++ b/packages/honker-cpp/build.zig
@@ -34,6 +34,7 @@ pub fn build(b: *std.Build) void {
         "test/test_basic.cpp",
         "test/test_parity.cpp",
         "test/test_phase_mantle.cpp",
+        "test/test_job_details.cpp",
     };
 
     inline for (test_files) |tf| {

--- a/packages/honker-cpp/include/honker.hpp
+++ b/packages/honker-cpp/include/honker.hpp
@@ -1028,6 +1028,27 @@ private:
     int64_t     job_id_;
 };
 
+namespace detail {
+
+/// Decode one honker_scheduler_tick() blob. Every field is required: a
+/// fire with name "" or job_id 0 is not a plausible default, it is a
+/// row we failed to read.
+inline std::vector<ScheduledFire> parse_scheduler_fires(const std::string& json) {
+    auto arr = parse_row_array(json, "scheduler tick");
+    std::vector<ScheduledFire> out;
+    out.reserve(arr.size());
+    for (const auto& j : arr) {
+        out.emplace_back(
+            row_str(j, "name", "scheduler fire"),
+            row_str(j, "queue", "scheduler fire"),
+            row_i64(j, "fire_at", "scheduler fire"),
+            row_i64(j, "job_id", "scheduler fire"));
+    }
+    return out;
+}
+
+}  // namespace detail
+
 // =====================================================================
 // Scheduler
 // =====================================================================
@@ -1193,23 +1214,10 @@ public:
     Scheduler(Database* db) : db_(db) {}
 
 private:
-    /// Decode one honker_scheduler_tick() blob. Every field is required:
-    /// a fire with name "" or job_id 0 is not a plausible default, it is
-    /// a row we failed to read.
     std::vector<ScheduledFire> parse_fires(char* rows) {
         std::string json{rows};
         honker_cpp_free(rows);
-        auto arr = detail::parse_row_array(json, "scheduler tick");
-        std::vector<ScheduledFire> out;
-        out.reserve(arr.size());
-        for (const auto& j : arr) {
-            out.emplace_back(
-                detail::row_str(j, "name", "scheduler fire"),
-                detail::row_str(j, "queue", "scheduler fire"),
-                detail::row_i64(j, "fire_at", "scheduler fire"),
-                detail::row_i64(j, "job_id", "scheduler fire"));
-        }
-        return out;
+        return detail::parse_scheduler_fires(json);
     }
 
     Database* db_;

--- a/packages/honker-cpp/include/honker.hpp
+++ b/packages/honker-cpp/include/honker.hpp
@@ -410,8 +410,15 @@ inline std::string row_str(const nlohmann::json& j, const char* key, const char*
     return row_get<std::string>(row_field(j, key, what), key, what, "a string");
 }
 
+/// A genuinely nullable key: absent or null means std::nullopt, never
+/// 0 or "". The row still has to be an object — otherwise every
+/// nullable field on a garbage row would silently read as null, which
+/// is the tolerant lookup this file exists to avoid.
 inline std::optional<int64_t> row_opt_i64(
     const nlohmann::json& j, const char* key, const char* what) {
+    if (!j.is_object()) {
+        throw Error{std::string{what} + " is not a JSON object"};
+    }
     const auto it = j.find(key);
     if (it == j.end() || it->is_null()) return std::nullopt;
     return row_get<int64_t>(*it, key, what, "an integer");
@@ -419,6 +426,9 @@ inline std::optional<int64_t> row_opt_i64(
 
 inline std::optional<std::string> row_opt_str(
     const nlohmann::json& j, const char* key, const char* what) {
+    if (!j.is_object()) {
+        throw Error{std::string{what} + " is not a JSON object"};
+    }
     const auto it = j.find(key);
     if (it == j.end() || it->is_null()) return std::nullopt;
     return row_get<std::string>(*it, key, what, "a string");

--- a/packages/honker-cpp/include/honker.hpp
+++ b/packages/honker-cpp/include/honker.hpp
@@ -674,6 +674,12 @@ public:
         return std::move(jobs.front());
     }
 
+    /// Claim up to n jobs. Decoding is all-or-nothing: one unreadable
+    /// row throws and no Job comes back, even though the claim UPDATE
+    /// already ran on every row it matched. Those rows stay claimed and
+    /// carry a burnt attempt until their visibility timeout expires,
+    /// and the exception carries no ids, so treat it as a core bug and
+    /// not as a retryable condition.
     std::vector<Job> claim_batch(std::string_view worker_id, int64_t n) {
         const std::string w{worker_id};
         char* rows = honker_cpp_claim_batch(
@@ -733,8 +739,9 @@ public:
     /// Read a single job row by id as a decoded JobSnapshot. Returns
     /// nullopt on miss (ack'd, dead'd, or never existed).
     ///
-    /// NOT queue-scoped: job ids are globally unique and this lookup
-    /// hits any queue's row. Scoping is tracked in #134.
+    /// Today this lookup is not queue-scoped — job ids are globally
+    /// unique and it hits any queue's row. Whether it stays that way
+    /// is #134; do not depend on either answer.
     std::optional<JobSnapshot> get_job(int64_t job_id) {
         const std::string json = get_job_json(job_id);
         if (json.empty()) return std::nullopt;

--- a/packages/honker-cpp/include/honker.hpp
+++ b/packages/honker-cpp/include/honker.hpp
@@ -483,16 +483,20 @@ inline nlohmann::json parse_row_array(const std::string& json, const char* what)
 /// worker_id() and claim_expires_at() are optional because a pending
 /// row has neither. payload() is the raw JSON text exactly as stored;
 /// parse it with your preferred JSON library.
+///
+/// The string accessors hand back a reference into the snapshot, so
+/// they neither copy nor allocate — keep the JobSnapshot alive for as
+/// long as you hold one.
 class JobSnapshot {
 public:
     int64_t     id()         const noexcept { return id_; }
-    std::string queue()      const noexcept { return queue_; }
-    std::string payload()    const noexcept { return payload_; }
+    const std::string& queue()   const noexcept { return queue_; }
+    const std::string& payload() const noexcept { return payload_; }
     /// "pending" or "processing".
-    std::string state()      const noexcept { return state_; }
+    const std::string& state()   const noexcept { return state_; }
     int64_t     priority()   const noexcept { return priority_; }
     int64_t     run_at()     const noexcept { return run_at_; }
-    std::optional<std::string> worker_id() const noexcept { return worker_id_; }
+    const std::optional<std::string>& worker_id() const noexcept { return worker_id_; }
     std::optional<int64_t> claim_expires_at() const noexcept { return claim_expires_at_; }
     int64_t     attempts()     const noexcept { return attempts_; }
     int64_t     max_attempts() const noexcept { return max_attempts_; }
@@ -545,16 +549,20 @@ private:
 /// a claim is what makes this a Job.
 ///
 /// payload() is the raw JSON text exactly as stored.
+///
+/// The string accessors hand back a reference into the Job, so they
+/// neither copy nor allocate — keep the Job alive for as long as you
+/// hold one.
 class Job {
 public:
     int64_t     id()        const noexcept { return id_; }
-    std::string queue()     const noexcept { return queue_; }
-    std::string payload()   const noexcept { return payload_; }
+    const std::string& queue()   const noexcept { return queue_; }
+    const std::string& payload() const noexcept { return payload_; }
     /// Always "processing" for a claimed job.
-    std::string state()     const noexcept { return state_; }
+    const std::string& state()   const noexcept { return state_; }
     int64_t     priority()  const noexcept { return priority_; }
     int64_t     run_at()    const noexcept { return run_at_; }
-    std::string worker_id() const noexcept { return worker_id_; }
+    const std::string& worker_id() const noexcept { return worker_id_; }
     int64_t     claim_expires_at() const noexcept { return claim_expires_at_; }
     int64_t     attempts()     const noexcept { return attempts_; }
     int64_t     max_attempts() const noexcept { return max_attempts_; }

--- a/packages/honker-cpp/include/honker.hpp
+++ b/packages/honker-cpp/include/honker.hpp
@@ -718,7 +718,7 @@ public:
         char* raw = honker_cpp_get_job(db_, job_id);
         if (!raw) return {};
         std::string out{raw};
-        std::free(raw);
+        honker_cpp_free(raw);
         return out;
     }
 
@@ -1146,7 +1146,7 @@ public:
         char* raw = honker_cpp_scheduler_list(db_->raw());
         if (!raw) return "[]";
         std::string out{raw};
-        std::free(raw);
+        honker_cpp_free(raw);
         return out;
     }
 

--- a/packages/honker-cpp/include/honker.hpp
+++ b/packages/honker-cpp/include/honker.hpp
@@ -953,16 +953,27 @@ public:
         }
     }
 
+    /// Blocks until the next event. Throws honker::Error if the
+    /// every-save_every_n checkpoint write fails. The event is not
+    /// consumed in that case: the in-memory position rolls back so a
+    /// later next() hands out the same event rather than skipping it.
     std::optional<StreamEvent> next() {
         while (true) {
             if (idx_ < buffer_.size()) {
+                const int64_t prev_offset = last_offset_;
+                last_offset_ = buffer_[idx_].offset();
+                ++pending_;
+                if (pending_ >= save_every_n_) {
+                    try {
+                        flush_offset();
+                    } catch (...) {
+                        --pending_;
+                        last_offset_ = prev_offset;
+                        throw;
+                    }
+                }
                 auto ev = std::move(buffer_[idx_]);
                 ++idx_;
-                ++pending_;
-                last_offset_ = ev.offset();
-                if (pending_ >= save_every_n_) {
-                    flush_offset();
-                }
                 return ev;
             }
             buffer_ = read_batch();
@@ -973,6 +984,11 @@ public:
         }
     }
 
+    /// Persist the consumer's position now. Throws honker::Error if the
+    /// checkpoint write fails — a silently dropped checkpoint replays
+    /// the topic, so call this before the subscription goes out of
+    /// scope when you need the failure reported; the destructor cannot
+    /// throw and has to swallow it.
     void save_offset() {
         flush_offset();
     }
@@ -988,9 +1004,14 @@ private:
         return detail::parse_stream_events(json);
     }
 
+    /// Persist the checkpoint. A failed write must not clear pending_:
+    /// the offset is still unsaved, so the destructor gets another try
+    /// and offset() keeps reporting the uncommitted position.
     void flush_offset() {
         if (pending_ == 0) return;
-        honker_cpp_stream_save_offset(db_, consumer_.c_str(), topic_.c_str(), last_offset_);
+        const auto n = honker_cpp_stream_save_offset(
+            db_, consumer_.c_str(), topic_.c_str(), last_offset_);
+        if (n < 0) throw Error{"save_offset failed: SQL error"};
         pending_ = 0;
     }
 

--- a/packages/honker-cpp/include/honker.hpp
+++ b/packages/honker-cpp/include/honker.hpp
@@ -178,6 +178,8 @@ public:
         try {
             open_core_watcher();
         } catch (...) {
+            // Not a swallow: close() releases the handle we just opened,
+            // then the original failure is rethrown to the caller.
             close();
             throw;
         }
@@ -371,32 +373,92 @@ private:
 
 namespace detail {
 
-inline const nlohmann::json& job_field(const nlohmann::json& j, const char* key) {
+/// Look up a required key on one decoded row. `what` names the row
+/// kind so the message says which decoder failed ("job row",
+/// "stream event", "scheduler fire").
+inline const nlohmann::json& row_field(
+    const nlohmann::json& j, const char* key, const char* what) {
+    if (!j.is_object()) {
+        throw Error{std::string{what} + " is not a JSON object"};
+    }
     const auto it = j.find(key);
     if (it == j.end() || it->is_null()) {
-        throw Error{std::string{"job row is missing required field '"} + key + "'"};
+        throw Error{std::string{what} + " is missing required field '" + key + "'"};
     }
     return *it;
 }
 
+/// nlohmann throws its own nlohmann::json::type_error when a present
+/// value has the wrong type. Callers are told to catch honker::Error,
+/// so translate here rather than leaking the JSON library's exception
+/// type out of honker's API.
+template <typename T>
+T row_get(const nlohmann::json& v, const char* key, const char* what, const char* want) {
+    try {
+        return v.get<T>();
+    } catch (const nlohmann::json::exception& e) {
+        throw Error{std::string{what} + " field '" + key + "' is not " + want +
+                    ": " + e.what()};
+    }
+}
+
+inline int64_t row_i64(const nlohmann::json& j, const char* key, const char* what) {
+    return row_get<int64_t>(row_field(j, key, what), key, what, "an integer");
+}
+
+inline std::string row_str(const nlohmann::json& j, const char* key, const char* what) {
+    return row_get<std::string>(row_field(j, key, what), key, what, "a string");
+}
+
+inline std::optional<int64_t> row_opt_i64(
+    const nlohmann::json& j, const char* key, const char* what) {
+    const auto it = j.find(key);
+    if (it == j.end() || it->is_null()) return std::nullopt;
+    return row_get<int64_t>(*it, key, what, "an integer");
+}
+
+inline std::optional<std::string> row_opt_str(
+    const nlohmann::json& j, const char* key, const char* what) {
+    const auto it = j.find(key);
+    if (it == j.end() || it->is_null()) return std::nullopt;
+    return row_get<std::string>(*it, key, what, "a string");
+}
+
+constexpr const char* kJobRow = "job row";
+
 inline int64_t job_i64(const nlohmann::json& j, const char* key) {
-    return job_field(j, key).get<int64_t>();
+    return row_i64(j, key, kJobRow);
 }
 
 inline std::string job_str(const nlohmann::json& j, const char* key) {
-    return job_field(j, key).get<std::string>();
+    return row_str(j, key, kJobRow);
 }
 
 inline std::optional<int64_t> job_opt_i64(const nlohmann::json& j, const char* key) {
-    const auto it = j.find(key);
-    if (it == j.end() || it->is_null()) return std::nullopt;
-    return it->get<int64_t>();
+    return row_opt_i64(j, key, kJobRow);
 }
 
 inline std::optional<std::string> job_opt_str(const nlohmann::json& j, const char* key) {
-    const auto it = j.find(key);
-    if (it == j.end() || it->is_null()) return std::nullopt;
-    return it->get<std::string>();
+    return row_opt_str(j, key, kJobRow);
+}
+
+/// Parse one honker JSON blob. A malformed blob is a bug in the core
+/// we are talking to, not an empty result — surface it instead of
+/// quietly handing back nothing.
+inline nlohmann::json parse_row_blob(const std::string& json, const char* what) {
+    try {
+        return nlohmann::json::parse(json);
+    } catch (const nlohmann::json::exception& e) {
+        throw Error{std::string{what} + " JSON is not parseable: " + e.what()};
+    }
+}
+
+inline nlohmann::json parse_row_array(const std::string& json, const char* what) {
+    auto arr = parse_row_blob(json, what);
+    if (!arr.is_array()) {
+        throw Error{std::string{what} + " result is not a JSON array"};
+    }
+    return arr;
 }
 
 }  // namespace detail
@@ -658,7 +720,7 @@ public:
     std::optional<JobSnapshot> get_job(int64_t job_id) {
         const std::string json = get_job_json(job_id);
         if (json.empty()) return std::nullopt;
-        return JobSnapshot::from_json(parse_job_json(json));
+        return JobSnapshot::from_json(detail::parse_row_blob(json, "job row"));
     }
 
     Queue(sqlite3* db, std::string name, int64_t vis, int64_t max)
@@ -666,21 +728,8 @@ public:
           visibility_timeout_s_(vis), max_attempts_(max) {}
 
 private:
-    /// Parse one honker JSON blob. A malformed blob is a core bug, not
-    /// an empty result — surface it instead of returning nothing.
-    static nlohmann::json parse_job_json(const std::string& json) {
-        try {
-            return nlohmann::json::parse(json);
-        } catch (const std::exception& e) {
-            throw Error{std::string{"job JSON is not parseable: "} + e.what()};
-        }
-    }
-
     std::vector<Job> parse_claim(const std::string& json) {
-        auto arr = parse_job_json(json);
-        if (!arr.is_array()) {
-            throw Error{"claim result is not a JSON array"};
-        }
+        auto arr = detail::parse_row_array(json, "claim");
         std::vector<Job> out;
         out.reserve(arr.size());
         for (const auto& j : arr) {
@@ -780,6 +829,32 @@ private:
     int64_t     created_at_;
 };
 
+namespace detail {
+
+/// Decode one honker_stream_read_since() blob. Shared by Stream::read*
+/// and StreamSubscription::read_batch so both fail the same way.
+///
+/// A malformed row used to be swallowed, which turned a bad row into
+/// offset 0 — and a consumer that saved that offset replayed the whole
+/// topic. Throw instead. `key` stays optional because the core writes
+/// NULL for an unkeyed event.
+inline std::vector<StreamEvent> parse_stream_events(const std::string& json) {
+    auto arr = parse_row_array(json, "stream read");
+    std::vector<StreamEvent> out;
+    out.reserve(arr.size());
+    for (const auto& j : arr) {
+        out.emplace_back(
+            row_i64(j, "offset", "stream event"),
+            row_str(j, "topic", "stream event"),
+            row_opt_str(j, "key", "stream event").value_or(std::string{}),
+            row_str(j, "payload", "stream event"),
+            row_i64(j, "created_at", "stream event"));
+    }
+    return out;
+}
+
+}  // namespace detail
+
 // =====================================================================
 // Stream
 // =====================================================================
@@ -846,23 +921,7 @@ private:
     std::vector<StreamEvent> parse_events(char* rows) {
         std::string json{rows};
         honker_cpp_free(rows);
-        std::vector<StreamEvent> out;
-        try {
-            auto arr = nlohmann::json::parse(json);
-            if (!arr.is_array()) return out;
-            for (const auto& j : arr) {
-                std::string key = (j.contains("key") && !j["key"].is_null())
-                    ? j["key"].get<std::string>() : "";
-                out.emplace_back(
-                    j.value("offset", 0),
-                    j.value("topic", ""),
-                    key,
-                    j.value("payload", ""),
-                    j.value("created_at", 0)
-                );
-            }
-        } catch (...) {}
-        return out;
+        return detail::parse_stream_events(json);
     }
 
     Database*   owner_;
@@ -886,6 +945,10 @@ public:
 
     ~StreamSubscription() {
         if (pending_ > 0) {
+            // A destructor may not throw. The lost checkpoint is
+            // survivable — the consumer replays from the last saved
+            // offset. Call save_offset() before the subscription goes
+            // out of scope if you need the failure reported.
             try { flush_offset(); } catch (...) {}
         }
     }
@@ -922,23 +985,7 @@ private:
         if (!rows) return {};
         std::string json{rows};
         honker_cpp_free(rows);
-        std::vector<StreamEvent> out;
-        try {
-            auto arr = nlohmann::json::parse(json);
-            if (!arr.is_array()) return out;
-            for (const auto& j : arr) {
-                std::string key = (j.contains("key") && !j["key"].is_null())
-                    ? j["key"].get<std::string>() : "";
-                out.emplace_back(
-                    j.value("offset", 0),
-                    j.value("topic", ""),
-                    key,
-                    j.value("payload", ""),
-                    j.value("created_at", 0)
-                );
-            }
-        } catch (...) {}
-        return out;
+        return detail::parse_stream_events(json);
     }
 
     void flush_offset() {
@@ -1146,22 +1193,22 @@ public:
     Scheduler(Database* db) : db_(db) {}
 
 private:
+    /// Decode one honker_scheduler_tick() blob. Every field is required:
+    /// a fire with name "" or job_id 0 is not a plausible default, it is
+    /// a row we failed to read.
     std::vector<ScheduledFire> parse_fires(char* rows) {
         std::string json{rows};
         honker_cpp_free(rows);
+        auto arr = detail::parse_row_array(json, "scheduler tick");
         std::vector<ScheduledFire> out;
-        try {
-            auto arr = nlohmann::json::parse(json);
-            if (!arr.is_array()) return out;
-            for (const auto& j : arr) {
-                out.emplace_back(
-                    j.value("name", ""),
-                    j.value("queue", ""),
-                    j.value("fire_at", 0),
-                    j.value("job_id", 0)
-                );
-            }
-        } catch (...) {}
+        out.reserve(arr.size());
+        for (const auto& j : arr) {
+            out.emplace_back(
+                detail::row_str(j, "name", "scheduler fire"),
+                detail::row_str(j, "queue", "scheduler fire"),
+                detail::row_i64(j, "fire_at", "scheduler fire"),
+                detail::row_i64(j, "job_id", "scheduler fire"));
+        }
         return out;
     }
 
@@ -1194,6 +1241,9 @@ public:
 
     ~Lock() {
         if (!released_) {
+            // A destructor may not throw. An unreleased lock still
+            // expires on its TTL. Call release() explicitly if you need
+            // the failure reported.
             try { release(); } catch (...) {}
         }
     }
@@ -1207,6 +1257,7 @@ public:
     }
     Lock& operator=(Lock&& other) noexcept {
         if (this != &other) {
+            // noexcept move-assign: same reasoning as the destructor.
             if (!released_) { try { release(); } catch (...) {} }
             db_ = other.db_;
             name_ = std::move(other.name_);

--- a/packages/honker-cpp/include/honker.hpp
+++ b/packages/honker-cpp/include/honker.hpp
@@ -132,6 +132,7 @@ public:
 
 class Database;
 class Transaction;
+class JobSnapshot;
 class Job;
 class Queue;
 class Outbox;
@@ -360,15 +361,133 @@ private:
 };
 
 // =====================================================================
+// Job field decoding
+// =====================================================================
+//
+// honker_claim_batch() and honker_get_job() return the same twelve
+// snake_case keys. These helpers read them without inventing values:
+// a required key that is absent or null is a bug in the core we are
+// talking to, so it throws rather than defaulting to 0 or "".
+
+namespace detail {
+
+inline const nlohmann::json& job_field(const nlohmann::json& j, const char* key) {
+    const auto it = j.find(key);
+    if (it == j.end() || it->is_null()) {
+        throw Error{std::string{"job row is missing required field '"} + key + "'"};
+    }
+    return *it;
+}
+
+inline int64_t job_i64(const nlohmann::json& j, const char* key) {
+    return job_field(j, key).get<int64_t>();
+}
+
+inline std::string job_str(const nlohmann::json& j, const char* key) {
+    return job_field(j, key).get<std::string>();
+}
+
+inline std::optional<int64_t> job_opt_i64(const nlohmann::json& j, const char* key) {
+    const auto it = j.find(key);
+    if (it == j.end() || it->is_null()) return std::nullopt;
+    return it->get<int64_t>();
+}
+
+inline std::optional<std::string> job_opt_str(const nlohmann::json& j, const char* key) {
+    const auto it = j.find(key);
+    if (it == j.end() || it->is_null()) return std::nullopt;
+    return it->get<std::string>();
+}
+
+}  // namespace detail
+
+// =====================================================================
+// JobSnapshot
+// =====================================================================
+
+/// A read-only row from Queue::get_job(). Data only — a snapshot
+/// holds no claim, so there is no ack/retry/fail/heartbeat here.
+///
+/// worker_id() and claim_expires_at() are optional because a pending
+/// row has neither. payload() is the raw JSON text exactly as stored;
+/// parse it with your preferred JSON library.
+class JobSnapshot {
+public:
+    int64_t     id()         const noexcept { return id_; }
+    std::string queue()      const noexcept { return queue_; }
+    std::string payload()    const noexcept { return payload_; }
+    /// "pending" or "processing".
+    std::string state()      const noexcept { return state_; }
+    int64_t     priority()   const noexcept { return priority_; }
+    int64_t     run_at()     const noexcept { return run_at_; }
+    std::optional<std::string> worker_id() const noexcept { return worker_id_; }
+    std::optional<int64_t> claim_expires_at() const noexcept { return claim_expires_at_; }
+    int64_t     attempts()     const noexcept { return attempts_; }
+    int64_t     max_attempts() const noexcept { return max_attempts_; }
+    int64_t     created_at()   const noexcept { return created_at_; }
+    std::optional<int64_t> expires_at() const noexcept { return expires_at_; }
+
+    /// Decode one honker_get_job() object. Throws honker::Error when a
+    /// required field is missing.
+    static JobSnapshot from_json(const nlohmann::json& j) {
+        JobSnapshot s;
+        s.id_               = detail::job_i64(j, "id");
+        s.queue_            = detail::job_str(j, "queue");
+        s.payload_          = detail::job_str(j, "payload");
+        s.state_            = detail::job_str(j, "state");
+        s.priority_         = detail::job_i64(j, "priority");
+        s.run_at_           = detail::job_i64(j, "run_at");
+        s.worker_id_        = detail::job_opt_str(j, "worker_id");
+        s.claim_expires_at_ = detail::job_opt_i64(j, "claim_expires_at");
+        s.attempts_         = detail::job_i64(j, "attempts");
+        s.max_attempts_     = detail::job_i64(j, "max_attempts");
+        s.created_at_       = detail::job_i64(j, "created_at");
+        s.expires_at_       = detail::job_opt_i64(j, "expires_at");
+        return s;
+    }
+
+private:
+    JobSnapshot() = default;
+
+    int64_t     id_ = 0;
+    std::string queue_;
+    std::string payload_;
+    std::string state_;
+    int64_t     priority_ = 0;
+    int64_t     run_at_ = 0;
+    std::optional<std::string> worker_id_;
+    std::optional<int64_t> claim_expires_at_;
+    int64_t     attempts_ = 0;
+    int64_t     max_attempts_ = 0;
+    int64_t     created_at_ = 0;
+    std::optional<int64_t> expires_at_;
+};
+
+// =====================================================================
 // Job
 // =====================================================================
 
+/// A claimed unit of work. Carries the same twelve fields as
+/// JobSnapshot plus the claim methods. state() is always "processing",
+/// and worker_id() / claim_expires_at() are never null because holding
+/// a claim is what makes this a Job.
+///
+/// payload() is the raw JSON text exactly as stored.
 class Job {
 public:
     int64_t     id()        const noexcept { return id_; }
+    std::string queue()     const noexcept { return queue_; }
     std::string payload()   const noexcept { return payload_; }
+    /// Always "processing" for a claimed job.
+    std::string state()     const noexcept { return state_; }
+    int64_t     priority()  const noexcept { return priority_; }
+    int64_t     run_at()    const noexcept { return run_at_; }
     std::string worker_id() const noexcept { return worker_id_; }
-    int64_t     attempts()  const noexcept { return attempts_; }
+    int64_t     claim_expires_at() const noexcept { return claim_expires_at_; }
+    int64_t     attempts()     const noexcept { return attempts_; }
+    int64_t     max_attempts() const noexcept { return max_attempts_; }
+    int64_t     created_at()   const noexcept { return created_at_; }
+    std::optional<int64_t> expires_at() const noexcept { return expires_at_; }
 
     bool ack() {
         const auto n = honker_cpp_ack(db_, id_, worker_id_.c_str());
@@ -396,17 +515,43 @@ public:
         return n > 0;
     }
 
-    Job(sqlite3* db, int64_t id, std::string payload,
-        std::string worker_id, int64_t attempts)
-        : db_(db), id_(id), payload_(std::move(payload)),
-          worker_id_(std::move(worker_id)), attempts_(attempts) {}
+    /// Decode one honker_claim_batch() element. Throws honker::Error
+    /// when a required field is missing — including worker_id and
+    /// claim_expires_at, which a claimed row always carries.
+    static Job from_json(sqlite3* db, const nlohmann::json& j) {
+        Job job;
+        job.db_               = db;
+        job.id_               = detail::job_i64(j, "id");
+        job.queue_            = detail::job_str(j, "queue");
+        job.payload_          = detail::job_str(j, "payload");
+        job.state_            = detail::job_str(j, "state");
+        job.priority_         = detail::job_i64(j, "priority");
+        job.run_at_           = detail::job_i64(j, "run_at");
+        job.worker_id_        = detail::job_str(j, "worker_id");
+        job.claim_expires_at_ = detail::job_i64(j, "claim_expires_at");
+        job.attempts_         = detail::job_i64(j, "attempts");
+        job.max_attempts_     = detail::job_i64(j, "max_attempts");
+        job.created_at_       = detail::job_i64(j, "created_at");
+        job.expires_at_       = detail::job_opt_i64(j, "expires_at");
+        return job;
+    }
 
 private:
-    sqlite3*    db_;
-    int64_t     id_;
+    Job() = default;
+
+    sqlite3*    db_ = nullptr;
+    int64_t     id_ = 0;
+    std::string queue_;
     std::string payload_;
+    std::string state_;
+    int64_t     priority_ = 0;
+    int64_t     run_at_ = 0;
     std::string worker_id_;
-    int64_t     attempts_;
+    int64_t     claim_expires_at_ = 0;
+    int64_t     attempts_ = 0;
+    int64_t     max_attempts_ = 0;
+    int64_t     created_at_ = 0;
+    std::optional<int64_t> expires_at_;
 };
 
 // =====================================================================
@@ -442,7 +587,11 @@ public:
         char* rows = honker_cpp_claim_one(
             db_, name_.c_str(), w.c_str(), visibility_timeout_s_);
         if (!rows) return std::nullopt;
-        return parse_jobs(rows, 1);
+        std::string json{rows};
+        honker_cpp_free(rows);
+        auto jobs = parse_claim(json);
+        if (jobs.empty()) return std::nullopt;
+        return std::move(jobs.front());
     }
 
     std::vector<Job> claim_batch(std::string_view worker_id, int64_t n) {
@@ -452,19 +601,7 @@ public:
         if (!rows) return {};
         std::string json{rows};
         honker_cpp_free(rows);
-        std::vector<Job> out;
-        try {
-            auto arr = nlohmann::json::parse(json);
-            if (!arr.is_array()) return out;
-            for (const auto& j : arr) {
-                int64_t id = j.value("id", 0);
-                std::string payload = j.value("payload", "");
-                std::string wid = j.value("worker_id", w);
-                int64_t attempts = j.value("attempts", 1);
-                out.emplace_back(db_, id, std::move(payload), std::move(wid), attempts);
-            }
-        } catch (...) {}
-        return out;
+        return parse_claim(json);
     }
 
     int64_t ack_batch(const std::vector<int64_t>& ids, std::string_view worker_id) {
@@ -502,9 +639,9 @@ public:
         return rc > 0;
     }
 
-    /// Read a single job row by id. Returns the JSON-string blob or
-    /// an empty string on miss. Caller parses with their preferred
-    /// JSON library — keeping this header dependency-free.
+    /// Read a single job row by id. Returns the raw JSON-string blob
+    /// or an empty string on miss. Use get_job() for the decoded
+    /// JobSnapshot; this stays for callers that want the bytes.
     std::string get_job_json(int64_t job_id) {
         char* raw = honker_cpp_get_job(db_, job_id);
         if (!raw) return {};
@@ -513,26 +650,43 @@ public:
         return out;
     }
 
+    /// Read a single job row by id as a decoded JobSnapshot. Returns
+    /// nullopt on miss (ack'd, dead'd, or never existed).
+    ///
+    /// NOT queue-scoped: job ids are globally unique and this lookup
+    /// hits any queue's row. Scoping is tracked in #134.
+    std::optional<JobSnapshot> get_job(int64_t job_id) {
+        const std::string json = get_job_json(job_id);
+        if (json.empty()) return std::nullopt;
+        return JobSnapshot::from_json(parse_job_json(json));
+    }
+
     Queue(sqlite3* db, std::string name, int64_t vis, int64_t max)
         : db_(db), name_(std::move(name)),
           visibility_timeout_s_(vis), max_attempts_(max) {}
 
 private:
-    std::optional<Job> parse_jobs(char* rows, int64_t) {
-        std::string json{rows};
-        honker_cpp_free(rows);
+    /// Parse one honker JSON blob. A malformed blob is a core bug, not
+    /// an empty result — surface it instead of returning nothing.
+    static nlohmann::json parse_job_json(const std::string& json) {
         try {
-            auto arr = nlohmann::json::parse(json);
-            if (!arr.is_array() || arr.empty()) return std::nullopt;
-            const auto& j = arr[0];
-            int64_t id = j.value("id", 0);
-            std::string payload = j.value("payload", "");
-            std::string wid = j.value("worker_id", "");
-            int64_t attempts = j.value("attempts", 1);
-            return Job{db_, id, std::move(payload), std::move(wid), attempts};
-        } catch (...) {
-            return std::nullopt;
+            return nlohmann::json::parse(json);
+        } catch (const std::exception& e) {
+            throw Error{std::string{"job JSON is not parseable: "} + e.what()};
         }
+    }
+
+    std::vector<Job> parse_claim(const std::string& json) {
+        auto arr = parse_job_json(json);
+        if (!arr.is_array()) {
+            throw Error{"claim result is not a JSON array"};
+        }
+        std::vector<Job> out;
+        out.reserve(arr.size());
+        for (const auto& j : arr) {
+            out.push_back(Job::from_json(db_, j));
+        }
+        return out;
     }
 
     sqlite3*    db_;

--- a/packages/honker-cpp/test/test_job_details.cpp
+++ b/packages/honker-cpp/test/test_job_details.cpp
@@ -1,0 +1,327 @@
+// Issue #136: claimed jobs and read-only snapshots must carry every
+// field honker_claim_batch() / honker_get_job() return.
+//
+// Every value asserted here is chosen to be distinguishable from the
+// others. Defaults (priority 0, max_attempts 3, a 300s visibility
+// timeout, run_at == created_at) would let a wrong field pass for the
+// right one, so the fixture uses odd constants and back-dates run_at
+// well away from created_at.
+
+#include "honker.hpp"
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <filesystem>
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+
+namespace fs = std::filesystem;
+using nlohmann::json;
+
+namespace {
+
+// Fixture constants. All distinct, none a default, none derivable
+// from another by accident.
+constexpr int64_t VISIBILITY_TIMEOUT_S = 137;
+constexpr int64_t MAX_ATTEMPTS         = 9;
+constexpr int64_t HIGH_PRIORITY        = 42;
+constexpr int64_t LOW_PRIORITY         = 7;
+constexpr int64_t RUN_AT_BACKDATE_S    = 300;
+constexpr int64_t EXPIRES_S            = 9000;
+constexpr int64_t DELAY_S              = 600;
+
+int64_t now_unix() { return static_cast<int64_t>(std::time(nullptr)); }
+
+[[noreturn]] void fail(const std::string& msg) {
+    std::cerr << "FAIL: " << msg << '\n';
+    std::abort();
+}
+
+void check_i64(int64_t got, int64_t want, const char* what) {
+    if (got != want) {
+        fail(std::string{what} + ": got " + std::to_string(got) +
+             ", want " + std::to_string(want));
+    }
+}
+
+void check_ne_i64(int64_t got, int64_t forbidden, const char* what) {
+    if (got == forbidden) {
+        fail(std::string{what} + ": got " + std::to_string(got) +
+             ", which must not equal " + std::to_string(forbidden));
+    }
+}
+
+void check_str(const std::string& got, const std::string& want, const char* what) {
+    if (got != want) {
+        fail(std::string{what} + ": got \"" + got + "\", want \"" + want + "\"");
+    }
+}
+
+void check_range(int64_t got, int64_t lo, int64_t hi, const char* what) {
+    if (got < lo || got > hi) {
+        fail(std::string{what} + ": got " + std::to_string(got) +
+             ", want within [" + std::to_string(lo) + ", " + std::to_string(hi) + "]");
+    }
+}
+
+honker::Database open_db(const fs::path& tmp, const char* ext) {
+    fs::remove(tmp);
+    fs::remove(tmp.string() + "-wal");
+    fs::remove(tmp.string() + "-shm");
+    return honker::Database{tmp.string(), ext};
+}
+
+// The C ABI's enqueue takes only delay/priority/max_attempts. The
+// fixture needs an absolute run_at and an expiry too, so it goes
+// through the SQL function directly. Nothing about the read path
+// changes — this is only how the row gets on disk.
+int64_t raw_enqueue(sqlite3* db, const char* queue, const char* payload,
+                    int64_t run_at, int64_t priority, int64_t max_attempts,
+                    std::optional<int64_t> expires) {
+    sqlite3_stmt* stmt = nullptr;
+    const char* sql = "SELECT honker_enqueue(?1, ?2, ?3, NULL, ?4, ?5, ?6)";
+    const int prepared = sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr);
+    assert(prepared == SQLITE_OK);
+    (void)prepared;
+    sqlite3_bind_text(stmt, 1, queue, -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 2, payload, -1, SQLITE_STATIC);
+    sqlite3_bind_int64(stmt, 3, run_at);
+    sqlite3_bind_int64(stmt, 4, priority);
+    sqlite3_bind_int64(stmt, 5, max_attempts);
+    if (expires) {
+        sqlite3_bind_int64(stmt, 6, *expires);
+    } else {
+        sqlite3_bind_null(stmt, 6);
+    }
+    int64_t id = -1;
+    if (sqlite3_step(stmt) == SQLITE_ROW) id = sqlite3_column_int64(stmt, 0);
+    sqlite3_finalize(stmt);
+    if (id <= 0) fail("raw_enqueue did not return a job id");
+    return id;
+}
+
+void test_claimed_job_carries_every_core_field(const char* ext) {
+    auto db = open_db(fs::temp_directory_path() / "honker-cpp-details-claim.db", ext);
+    auto q = db.queue("details", VISIBILITY_TIMEOUT_S, MAX_ATTEMPTS);
+
+    const int64_t enqueued_lo = now_unix();
+    // Back-dated run_at: claimable immediately, but far enough from
+    // created_at that swapping the two fields cannot pass.
+    const int64_t high_run_at = enqueued_lo - RUN_AT_BACKDATE_S;
+    const int64_t high_id = raw_enqueue(
+        db.raw(), "details", R"({"to":"alice@example.com","v":1})",
+        high_run_at, HIGH_PRIORITY, MAX_ATTEMPTS, EXPIRES_S);
+    const int64_t low_run_at = enqueued_lo - (RUN_AT_BACKDATE_S / 2);
+    // No expiry on this one: proves expires_at is read per-row and not
+    // filled from a constant.
+    const int64_t low_id = raw_enqueue(
+        db.raw(), "details", R"({"to":"bob@example.com","v":1})",
+        low_run_at, LOW_PRIORITY, MAX_ATTEMPTS, std::nullopt);
+    const int64_t enqueued_hi = now_unix();
+
+    const int64_t claim_lo = now_unix();
+    auto jobs = q.claim_batch("worker-parity", 2);
+    const int64_t claim_hi = now_unix();
+    check_i64(static_cast<int64_t>(jobs.size()), 2, "claimed job count");
+
+    // priority DESC decides the order, so the high-priority row is first.
+    const auto& high = jobs[0];
+    const auto& low  = jobs[1];
+
+    check_i64(high.id(), high_id, "id");
+    check_i64(low.id(), low_id, "id of the second row");
+    check_str(high.queue(), "details", "queue");
+    check_str(high.payload(), R"({"to":"alice@example.com","v":1})",
+              "payload stays the raw JSON text as enqueued");
+    check_str(json::parse(high.payload())["to"].get<std::string>(),
+              "alice@example.com", "decoded payload");
+    check_str(high.state(), "processing", "state");
+
+    check_i64(high.priority(), HIGH_PRIORITY, "priority");
+    check_i64(low.priority(), LOW_PRIORITY, "priority is per-row, not a constant");
+
+    check_i64(high.run_at(), high_run_at, "run_at");
+    check_i64(low.run_at(), low_run_at, "run_at is per-row");
+    check_ne_i64(high.run_at(), high.created_at(), "run_at must not be created_at");
+
+    check_str(high.worker_id(), "worker-parity", "worker_id");
+
+    check_range(high.claim_expires_at(), claim_lo + VISIBILITY_TIMEOUT_S,
+                claim_hi + VISIBILITY_TIMEOUT_S,
+                "claim_expires_at is the claim instant + 137s");
+
+    check_i64(high.attempts(), 1, "attempts after the first claim");
+    check_i64(high.max_attempts(), MAX_ATTEMPTS, "max_attempts");
+    check_range(high.created_at(), enqueued_lo, enqueued_hi,
+                "created_at inside the enqueue window");
+
+    if (!high.expires_at().has_value()) fail("expires_at unset on the high row");
+    check_range(*high.expires_at(), enqueued_lo + EXPIRES_S, enqueued_hi + EXPIRES_S,
+                "expires_at is the enqueue instant + 9000s");
+    if (low.expires_at().has_value()) {
+        fail("expires_at should stay null when the enqueue set no expiry");
+    }
+
+    std::cout << "claimed_job_carries_every_core_field: ok\n";
+}
+
+void test_claimed_job_attempts_count_up_across_retries(const char* ext) {
+    auto db = open_db(fs::temp_directory_path() / "honker-cpp-details-attempts.db", ext);
+    auto q = db.queue("details", VISIBILITY_TIMEOUT_S, MAX_ATTEMPTS);
+    q.enqueue(R"({"n":1})");
+
+    auto first = q.claim_one("w1");
+    if (!first.has_value()) fail("first claim came back empty");
+    check_i64(first->attempts(), 1, "attempts on the first claim");
+    assert(first->retry(0, "boom") == true);
+
+    auto second = q.claim_one("w2");
+    if (!second.has_value()) fail("second claim came back empty");
+    check_i64(second->attempts(), 2,
+              "attempts must advance with the retry, not stick at 1");
+    check_str(second->worker_id(), "w2", "worker_id follows the new holder");
+    check_i64(second->id(), first->id(), "same row, re-claimed");
+    check_i64(second->created_at(), first->created_at(),
+              "created_at is stable across claims");
+
+    std::cout << "claimed_job_attempts_count_up_across_retries: ok\n";
+}
+
+void test_snapshot_pending_then_processing_then_miss(const char* ext) {
+    const auto path = fs::temp_directory_path() / "honker-cpp-details-snapshot.db";
+    auto db = open_db(path, ext);
+    auto q = db.queue("details", VISIBILITY_TIMEOUT_S, MAX_ATTEMPTS);
+
+    const int64_t enqueued_lo = now_unix();
+    const int64_t id = raw_enqueue(
+        db.raw(), "details", R"({"to":"carol@example.com"})",
+        enqueued_lo, HIGH_PRIORITY, MAX_ATTEMPTS, EXPIRES_S);
+    const int64_t enqueued_hi = now_unix();
+
+    auto pending = q.get_job(id);
+    if (!pending.has_value()) fail("pending snapshot missed");
+    check_i64(pending->id(), id, "id");
+    check_str(pending->queue(), "details", "queue");
+    check_str(pending->payload(), R"({"to":"carol@example.com"})",
+              "snapshot payload stays raw JSON text");
+    check_str(pending->state(), "pending", "state before any claim");
+    check_i64(pending->priority(), HIGH_PRIORITY, "priority");
+    check_i64(pending->run_at(), enqueued_lo, "run_at");
+    if (pending->worker_id().has_value()) fail("no holder while pending");
+    if (pending->claim_expires_at().has_value()) fail("no claim deadline while pending");
+    check_i64(pending->attempts(), 0, "attempts before any claim");
+    check_i64(pending->max_attempts(), MAX_ATTEMPTS, "max_attempts");
+    check_range(pending->created_at(), enqueued_lo, enqueued_hi,
+                "created_at inside the enqueue window");
+    if (!pending->expires_at().has_value()) fail("expires_at unset");
+    check_range(*pending->expires_at(), enqueued_lo + EXPIRES_S,
+                enqueued_hi + EXPIRES_S, "expires_at is the enqueue instant + 9000s");
+
+    // A second reader sees the processing details of someone else's claim.
+    const int64_t claim_lo = now_unix();
+    auto job = q.claim_one("worker-reader");
+    const int64_t claim_hi = now_unix();
+    if (!job.has_value()) fail("claim came back empty");
+
+    honker::Database reader{path.string(), ext};
+    auto rq = reader.queue("details", VISIBILITY_TIMEOUT_S, MAX_ATTEMPTS);
+    auto processing = rq.get_job(id);
+    if (!processing.has_value()) fail("processing snapshot missed");
+    check_str(processing->state(), "processing", "state while claimed");
+    if (!processing->worker_id().has_value()) fail("worker_id unset while processing");
+    check_str(*processing->worker_id(), "worker-reader", "worker_id names the holder");
+    check_i64(processing->attempts(), 1, "attempts after the claim");
+    if (!processing->claim_expires_at().has_value()) {
+        fail("claim_expires_at unset while processing");
+    }
+    check_range(*processing->claim_expires_at(), claim_lo + VISIBILITY_TIMEOUT_S,
+                claim_hi + VISIBILITY_TIMEOUT_S,
+                "claim_expires_at is the claim instant + 137s");
+    // Unchanged by the claim.
+    check_i64(processing->priority(), HIGH_PRIORITY, "priority survives");
+    check_i64(processing->max_attempts(), MAX_ATTEMPTS, "max_attempts survives");
+    check_i64(processing->created_at(), pending->created_at(), "created_at survives");
+    check_i64(*processing->expires_at(), *pending->expires_at(), "expires_at survives");
+
+    assert(job->ack() == true);
+    if (rq.get_job(id).has_value()) fail("the reader still sees a job after ack");
+
+    std::cout << "snapshot_pending_then_processing_then_miss: ok\n";
+}
+
+void test_delayed_job_snapshot_reports_future_run_at(const char* ext) {
+    auto db = open_db(fs::temp_directory_path() / "honker-cpp-details-delay.db", ext);
+    auto q = db.queue("details", VISIBILITY_TIMEOUT_S, MAX_ATTEMPTS);
+
+    const int64_t lo = now_unix();
+    const int64_t id = q.enqueue(R"({"later":true})", DELAY_S);
+    const int64_t hi = now_unix();
+
+    auto row = q.get_job(id);
+    if (!row.has_value()) fail("delayed snapshot missed");
+    check_range(row->run_at(), lo + DELAY_S, hi + DELAY_S,
+                "delayed run_at is the enqueue instant + 600s");
+    check_i64(row->run_at() - row->created_at(), DELAY_S,
+              "run_at must sit exactly 600s after created_at");
+    check_str(row->state(), "pending", "a delayed job stays pending");
+    if (q.claim_one("w").has_value()) fail("a delayed job is not claimable yet");
+
+    std::cout << "delayed_job_snapshot_reports_future_run_at: ok\n";
+}
+
+void test_get_job_json_still_returns_the_raw_blob(const char* ext) {
+    // get_job() decodes; get_job_json() keeps handing back the bytes.
+    // Both must agree, and both must miss after ack.
+    auto db = open_db(fs::temp_directory_path() / "honker-cpp-details-rawjson.db", ext);
+    auto q = db.queue("details", VISIBILITY_TIMEOUT_S, MAX_ATTEMPTS);
+    const int64_t id = q.enqueue(R"({"raw":true})", 0, LOW_PRIORITY);
+
+    const auto blob = q.get_job_json(id);
+    if (blob.empty()) fail("get_job_json missed a live row");
+    auto parsed = json::parse(blob);
+    auto row = q.get_job(id);
+    if (!row.has_value()) fail("get_job missed a live row");
+    check_i64(row->id(), parsed["id"].get<int64_t>(), "id agrees with the raw blob");
+    check_str(row->payload(), parsed["payload"].get<std::string>(),
+              "payload agrees with the raw blob");
+    check_i64(row->priority(), LOW_PRIORITY, "priority agrees with the enqueue");
+
+    auto job = q.claim_one("w");
+    if (!job.has_value()) fail("claim came back empty");
+    assert(job->ack() == true);
+    if (!q.get_job_json(id).empty()) fail("get_job_json should miss after ack");
+    if (q.get_job(id).has_value()) fail("get_job should miss after ack");
+
+    std::cout << "get_job_json_still_returns_the_raw_blob: ok\n";
+}
+
+}  // anonymous namespace
+
+int main() {
+    const char* ext = std::getenv("HONKER_EXTENSION_PATH");
+    if (!ext || !*ext) {
+        std::fputs(
+            "skip: HONKER_EXTENSION_PATH not set "
+            "(export it to ./libhonker_ext.{dylib,so})\n",
+            stderr);
+        return 0;
+    }
+
+    try {
+        test_claimed_job_carries_every_core_field(ext);
+        test_claimed_job_attempts_count_up_across_retries(ext);
+        test_snapshot_pending_then_processing_then_miss(ext);
+        test_delayed_job_snapshot_reports_future_run_at(ext);
+        test_get_job_json_still_returns_the_raw_blob(ext);
+    } catch (const std::exception& e) {
+        std::cerr << "FAIL: " << e.what() << '\n';
+        return 1;
+    }
+
+    std::cout << "all job detail tests passed\n";
+    return 0;
+}

--- a/packages/honker-cpp/test/test_job_details.cpp
+++ b/packages/honker-cpp/test/test_job_details.cpp
@@ -18,6 +18,7 @@
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace fs = std::filesystem;
 using nlohmann::json;
@@ -299,9 +300,197 @@ void test_get_job_json_still_returns_the_raw_blob(const char* ext) {
     std::cout << "get_job_json_still_returns_the_raw_blob: ok\n";
 }
 
+
+// ---------------------------------------------------------------------
+// Decode failures. These are the tests that defend the "fails loudly"
+// promise: a malformed blob, an absent or null required field, and a
+// wrong-typed field must each raise honker::Error instead of producing
+// a plausible-looking default.
+//
+// They need no extension and no database. They call exactly the
+// functions Queue::get_job() and Queue::claim_batch() call —
+// detail::parse_row_blob / detail::parse_row_array / from_json — so
+// reverting the guard in honker.hpp fails them.
+// ---------------------------------------------------------------------
+
+// A complete, well-formed claimed-job row. Every failure case below is
+// this object with one thing wrong.
+json good_row() {
+    return json{
+        {"id", 101},
+        {"queue", "details"},
+        {"payload", R"({"n":1})"},
+        {"state", "processing"},
+        {"priority", HIGH_PRIORITY},
+        {"run_at", 1700000000},
+        {"worker_id", "w1"},
+        {"claim_expires_at", 1700000137},
+        {"attempts", 1},
+        {"max_attempts", MAX_ATTEMPTS},
+        {"created_at", 1700000300},
+        {"expires_at", 1700009000},
+    };
+}
+
+// Runs fn and demands it throw honker::Error whose message contains
+// needle. Returning normally, or throwing anything else, is a failure —
+// a caller told to write catch (const honker::Error&) must not have a
+// JSON library's exception escape past it.
+template <typename Fn>
+void expect_honker_error(Fn&& fn, const std::string& needle, const std::string& label) {
+    try {
+        fn();
+    } catch (const honker::Error& e) {
+        const std::string msg = e.what();
+        if (msg.find(needle) == std::string::npos) {
+            fail(label + ": honker::Error said \"" + msg +
+                 "\", which does not mention \"" + needle + "\"");
+        }
+        return;
+    } catch (const json::exception& e) {
+        fail(label + ": leaked nlohmann::json::exception \"" +
+             std::string{e.what()} + "\" instead of honker::Error");
+    } catch (const std::exception& e) {
+        fail(label + ": threw \"" + std::string{e.what()} +
+             "\" instead of honker::Error");
+    }
+    fail(label + ": returned normally — no error was raised");
+}
+
+void test_decode_rejects_unparseable_json() {
+    expect_honker_error(
+        [] { (void)honker::detail::parse_row_blob(R"({"id": 1,)", "job row"); },
+        "not parseable", "get_job blob with truncated JSON");
+    expect_honker_error(
+        [] { (void)honker::detail::parse_row_blob("", "job row"); },
+        "not parseable", "get_job blob that is empty text");
+    expect_honker_error(
+        [] { (void)honker::detail::parse_row_array("<html>nope</html>", "claim"); },
+        "not parseable", "claim blob that is not JSON at all");
+
+    std::cout << "decode_rejects_unparseable_json: ok\n";
+}
+
+void test_decode_rejects_a_non_array_claim_result() {
+    // A claim that comes back as a bare object or null is a core bug.
+    // Returning {} here would read as "nothing to claim" while the
+    // claim UPDATE has already burned an attempt on every row.
+    expect_honker_error(
+        [] { (void)honker::detail::parse_row_array(good_row().dump(), "claim"); },
+        "not a JSON array", "claim result that is a single object");
+    expect_honker_error(
+        [] { (void)honker::detail::parse_row_array("null", "claim"); },
+        "not a JSON array", "claim result that is null");
+    expect_honker_error(
+        [] { (void)honker::detail::parse_row_array("17", "claim"); },
+        "not a JSON array", "claim result that is a number");
+
+    std::cout << "decode_rejects_a_non_array_claim_result: ok\n";
+}
+
+void test_decode_rejects_a_missing_required_field() {
+    // The fixture itself must decode, so a failure below is the removed
+    // field and not a broken fixture.
+    const auto ok = honker::JobSnapshot::from_json(good_row());
+    check_i64(ok.id(), 101, "the fixture row decodes cleanly");
+    check_i64(ok.attempts(), 1, "the fixture row decodes cleanly");
+
+    // Every non-nullable field on a snapshot, absent and explicitly
+    // null. This loop is what catches a thirteenth field added later
+    // with a tolerant lookup.
+    const std::vector<std::string> required = {
+        "id", "queue", "payload", "state", "priority",
+        "run_at", "attempts", "max_attempts", "created_at",
+    };
+    for (const auto& key : required) {
+        auto absent = good_row();
+        absent.erase(key);
+        expect_honker_error(
+            [&] { (void)honker::JobSnapshot::from_json(absent); },
+            "missing required field '" + key + "'",
+            "snapshot with no " + key);
+
+        auto nulled = good_row();
+        nulled[key] = nullptr;
+        expect_honker_error(
+            [&] { (void)honker::JobSnapshot::from_json(nulled); },
+            "missing required field '" + key + "'",
+            "snapshot with a null " + key);
+    }
+
+    // A claimed row always carries the claim fields, so Job requires
+    // the two that JobSnapshot leaves optional.
+    for (const auto& key : std::vector<std::string>{"worker_id", "claim_expires_at"}) {
+        auto absent = good_row();
+        absent.erase(key);
+        expect_honker_error(
+            [&] { (void)honker::Job::from_json(nullptr, absent); },
+            "missing required field '" + key + "'",
+            "claimed job with no " + key);
+    }
+
+    // A row that is not an object at all.
+    expect_honker_error(
+        [] { (void)honker::JobSnapshot::from_json(json::array({1, 2})); },
+        "not a JSON object", "snapshot from a JSON array");
+
+    std::cout << "decode_rejects_a_missing_required_field: ok\n";
+}
+
+void test_decode_reports_a_wrong_typed_field_as_honker_error() {
+    // README promises honker::Error, so nlohmann's type_error must not
+    // escape. expect_honker_error fails loudly if it does.
+    struct Case {
+        std::string key;
+        json        value;
+        std::string want;
+    };
+    const std::vector<Case> cases = {
+        {"id",               json("101"),                  "an integer"},
+        {"attempts",         json(true),                   "an integer"},
+        {"claim_expires_at", json("1700000137"),           "an integer"},
+        {"payload",          json::object({{"n", 1}}),     "a string"},
+        {"queue",            json::array({"details"}),     "a string"},
+        {"state",            json(3),                      "a string"},
+        // Nullable fields decode through the same helper.
+        {"expires_at",       json("1700009000"),           "an integer"},
+        {"worker_id",        json(7),                      "a string"},
+    };
+    for (const auto& c : cases) {
+        auto bad = good_row();
+        bad[c.key] = c.value;
+        expect_honker_error(
+            [&] { (void)honker::JobSnapshot::from_json(bad); },
+            "field '" + c.key + "' is not " + c.want,
+            "snapshot with a wrong-typed " + c.key);
+    }
+
+    // Same guarantee on the claim path.
+    auto bad_claim = good_row();
+    bad_claim["worker_id"] = 7;
+    expect_honker_error(
+        [&] { (void)honker::Job::from_json(nullptr, bad_claim); },
+        "field 'worker_id' is not a string",
+        "claimed job with a wrong-typed worker_id");
+
+    std::cout << "decode_reports_a_wrong_typed_field_as_honker_error: ok\n";
+}
+
 }  // anonymous namespace
 
 int main() {
+    // Decode-failure tests first: they need no extension, so they run
+    // even where the DB-backed tests below would skip.
+    try {
+        test_decode_rejects_unparseable_json();
+        test_decode_rejects_a_non_array_claim_result();
+        test_decode_rejects_a_missing_required_field();
+        test_decode_reports_a_wrong_typed_field_as_honker_error();
+    } catch (const std::exception& e) {
+        std::cerr << "FAIL: " << e.what() << '\n';
+        return 1;
+    }
+
     const char* ext = std::getenv("HONKER_EXTENSION_PATH");
     if (!ext || !*ext) {
         std::fputs(

--- a/packages/honker-cpp/test/test_job_details.cpp
+++ b/packages/honker-cpp/test/test_job_details.cpp
@@ -476,6 +476,73 @@ void test_decode_reports_a_wrong_typed_field_as_honker_error() {
     std::cout << "decode_reports_a_wrong_typed_field_as_honker_error: ok\n";
 }
 
+void test_stream_and_scheduler_rows_decode_loudly() {
+    // Same anti-pattern as the job decoders, same fix. The offset one
+    // is the dangerous shape: a swallowed row used to yield offset 0,
+    // and a consumer that saved that offset replayed the whole topic.
+    const json event = json{
+        {"offset", 42},
+        {"topic", "t"},
+        {"key", "k"},
+        {"payload", R"({"n":1})"},
+        {"created_at", 1700000000},
+    };
+
+    // Positive: the well-formed row decodes, and a null key stays the
+    // empty string rather than becoming an error.
+    auto unkeyed = event;
+    unkeyed["key"] = nullptr;
+    const auto events = honker::detail::parse_stream_events(
+        json::array({event, unkeyed}).dump());
+    check_i64(static_cast<int64_t>(events.size()), 2, "stream events decoded");
+    check_i64(events[0].offset(), 42, "stream event offset");
+    check_str(events[0].key(), "k", "stream event key");
+    check_str(events[1].key(), "", "a null key decodes to the empty string");
+
+    for (const auto& key : std::vector<std::string>{
+             "offset", "topic", "payload", "created_at"}) {
+        auto bad = event;
+        bad.erase(key);
+        expect_honker_error(
+            [&] { (void)honker::detail::parse_stream_events(json::array({bad}).dump()); },
+            "missing required field '" + key + "'",
+            "stream event with no " + key);
+    }
+    auto typed = event;
+    typed["offset"] = "42";
+    expect_honker_error(
+        [&] { (void)honker::detail::parse_stream_events(json::array({typed}).dump()); },
+        "field 'offset' is not an integer",
+        "stream event with a string offset");
+    expect_honker_error(
+        [] { (void)honker::detail::parse_stream_events("{oops"); },
+        "not parseable", "stream read blob that is not JSON");
+
+    const json fire = json{
+        {"name", "nightly"},
+        {"queue", "emails"},
+        {"fire_at", 1700000000},
+        {"job_id", 7},
+    };
+    const auto fires = honker::detail::parse_scheduler_fires(json::array({fire}).dump());
+    check_i64(static_cast<int64_t>(fires.size()), 1, "scheduler fires decoded");
+    check_i64(fires[0].job_id(), 7, "scheduler fire job_id");
+
+    for (const auto& key : std::vector<std::string>{"name", "queue", "fire_at", "job_id"}) {
+        auto bad = fire;
+        bad.erase(key);
+        expect_honker_error(
+            [&] { (void)honker::detail::parse_scheduler_fires(json::array({bad}).dump()); },
+            "missing required field '" + key + "'",
+            "scheduler fire with no " + key);
+    }
+    expect_honker_error(
+        [] { (void)honker::detail::parse_scheduler_fires(R"({"name":"n"})"); },
+        "not a JSON array", "scheduler tick result that is a single object");
+
+    std::cout << "stream_and_scheduler_rows_decode_loudly: ok\n";
+}
+
 }  // anonymous namespace
 
 int main() {
@@ -486,6 +553,7 @@ int main() {
         test_decode_rejects_a_non_array_claim_result();
         test_decode_rejects_a_missing_required_field();
         test_decode_reports_a_wrong_typed_field_as_honker_error();
+        test_stream_and_scheduler_rows_decode_loudly();
     } catch (const std::exception& e) {
         std::cerr << "FAIL: " << e.what() << '\n';
         return 1;

--- a/packages/honker-cpp/test/test_job_details.cpp
+++ b/packages/honker-cpp/test/test_job_details.cpp
@@ -485,6 +485,17 @@ void test_decode_rejects_a_missing_required_field() {
         [] { (void)honker::JobSnapshot::from_json(json::array({1, 2})); },
         "not a JSON object", "snapshot from a JSON array");
 
+    // The nullable helpers are nullable, not tolerant. Without their own
+    // object check they read nullopt off any non-object, which would let
+    // a garbage row decode as "every optional field is unset" the moment
+    // a required field stops being read first.
+    expect_honker_error(
+        [] { (void)honker::detail::row_opt_i64(json::array({1}), "expires_at", "job row"); },
+        "not a JSON object", "row_opt_i64 on a row that is not an object");
+    expect_honker_error(
+        [] { (void)honker::detail::row_opt_str(json("nope"), "worker_id", "job row"); },
+        "not a JSON object", "row_opt_str on a row that is not an object");
+
     std::cout << "decode_rejects_a_missing_required_field: ok\n";
 }
 

--- a/packages/honker-cpp/test/test_job_details.cpp
+++ b/packages/honker-cpp/test/test_job_details.cpp
@@ -300,6 +300,57 @@ void test_get_job_json_still_returns_the_raw_blob(const char* ext) {
     std::cout << "get_job_json_still_returns_the_raw_blob: ok\n";
 }
 
+void exec_raw(sqlite3* db, const char* sql) {
+    char* err = nullptr;
+    if (sqlite3_exec(db, sql, nullptr, nullptr, &err) != SQLITE_OK) {
+        const std::string msg = err ? err : "unknown error";
+        sqlite3_free(err);
+        fail(std::string{"exec_raw failed for "} + sql + ": " + msg);
+    }
+}
+
+// The decoders throw on a malformed stream row so a bad row cannot
+// become offset 0. That only closes the read half. The write half is
+// StreamSubscription's checkpoint: if it drops a failed save on the
+// floor, the consumer replays the topic just the same, and nothing —
+// not the destructor's catch (...), not save_offset() — ever says so.
+void test_stream_subscription_reports_a_failed_checkpoint(const char* ext) {
+    const auto path = fs::temp_directory_path() / "honker-cpp-details-checkpoint.db";
+    auto db = open_db(path, ext);
+    auto stream = db.stream("checkpoints");
+    const int64_t first_offset = stream.publish(R"({"n":1})");
+    stream.publish(R"({"n":2})");
+
+    // save_every_n is far above the event count, so the only checkpoint
+    // in this test is the one it asks for explicitly.
+    auto sub = stream.subscribe("consumer-a", 1000, std::chrono::milliseconds(20));
+    auto first = sub.next();
+    if (!first.has_value()) fail("the subscription produced no event");
+    check_i64(first->offset(), first_offset, "first event offset");
+
+    // query_only makes every write on this connection fail the way a
+    // read-only volume or a full disk would.
+    exec_raw(db.raw(), "PRAGMA query_only = 1");
+    bool reported = false;
+    try {
+        sub.save_offset();
+    } catch (const honker::Error&) {
+        reported = true;
+    }
+    exec_raw(db.raw(), "PRAGMA query_only = 0");
+    if (!reported) fail("save_offset swallowed a failed checkpoint write");
+
+    // The failure did not fake a checkpoint either.
+    check_i64(stream.get_offset("consumer-a"), 0,
+              "a failed checkpoint must leave the saved offset untouched");
+
+    // And the position is still pending, so a retry commits it.
+    sub.save_offset();
+    check_i64(stream.get_offset("consumer-a"), first_offset,
+              "the retry saved the offset the failed write did not");
+
+    std::cout << "stream_subscription_reports_a_failed_checkpoint: ok\n";
+}
 
 // ---------------------------------------------------------------------
 // Decode failures. These are the tests that defend the "fails loudly"
@@ -574,6 +625,7 @@ int main() {
         test_snapshot_pending_then_processing_then_miss(ext);
         test_delayed_job_snapshot_reports_future_run_at(ext);
         test_get_job_json_still_returns_the_raw_blob(ext);
+        test_stream_subscription_reports_a_failed_checkpoint(ext);
     } catch (const std::exception& e) {
         std::cerr << "FAIL: " << e.what() << '\n';
         return 1;


### PR DESCRIPTION
Part of #136 (C++ binding checklist item).

## Stacked on #124

**This PR targets `feat/node-typed-jobs` (#124), not `main`, and must merge after #124.** It depends on the widened `honker_claim_batch` RETURNING clause that exists only on that branch. `honker-core` is unchanged here.

## What changed

`packages/honker-cpp/include/honker.hpp` only — no Zig, no C ABI change.

- **All twelve fields on `honker::Job`.** Added `queue()`, `state()`, `priority()`, `run_at()`, `claim_expires_at()`, `max_attempts()`, `created_at()`, `expires_at()` alongside the existing `id()`, `payload()`, `worker_id()`, `attempts()`. Keeps `ack()` / `retry()` / `fail()` / `heartbeat()`.
- **New `honker::JobSnapshot`.** Same twelve fields, data only, no claim methods. Returned by the new `Queue::get_job(id) -> std::optional<JobSnapshot>`.
- On `Job`, `worker_id()` and `claim_expires_at()` are plain values because holding a claim is what makes it a `Job`. On `JobSnapshot` they are `std::optional` because a pending row has neither. `expires_at()` is `std::optional<int64_t>` on both.
- `Queue::get_job_json(id)` is unchanged and still returns the undecoded blob.
- **Style.** Followed what is already in this header: snake_case accessor methods, trailing-underscore members, `std::optional` for nullable fields, `nlohmann::json` for parsing (already a header dependency, used by `Outbox`). No templates and no codec — #136 explicitly says C++ keeps dynamic values / raw JSON unless a small codec helper is useful, and nothing here needed one.

## Payload encoding (please read: cross-binding divergence)

Per the coordination note, payload encoding is **unchanged**: `payload()` is the raw JSON text on both `Job` and `JobSnapshot`, exactly as before.

| binding | claimed job payload | snapshot (`getJob`/`get_job`) payload |
| --- | --- | --- |
| C++ (this PR) | raw JSON text | raw JSON text |
| Node (#124) | decoded value | **decoded value** |
| Rust | raw JSON bytes | raw JSON text |
| Go | raw JSON | raw JSON text |
| Python | raw JSON | raw JSON text |

Node decodes; the rest hand back raw. Worth one deliberate decision across all bindings later. Flagging, not resolving.

## Fail loudly (behavior change)

Claim parsing used to be wrapped in `catch (...) {}` and pulled fields with `j.value("id", 0)`, `j.value("attempts", 1)`, and friends. A malformed blob silently became an empty result, and a missing field silently became a plausible-looking default — exactly the failure mode that would make a field-parity test pass for the wrong reason.

Decoding now throws `honker::Error` on unparseable JSON or on a missing/null required field. Nullable fields (`worker_id` and `claim_expires_at` on a snapshot, `expires_at` on both) still decode to `std::nullopt`. An empty claim result is still an empty result — that is a real answer, not a failure.

## ABI

No exported C symbol added, removed, or renamed. `honker_cpp_cancel`, `honker_cpp_get_job`, `honker_cpp_claim_batch` and the rest are untouched, and `src/honker.zig` has no diff. `Job`'s public constructor is replaced by a `Job::from_json(sqlite3*, const nlohmann::json&)` factory; nothing in the repo constructed a `Job` directly.

## Tests

New `packages/honker-cpp/test/test_job_details.cpp`, registered in `build.zig`. 5 tests, all passing:

- `claimed_job_carries_every_core_field`
- `claimed_job_attempts_count_up_across_retries`
- `snapshot_pending_then_processing_then_miss`
- `delayed_job_snapshot_reports_future_run_at`
- `get_job_json_still_returns_the_raw_blob`

Every field is asserted against a value that could not be produced by another field. The fixture deliberately avoids defaults and same-second coincidences: visibility timeout 137s (not 300), `max_attempts` 9 (not 3), priorities 42 and 7 on two rows so `priority` cannot be a constant, `run_at` back-dated 300s so it is never equal to `created_at`, `expires_at` set on one row and null on the other, and `claim_expires_at` bracketed against the claim instant plus 137s.

The C ABI's `honker_cpp_enqueue` takes only delay/priority/max_attempts, so the fixture rows that need an absolute `run_at` or an expiry are inserted through the `honker_enqueue` SQL function on `db.raw()`. That is only how the row gets on disk; the read path under test is the ordinary binding one. The binding's own `enqueue()` is exercised by the delay and raw-blob tests.

Assertions use small `check_i64` / `check_str` / `check_range` helpers so a failure prints got-vs-want rather than just an expression.

The existing suites (`test_basic`, `test_parity` 28 tests, `test_phase_mantle` 8 tests) pass unmodified against the new header.

### Proof the tests are load-bearing

Two mutations, each reverted after:

**1. `run_at` sourced from `created_at`** in `Job::from_json`. `claimed_job_carries_every_core_field` fails:

```
FAIL: run_at: got 1788257032, want 1788256732
```

The 300-second gap is the deliberate `run_at` back-date.

**2. `created_at` sourced from `run_at`** in `JobSnapshot::from_json`. `delayed_job_snapshot_reports_future_run_at` fails:

```
FAIL: run_at must sit exactly 600s after created_at: got 0, want 600
```

This one is the interesting case: `snapshot_pending_then_processing_then_miss` **passed** under that mutation, because an undelayed job legitimately has `run_at == created_at`. That is exactly the coincidence-equality false pass to watch for, and the delayed-job test is what discriminates it.

Run locally with:

```
zig build test -Dsqlite-prefix="$(brew --prefix sqlite)" \
  -Djson-prefix="$(brew --prefix nlohmann-json)" \
  -Dhonker-ext=/path/to/libhonker_ext.dylib
```

## Not in scope

- `claimed_at`: that is #135 / PR #140 on another branch, deliberately not added here.
- `honker-core`, the SQL ABI, and `src/honker.zig` are untouched.
- Queue-scoped `get_job`: #134.
- No other binding touched.

https://claude.ai/code/session_01YMCFasvKC52r37DDKSTeMC
