### PR TITLE
Enforce JSON payload contract in core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,35 @@
   an M-series laptop, about 23.5 µs to 24.1 µs per enqueue against a 3.0 s
   floor. The enqueue cost is dominated by the SQLite insert and binding
   marshaling, not by the JSON check.
+- **Check `_honker_scheduler_tasks` before upgrading.** Existing rows are not
+  validated retroactively, and the two tables behave very differently. A
+  legacy `_honker_live` row is inert: it still claims, retries, and
+  dead-letters, and the decode failure lands on whichever consumer reads it. A
+  legacy `_honker_scheduler_tasks` row is not. `scheduler_tick` fires every due
+  schedule in one call, so one unfixable payload fails the whole tick — no
+  schedule advances its `next_fire_at` and **none of your other schedules
+  fire** until that row is fixed or removed. The tick error names the schedule
+  and queue so you can find it:
+
+  ```text
+  honker: payload must be valid JSON: expected ident at line 1 column 2
+    (schedule "nightly-report", queue "reports"); fix or remove the schedule
+    row, then tick again
+  ```
+
+  Repair it with `honker_scheduler_update(name, NULL, '<json>', ...)`, or drop
+  it with `honker_scheduler_unregister(name)`.
+- **`save_result` takes raw text in most bindings** and now requires that text
+  to be JSON. Rust, Go, Node, Bun, Ruby, Elixir, C++, JVM, and Kotlin all pass
+  the value through unserialized, unlike their `enqueue` / `publish` / `notify`
+  methods. `save_result(id, "done", ttl)` used to store `done` and now fails —
+  pass `'"done"'`. Python and .NET serialize for you and are unaffected.
 - The migration detection query in the guide,
-  `SELECT id FROM _honker_live WHERE NOT json_valid(payload)`, still does not
-  agree with honker exactly. `json_valid()` returns 1 for lone surrogates and
-  for `1e999`, so it will miss legacy rows that honker now rejects. To find
-  every row that will not decode, decode it.
+  `SELECT id FROM _honker_live WHERE NOT json_valid(payload)` (and the same
+  query over `_honker_scheduler_tasks`), still does not agree with honker
+  exactly. `json_valid()` returns 1 for lone surrogates, for `1e999`, and for
+  nesting between 129 and about 1000 levels, so it will miss legacy rows that
+  honker now rejects. To find every row that will not decode, decode it.
 
 ## 2026-08-27 — Node 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## Unreleased — JSON payload contract
+
+- **Breaking:** every payload accepted by Honker core must be valid JSON. Queue
+  enqueue, stream publish, notifications, task results, and scheduler register
+  or update now reject non-JSON text with
+  `honker: payload must be valid JSON`. Objects, arrays, strings, numbers,
+  booleans, and `null` remain valid payloads. Language bindings already encode
+  payloads as JSON; callers using the SQL extension directly must pass JSON
+  text.
+
 ## 2026-08-27 — Node 0.5.1
 
 - Node `@russellthehippo/honker-node`: 0.5.1, with the four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,49 @@
 
 ## Unreleased — JSON payload contract
 
-- **Breaking:** every payload accepted by Honker core must be valid JSON. Queue
-  enqueue, stream publish, notifications, task results, and scheduler register
-  or update now reject non-JSON text with
-  `honker: payload must be valid JSON`. Objects, arrays, strings, numbers,
-  booleans, and `null` remain valid payloads. Typed binding APIs encode values
-  where documented; raw JSON APIs and direct SQL callers must pass serialized
-  JSON text.
+- **Breaking:** every payload accepted by Honker core must be JSON that a JSON
+  decoder can read back. Queue enqueue, stream publish, notifications, task
+  results, and scheduler register or update all validate before the write.
+  Objects, arrays, strings, numbers, booleans, and `null` remain valid
+  payloads. Typed binding APIs encode values where documented; raw JSON APIs
+  and direct SQL callers must pass serialized JSON text.
+- Validation parses into `serde_json::Value` — the same thing the read side
+  does — rather than scanning the grammar structurally. A structural scan does
+  not unescape strings, range-check numbers, or bound nesting, so it accepted
+  text that no decoder can read. Three payload classes that used to enqueue
+  now fail at the producer instead:
+  - **Lone surrogates**, such as `"\ud800"` or `{"a":"\ud800"}`. Valid by the
+    JSON grammar, not representable as UTF-8. Both `json.dumps` in Python and
+    `JSON.stringify` in Node can emit these.
+  - **Numbers outside f64 range**, such as `1e999`, `-1e999`, or
+    `{"a":1e999}`.
+  - **Nesting deeper than 128 levels**, which is `serde_json`'s own recursion
+    limit. SQLite's `json_valid()` allows about 1000, so honker is now the
+    stricter of the two on depth.
+
+  This is intended, not a regression. A producer emitting any of these was
+  creating a job that a consumer could not decode — the failure moved from an
+  unrelated process at read time to the caller that caused it. If you were
+  relying on one of these shapes, encode it: escape a surrogate pair properly,
+  send an out-of-range number as a string, or flatten the nesting.
+- Rejection messages now name the actual problem and carry serde's own text.
+  Text that is not JSON gets
+  `honker: payload must be valid JSON: <serde message>`. Text that parses as
+  JSON but cannot be decoded gets
+  `honker: payload is valid JSON but cannot be decoded: <serde message>` —
+  telling that caller their payload "must be valid JSON" would send them
+  hunting for a syntax error they do not have.
+- The stricter parse is not measurable at the enqueue floor:
+  `tests/test_performance_floors.py::test_enqueue_throughput_floor_one_tx`
+  (10,000 enqueues in one transaction) went from 0.235 s to 0.241 s median on
+  an M-series laptop, about 23.5 µs to 24.1 µs per enqueue against a 3.0 s
+  floor. The enqueue cost is dominated by the SQLite insert and binding
+  marshaling, not by the JSON check.
+- The migration detection query in the guide,
+  `SELECT id FROM _honker_live WHERE NOT json_valid(payload)`, still does not
+  agree with honker exactly. `json_valid()` returns 1 for lone surrogates and
+  for `1e999`, so it will miss legacy rows that honker now rejects. To find
+  every row that will not decode, decode it.
 
 ## 2026-08-27 — Node 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
   enqueue, stream publish, notifications, task results, and scheduler register
   or update now reject non-JSON text with
   `honker: payload must be valid JSON`. Objects, arrays, strings, numbers,
-  booleans, and `null` remain valid payloads. Language bindings already encode
-  payloads as JSON; callers using the SQL extension directly must pass JSON
-  text.
+  booleans, and `null` remain valid payloads. Typed binding APIs encode values
+  where documented; raw JSON APIs and direct SQL callers must pass serialized
+  JSON text.
 
 ## 2026-08-27 — Node 0.5.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "rusqlite",
+ "serde",
  "serde_json",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,6 @@ dependencies = [
  "notify",
  "parking_lot",
  "rusqlite",
- "serde",
  "serde_json",
  "thiserror",
 ]

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ work. Commit lands both rows. Rollback drops both rows.
 
 Payloads are JSON. Queue enqueue, stream publish, notifications, task results,
 and scheduler register/update accept any valid JSON value: objects, arrays,
-strings, numbers, booleans, or `null`. Language bindings serialize values for
-you. When calling the SQL extension directly, pass serialized JSON text (for
+strings, numbers, booleans, or `null`. Typed binding APIs serialize values where
+documented. Raw JSON APIs and direct SQL calls require serialized JSON text (for
 example, `'{"id":42}'`, `'[1,2]'`, or `'"ready"'`); non-JSON text is rejected.
 
 SQLite has no server-side push channel, so honker uses a shared watcher.
@@ -157,7 +157,7 @@ Any SQLite client that can load extensions can use honker directly:
 ```sql
 .load ./libhonker_ext
 SELECT honker_bootstrap();
-INSERT INTO _honker_live (queue, payload) VALUES ('emails', '{"to":"alice"}');
+SELECT honker_enqueue('emails', '{"to":"alice"}', NULL, NULL, 0, 3, NULL);
 SELECT honker_claim_batch('emails', 'worker-1', 32, 300);    -- JSON array
 SELECT honker_ack_batch('[1,2,3]', 'worker-1');              -- DELETEs; returns count
 SELECT honker_sweep_expired('emails');                       -- count moved to dead
@@ -181,7 +181,6 @@ SELECT honker_result_save(42, '{"ok":true}', 3600);          -- save w/ 1h TTL
 SELECT honker_result_get(42);                                -- value or NULL
 SELECT honker_result_sweep();                                -- prune expired
 SELECT notify('orders', '{"id":42}');
-SELECT honker_enqueue('emails', '{"to":"alice@example.com"}', NULL, NULL, 0, 3, NULL);
 ```
 
 The extension shares tables with the language bindings, so a Python

--- a/README.md
+++ b/README.md
@@ -91,10 +91,17 @@ All three are INSERTs inside your transaction. Put `queue.enqueue(...)`,
 work. Commit lands both rows. Rollback drops both rows.
 
 Payloads are JSON. Queue enqueue, stream publish, notifications, task results,
-and scheduler register/update accept any valid JSON value: objects, arrays,
-strings, numbers, booleans, or `null`. Typed binding APIs serialize values where
-documented. Raw JSON APIs and direct SQL calls require serialized JSON text (for
-example, `'{"id":42}'`, `'[1,2]'`, or `'"ready"'`); non-JSON text is rejected.
+and scheduler register/update accept any JSON value that decodes: objects,
+arrays, strings, numbers, booleans, or `null`. Typed binding APIs serialize
+values where documented. Raw JSON APIs and direct SQL calls require serialized
+JSON text (for example, `'{"id":42}'`, `'[1,2]'`, or `'"ready"'`); non-JSON text
+is rejected.
+
+Validation parses the payload the same way the read side does, so anything that
+enqueues will decode. That rules out a few shapes the JSON grammar allows but no
+decoder can represent: lone surrogates such as `"\ud800"`, numbers outside f64
+range such as `1e999`, and nesting deeper than 128 levels. These are rejected at
+the producer rather than surfacing as an undecodable job in another process.
 
 SQLite has no server-side push channel, so honker uses a shared watcher.
 The stable backend reads `PRAGMA data_version` every millisecond; when

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ All three are INSERTs inside your transaction. Put `queue.enqueue(...)`,
 `stream.publish(...)`, or `notify(...)` beside the write that created the
 work. Commit lands both rows. Rollback drops both rows.
 
+Payloads are JSON. Queue enqueue, stream publish, notifications, task results,
+and scheduler register/update accept any valid JSON value: objects, arrays,
+strings, numbers, booleans, or `null`. Language bindings serialize values for
+you. When calling the SQL extension directly, pass serialized JSON text (for
+example, `'{"id":42}'`, `'[1,2]'`, or `'"ready"'`); non-JSON text is rejected.
+
 SQLite has no server-side push channel, so honker uses a shared watcher.
 The stable backend reads `PRAGMA data_version` every millisecond; when
 the counter changes, listeners re-read indexed SQLite state.

--- a/honker-core/Cargo.toml
+++ b/honker-core/Cargo.toml
@@ -28,8 +28,7 @@ name = "honker_core"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 parking_lot = "0.12.5"
 rusqlite = { version = "0.40.1", features = ["functions", "hooks"] }
-serde = "1"
-serde_json = "1"
+serde_json = { version = "1", features = ["raw_value"] }
 thiserror = "2.0.18"
 # Optional: kernel-watch backend.
 # macos_kqueue: on macOS, use kqueue (RecommendedWatcher = KqueueWatcher) instead of

--- a/honker-core/Cargo.toml
+++ b/honker-core/Cargo.toml
@@ -28,6 +28,7 @@ name = "honker_core"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 parking_lot = "0.12.5"
 rusqlite = { version = "0.40.1", features = ["functions", "hooks"] }
+serde = "1"
 serde_json = "1"
 thiserror = "2.0.18"
 # Optional: kernel-watch backend.

--- a/honker-core/Cargo.toml
+++ b/honker-core/Cargo.toml
@@ -28,7 +28,8 @@ name = "honker_core"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 parking_lot = "0.12.5"
 rusqlite = { version = "0.40.1", features = ["functions", "hooks"] }
-serde_json = { version = "1", features = ["raw_value"] }
+serde = "1"
+serde_json = "1"
 thiserror = "2.0.18"
 # Optional: kernel-watch backend.
 # macos_kqueue: on macOS, use kqueue (RecommendedWatcher = KqueueWatcher) instead of

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -1747,7 +1747,22 @@ mod payload_tests {
     use crate::{attach_honker_functions, bootstrap_honker_schema};
     use rusqlite::params;
 
+    // Bare scalars are JSON. A stricter validator is most likely to break
+    // these by accident, and #152 settled that they must keep working.
     const VALID_JSON_PAYLOADS: [&str; 6] = ["{}", "[]", "42", "\"str\"", "true", "null"];
+
+    // Valid by the JSON grammar, but no decoder can represent them: a lone
+    // surrogate is not valid UTF-8, and 1e999 overflows f64. A structural
+    // scan accepts all of these; `serde_json::Value` -- the read side --
+    // rejects them. Accepting them at enqueue is how a Python producer
+    // creates a job a Rust consumer cannot decode.
+    const UNDECODABLE_JSON_PAYLOADS: [&str; 5] = [
+        r#""\ud800""#,
+        r#"{"a":"\ud800"}"#,
+        "1e999",
+        r#"{"a":1e999}"#,
+        "-1e999",
+    ];
 
     fn db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
@@ -1758,10 +1773,33 @@ mod payload_tests {
 
     fn assert_payload_error<T>(result: rusqlite::Result<T>) {
         let err = result.err().expect("non-JSON payload must be rejected");
+        let text = err.to_string();
         assert!(
-            err.to_string()
-                .contains("honker: payload must be valid JSON"),
+            text.contains("honker: payload must be valid JSON"),
             "expected the JSON payload contract error, got: {err}"
+        );
+        assert!(
+            text.contains("line 1 column"),
+            "the error must pass serde's own message through so it names \
+             the real problem, got: {err}"
+        );
+    }
+
+    /// Text that parses as JSON but cannot be decoded gets its own message.
+    /// Telling this caller their payload "must be valid JSON" would send
+    /// them hunting for a syntax error they do not have.
+    fn assert_undecodable_payload_error<T>(result: rusqlite::Result<T>, payload: &str) {
+        let err = result
+            .err()
+            .unwrap_or_else(|| panic!("undecodable JSON payload must be rejected: {payload}"));
+        let text = err.to_string();
+        assert!(
+            text.contains("honker: payload is valid JSON but cannot be decoded"),
+            "expected the undecodable-JSON error for {payload}, got: {err}"
+        );
+        assert!(
+            text.contains("line 1 column"),
+            "the error must pass serde's own message through for {payload}, got: {err}"
         );
     }
 
@@ -1929,6 +1967,103 @@ mod payload_tests {
         ] {
             let result = conn.query_row(sql, ["not json"], |r| r.get::<_, i64>(0));
             assert_payload_error(result);
+        }
+        let stored: String = conn
+            .query_row(
+                "SELECT payload FROM _honker_scheduler_tasks WHERE name = 'nightly'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, "{}", "rejected payload must not be written");
+    }
+
+    #[test]
+    fn orm_select_enqueue_rejects_undecodable_json_payload() {
+        let conn = db();
+        for payload in UNDECODABLE_JSON_PAYLOADS {
+            let result = conn.query_row(
+                "SELECT honker_enqueue('emails', ?1, NULL, NULL, 0, 3, NULL)",
+                [payload],
+                |r| r.get::<_, i64>(0),
+            );
+            assert_undecodable_payload_error(result, payload);
+        }
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_live", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "rejected payload must not be written");
+    }
+
+    #[test]
+    fn stream_publish_rejects_undecodable_json_payload() {
+        let conn = db();
+        for payload in UNDECODABLE_JSON_PAYLOADS {
+            let result = conn.query_row(
+                "SELECT honker_stream_publish('orders', NULL, ?1)",
+                [payload],
+                |r| r.get::<_, i64>(0),
+            );
+            assert_undecodable_payload_error(result, payload);
+        }
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_stream", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "rejected payload must not be written");
+    }
+
+    #[test]
+    fn result_save_rejects_undecodable_json_payload() {
+        let conn = db();
+        for payload in UNDECODABLE_JSON_PAYLOADS {
+            let result = conn.query_row("SELECT honker_result_save(1, ?1, 0)", [payload], |r| {
+                r.get::<_, i64>(0)
+            });
+            assert_undecodable_payload_error(result, payload);
+        }
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_results", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "rejected payload must not be written");
+    }
+
+    #[test]
+    fn scheduler_register_rejects_undecodable_json_payload() {
+        let conn = db();
+        for payload in UNDECODABLE_JSON_PAYLOADS {
+            for sql in [
+                "SELECT honker_scheduler_register('nightly-6', 'backups', '@every 1m', ?1, 0, NULL)",
+                "SELECT honker_scheduler_register('nightly-7', 'backups', '@every 1m', ?1, 0, NULL, 3)",
+            ] {
+                let result = conn.query_row(sql, [payload], |r| r.get::<_, i64>(0));
+                assert_undecodable_payload_error(result, payload);
+            }
+        }
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_scheduler_tasks", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 0, "rejected payload must not be written");
+    }
+
+    #[test]
+    fn scheduler_update_rejects_undecodable_json_payload() {
+        let conn = db();
+        conn.query_row(
+            "SELECT honker_scheduler_register('nightly', 'backups', '@every 1m', '{}', 0, NULL, 3)",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap();
+        for payload in UNDECODABLE_JSON_PAYLOADS {
+            for sql in [
+                "SELECT honker_scheduler_update('nightly', NULL, ?1, NULL, NULL, 0)",
+                "SELECT honker_scheduler_update('nightly', NULL, ?1, NULL, NULL, 0, NULL, 0)",
+            ] {
+                let result = conn.query_row(sql, [payload], |r| r.get::<_, i64>(0));
+                assert_undecodable_payload_error(result, payload);
+            }
         }
         let stored: String = conn
             .query_row(

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -782,6 +782,7 @@ pub fn enqueue(
     max_attempts: i64,
     expires: Option<i64>,
 ) -> rusqlite::Result<i64> {
+    super::validate_json_payload(payload)?;
     let now: i64 = conn.query_row("SELECT unixepoch()", [], |r| r.get(0))?;
     let run_at_val: i64 = match (delay, run_at) {
         (Some(d), _) => now + d,
@@ -1234,6 +1235,7 @@ pub fn scheduler_register(
     expires_s: Option<i64>,
     max_attempts: i64,
 ) -> rusqlite::Result<i64> {
+    super::validate_json_payload(payload)?;
     let max_attempts = if max_attempts < 1 { 1 } else { max_attempts };
     let now = now_unix(conn)?;
     let next_fire_at = super::cron::next_after_unix(cron_expr, now).map_err(to_sql_err)?;
@@ -1502,6 +1504,9 @@ pub fn scheduler_update(
     expires_s: Option<Option<i64>>,
     max_attempts: Option<Option<i64>>,
 ) -> rusqlite::Result<i64> {
+    if let Some(payload) = payload {
+        super::validate_json_payload(payload)?;
+    }
     // Verify exists first so we can return 0 cleanly without dynamic SQL gymnastics.
     let exists: bool = conn
         .query_row(
@@ -1590,6 +1595,7 @@ pub fn result_save(
     value: &str,
     ttl_s: i64,
 ) -> rusqlite::Result<i64> {
+    super::validate_json_payload(value)?;
     if ttl_s > 0 {
         conn.execute(
             "INSERT INTO _honker_results (job_id, value, expires_at)
@@ -1646,6 +1652,7 @@ pub fn stream_publish(
     key: Option<&str>,
     payload: &str,
 ) -> rusqlite::Result<i64> {
+    super::validate_json_payload(payload)?;
     // Stream row INSERT advances data_version on commit — same wake
     // path as enqueue. No synthetic notification row (see enqueue).
     let offset: i64 = conn.query_row(
@@ -1732,6 +1739,202 @@ pub fn stream_get_offset(conn: &Connection, consumer: &str, topic: &str) -> rusq
 
 fn now_unix(conn: &Connection) -> rusqlite::Result<i64> {
     conn.query_row("SELECT unixepoch()", [], |r| r.get(0))
+}
+
+#[cfg(test)]
+mod payload_tests {
+    use super::*;
+    use crate::{attach_honker_functions, bootstrap_honker_schema};
+
+    const VALID_JSON_PAYLOADS: [&str; 6] = ["{}", "[]", "42", "\"str\"", "true", "null"];
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        bootstrap_honker_schema(&conn).unwrap();
+        conn
+    }
+
+    fn assert_payload_error<T>(result: rusqlite::Result<T>) {
+        let err = result.err().expect("non-JSON payload must be rejected");
+        assert!(
+            err.to_string()
+                .contains("honker: payload must be valid JSON"),
+            "expected the JSON payload contract error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn enqueue_rejects_non_json_payload() {
+        let conn = db();
+        assert_payload_error(enqueue(&conn, "emails", "not json", None, None, 0, 3, None));
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_live", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "rejected payload must not be written");
+    }
+
+    #[test]
+    fn enqueue_accepts_every_json_payload_shape() {
+        let conn = db();
+        for payload in VALID_JSON_PAYLOADS {
+            let id = enqueue(&conn, "emails", payload, None, None, 0, 3, None).unwrap();
+            let stored: String = conn
+                .query_row(
+                    "SELECT payload FROM _honker_live WHERE id = ?1",
+                    [id],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(stored, payload);
+        }
+    }
+
+    #[test]
+    fn orm_select_enqueue_rejects_non_json_payload() {
+        let conn = db();
+        attach_honker_functions(&conn).unwrap();
+        let result = conn.query_row(
+            "SELECT honker_enqueue('emails', ?1, NULL, NULL, 0, 3, NULL)",
+            ["not json"],
+            |r| r.get::<_, i64>(0),
+        );
+        assert_payload_error(result);
+    }
+
+    #[test]
+    fn stream_publish_rejects_non_json_payload() {
+        let conn = db();
+        assert_payload_error(stream_publish(&conn, "orders", None, "not json"));
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_stream", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "rejected payload must not be written");
+    }
+
+    #[test]
+    fn stream_publish_accepts_every_json_payload_shape() {
+        let conn = db();
+        for payload in VALID_JSON_PAYLOADS {
+            let offset = stream_publish(&conn, "orders", None, payload).unwrap();
+            let stored: String = conn
+                .query_row(
+                    "SELECT payload FROM _honker_stream WHERE offset = ?1",
+                    [offset],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(stored, payload);
+        }
+    }
+
+    #[test]
+    fn result_save_rejects_non_json_payload() {
+        let conn = db();
+        assert_payload_error(result_save(&conn, 1, "not json", 0));
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_results", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "rejected payload must not be written");
+    }
+
+    #[test]
+    fn result_save_accepts_every_json_payload_shape() {
+        let conn = db();
+        for (job_id, payload) in VALID_JSON_PAYLOADS.into_iter().enumerate() {
+            result_save(&conn, job_id as i64, payload, 0).unwrap();
+            assert_eq!(
+                result_get(&conn, job_id as i64).unwrap().as_deref(),
+                Some(payload)
+            );
+        }
+    }
+
+    #[test]
+    fn scheduler_register_rejects_non_json_payload() {
+        let conn = db();
+        assert_payload_error(scheduler_register(
+            &conn,
+            "nightly",
+            "backups",
+            "@every 1m",
+            "not json",
+            0,
+            None,
+            3,
+        ));
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_scheduler_tasks", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 0, "rejected payload must not be written");
+    }
+
+    #[test]
+    fn scheduler_register_accepts_every_json_payload_shape() {
+        let conn = db();
+        for payload in VALID_JSON_PAYLOADS {
+            scheduler_register(
+                &conn,
+                "nightly",
+                "backups",
+                "@every 1m",
+                payload,
+                0,
+                None,
+                3,
+            )
+            .unwrap();
+            let stored: String = conn
+                .query_row(
+                    "SELECT payload FROM _honker_scheduler_tasks WHERE name = 'nightly'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(stored, payload);
+        }
+    }
+
+    #[test]
+    fn scheduler_update_rejects_non_json_payload() {
+        let conn = db();
+        scheduler_register(&conn, "nightly", "backups", "@every 1m", "{}", 0, None, 3).unwrap();
+        assert_payload_error(scheduler_update(
+            &conn,
+            "nightly",
+            None,
+            Some("not json"),
+            None,
+            None,
+            None,
+        ));
+        let stored: String = conn
+            .query_row(
+                "SELECT payload FROM _honker_scheduler_tasks WHERE name = 'nightly'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, "{}", "rejected payload must not be written");
+    }
+
+    #[test]
+    fn scheduler_update_accepts_every_json_payload_shape() {
+        let conn = db();
+        scheduler_register(&conn, "nightly", "backups", "@every 1m", "{}", 0, None, 3).unwrap();
+        for payload in VALID_JSON_PAYLOADS {
+            scheduler_update(&conn, "nightly", None, Some(payload), None, None, None).unwrap();
+            let stored: String = conn
+                .query_row(
+                    "SELECT payload FROM _honker_scheduler_tasks WHERE name = 'nightly'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(stored, payload);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -1745,12 +1745,14 @@ fn now_unix(conn: &Connection) -> rusqlite::Result<i64> {
 mod payload_tests {
     use super::*;
     use crate::{attach_honker_functions, bootstrap_honker_schema};
+    use rusqlite::params;
 
     const VALID_JSON_PAYLOADS: [&str; 6] = ["{}", "[]", "42", "\"str\"", "true", "null"];
 
     fn db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         bootstrap_honker_schema(&conn).unwrap();
+        attach_honker_functions(&conn).unwrap();
         conn
     }
 
@@ -1764,9 +1766,14 @@ mod payload_tests {
     }
 
     #[test]
-    fn enqueue_rejects_non_json_payload() {
+    fn orm_select_enqueue_rejects_non_json_payload() {
         let conn = db();
-        assert_payload_error(enqueue(&conn, "emails", "not json", None, None, 0, 3, None));
+        let result = conn.query_row(
+            "SELECT honker_enqueue('emails', ?1, NULL, NULL, 0, 3, NULL)",
+            ["not json"],
+            |r| r.get::<_, i64>(0),
+        );
+        assert_payload_error(result);
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM _honker_live", [], |r| r.get(0))
             .unwrap();
@@ -1777,7 +1784,13 @@ mod payload_tests {
     fn enqueue_accepts_every_json_payload_shape() {
         let conn = db();
         for payload in VALID_JSON_PAYLOADS {
-            let id = enqueue(&conn, "emails", payload, None, None, 0, 3, None).unwrap();
+            let id: i64 = conn
+                .query_row(
+                    "SELECT honker_enqueue('emails', ?1, NULL, NULL, 0, 3, NULL)",
+                    [payload],
+                    |r| r.get(0),
+                )
+                .unwrap();
             let stored: String = conn
                 .query_row(
                     "SELECT payload FROM _honker_live WHERE id = ?1",
@@ -1790,21 +1803,14 @@ mod payload_tests {
     }
 
     #[test]
-    fn orm_select_enqueue_rejects_non_json_payload() {
+    fn stream_publish_rejects_non_json_payload() {
         let conn = db();
-        attach_honker_functions(&conn).unwrap();
         let result = conn.query_row(
-            "SELECT honker_enqueue('emails', ?1, NULL, NULL, 0, 3, NULL)",
+            "SELECT honker_stream_publish('orders', NULL, ?1)",
             ["not json"],
             |r| r.get::<_, i64>(0),
         );
         assert_payload_error(result);
-    }
-
-    #[test]
-    fn stream_publish_rejects_non_json_payload() {
-        let conn = db();
-        assert_payload_error(stream_publish(&conn, "orders", None, "not json"));
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM _honker_stream", [], |r| r.get(0))
             .unwrap();
@@ -1815,7 +1821,13 @@ mod payload_tests {
     fn stream_publish_accepts_every_json_payload_shape() {
         let conn = db();
         for payload in VALID_JSON_PAYLOADS {
-            let offset = stream_publish(&conn, "orders", None, payload).unwrap();
+            let offset: i64 = conn
+                .query_row(
+                    "SELECT honker_stream_publish('orders', NULL, ?1)",
+                    [payload],
+                    |r| r.get(0),
+                )
+                .unwrap();
             let stored: String = conn
                 .query_row(
                     "SELECT payload FROM _honker_stream WHERE offset = ?1",
@@ -1830,7 +1842,10 @@ mod payload_tests {
     #[test]
     fn result_save_rejects_non_json_payload() {
         let conn = db();
-        assert_payload_error(result_save(&conn, 1, "not json", 0));
+        let result = conn.query_row("SELECT honker_result_save(1, ?1, 0)", ["not json"], |r| {
+            r.get::<_, i64>(0)
+        });
+        assert_payload_error(result);
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM _honker_results", [], |r| r.get(0))
             .unwrap();
@@ -1841,27 +1856,34 @@ mod payload_tests {
     fn result_save_accepts_every_json_payload_shape() {
         let conn = db();
         for (job_id, payload) in VALID_JSON_PAYLOADS.into_iter().enumerate() {
-            result_save(&conn, job_id as i64, payload, 0).unwrap();
-            assert_eq!(
-                result_get(&conn, job_id as i64).unwrap().as_deref(),
-                Some(payload)
-            );
+            let job_id = job_id as i64;
+            conn.query_row(
+                "SELECT honker_result_save(?1, ?2, 0)",
+                params![job_id, payload],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap();
+            let stored: String = conn
+                .query_row(
+                    "SELECT value FROM _honker_results WHERE job_id = ?1",
+                    [job_id],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(stored, payload);
         }
     }
 
     #[test]
     fn scheduler_register_rejects_non_json_payload() {
         let conn = db();
-        assert_payload_error(scheduler_register(
-            &conn,
-            "nightly",
-            "backups",
-            "@every 1m",
-            "not json",
-            0,
-            None,
-            3,
-        ));
+        for sql in [
+            "SELECT honker_scheduler_register('nightly-6', 'backups', '@every 1m', ?1, 0, NULL)",
+            "SELECT honker_scheduler_register('nightly-7', 'backups', '@every 1m', ?1, 0, NULL, 3)",
+        ] {
+            let result = conn.query_row(sql, ["not json"], |r| r.get::<_, i64>(0));
+            assert_payload_error(result);
+        }
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM _honker_scheduler_tasks", [], |r| {
                 r.get(0)
@@ -1873,18 +1895,14 @@ mod payload_tests {
     #[test]
     fn scheduler_register_accepts_every_json_payload_shape() {
         let conn = db();
-        for payload in VALID_JSON_PAYLOADS {
-            scheduler_register(
-                &conn,
-                "nightly",
-                "backups",
-                "@every 1m",
-                payload,
-                0,
-                None,
-                3,
-            )
-            .unwrap();
+        for (index, payload) in VALID_JSON_PAYLOADS.into_iter().enumerate() {
+            let sql = if index % 2 == 0 {
+                "SELECT honker_scheduler_register('nightly', 'backups', '@every 1m', ?1, 0, NULL)"
+            } else {
+                "SELECT honker_scheduler_register('nightly', 'backups', '@every 1m', ?1, 0, NULL, 3)"
+            };
+            conn.query_row(sql, [payload], |r| r.get::<_, i64>(0))
+                .unwrap();
             let stored: String = conn
                 .query_row(
                     "SELECT payload FROM _honker_scheduler_tasks WHERE name = 'nightly'",
@@ -1899,16 +1917,19 @@ mod payload_tests {
     #[test]
     fn scheduler_update_rejects_non_json_payload() {
         let conn = db();
-        scheduler_register(&conn, "nightly", "backups", "@every 1m", "{}", 0, None, 3).unwrap();
-        assert_payload_error(scheduler_update(
-            &conn,
-            "nightly",
-            None,
-            Some("not json"),
-            None,
-            None,
-            None,
-        ));
+        conn.query_row(
+            "SELECT honker_scheduler_register('nightly', 'backups', '@every 1m', '{}', 0, NULL, 3)",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap();
+        for sql in [
+            "SELECT honker_scheduler_update('nightly', NULL, ?1, NULL, NULL, 0)",
+            "SELECT honker_scheduler_update('nightly', NULL, ?1, NULL, NULL, 0, NULL, 0)",
+        ] {
+            let result = conn.query_row(sql, ["not json"], |r| r.get::<_, i64>(0));
+            assert_payload_error(result);
+        }
         let stored: String = conn
             .query_row(
                 "SELECT payload FROM _honker_scheduler_tasks WHERE name = 'nightly'",
@@ -1922,9 +1943,20 @@ mod payload_tests {
     #[test]
     fn scheduler_update_accepts_every_json_payload_shape() {
         let conn = db();
-        scheduler_register(&conn, "nightly", "backups", "@every 1m", "{}", 0, None, 3).unwrap();
-        for payload in VALID_JSON_PAYLOADS {
-            scheduler_update(&conn, "nightly", None, Some(payload), None, None, None).unwrap();
+        conn.query_row(
+            "SELECT honker_scheduler_register('nightly', 'backups', '@every 1m', '{}', 0, NULL, 3)",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap();
+        for (index, payload) in VALID_JSON_PAYLOADS.into_iter().enumerate() {
+            let sql = if index % 2 == 0 {
+                "SELECT honker_scheduler_update('nightly', NULL, ?1, NULL, NULL, 0)"
+            } else {
+                "SELECT honker_scheduler_update('nightly', NULL, ?1, NULL, NULL, 0, NULL, 0)"
+            };
+            conn.query_row(sql, [payload], |r| r.get::<_, i64>(0))
+                .unwrap();
             let stored: String = conn
                 .query_row(
                     "SELECT payload FROM _honker_scheduler_tasks WHERE name = 'nightly'",

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -2075,6 +2075,52 @@ mod payload_tests {
         assert_eq!(stored, "{}", "rejected payload must not be written");
     }
 
+    /// The stricter parse also bounds nesting, which the structural scan did
+    /// not -- 50,000 nested arrays used to enqueue. A consumer decoding with
+    /// `serde_json` hits the same bound, so accepting these was the same
+    /// undecodable-job bug in a third shape.
+    ///
+    /// Deliberately does not pin the exact limit: `serde_json` owns that
+    /// number and may move it. 4096 is far enough past any plausible limit to
+    /// stay a rejection, and 32 is shallow enough to stay accepted.
+    #[test]
+    fn enqueue_rejects_nesting_deeper_than_the_decoder_accepts() {
+        let conn = db();
+        let payload = format!("{}{}", "[".repeat(4096), "]".repeat(4096));
+        let result = conn.query_row(
+            "SELECT honker_enqueue('emails', ?1, NULL, NULL, 0, 3, NULL)",
+            [payload.as_str()],
+            |r| r.get::<_, i64>(0),
+        );
+        assert_undecodable_payload_error(result, "4096 nested arrays");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_live", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "rejected payload must not be written");
+    }
+
+    /// The guard against over-tightening: ordinary nesting must still enqueue.
+    #[test]
+    fn enqueue_accepts_ordinary_nesting() {
+        let conn = db();
+        let payload = format!("{}{}", "[".repeat(32), "]".repeat(32));
+        let id: i64 = conn
+            .query_row(
+                "SELECT honker_enqueue('emails', ?1, NULL, NULL, 0, 3, NULL)",
+                [payload.as_str()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let stored: String = conn
+            .query_row(
+                "SELECT payload FROM _honker_live WHERE id = ?1",
+                [id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, payload);
+    }
+
     #[test]
     fn scheduler_update_accepts_every_json_payload_shape() {
         let conn = db();

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -1313,6 +1313,23 @@ fn scheduler_wake(_conn: &Connection) -> rusqlite::Result<()> {
 /// must be delivered.
 pub const SCHEDULER_MAX_CATCHUP_FIRES: i64 = 64;
 
+/// Attach the schedule's identity to a payload rejection raised while
+/// firing it.
+///
+/// Only `UserFunctionError` is rewritten -- that is what
+/// [`super::validate_json_payload`] returns. A real SQLite failure
+/// (`SQLITE_BUSY`, disk I/O) passes through untouched so callers can still
+/// match on its code.
+fn name_scheduled_payload_error(name: &str, queue: &str, err: rusqlite::Error) -> rusqlite::Error {
+    match err {
+        rusqlite::Error::UserFunctionError(inner) => to_sql_err(format!(
+            "{inner} (schedule {name:?}, queue {queue:?}); fix or remove the \
+             schedule row, then tick again"
+        )),
+        other => other,
+    }
+}
+
 /// For each registered task whose `next_fire_at <= now_unix`,
 /// enqueue the payload into its queue and advance `next_fire_at`
 /// to the next boundary. Keeps advancing within one tick while
@@ -1361,6 +1378,12 @@ pub fn scheduler_tick(conn: &Connection, now_unix: i64) -> rusqlite::Result<Stri
             // Enqueue at this boundary. `run_at` is NULL (claimable
             // immediately); `expires` is the task's expires_s if set.
             // max_attempts comes from the schedule row, not a constant.
+            // A schedule row written before the JSON payload contract can
+            // hold text `enqueue` now rejects. That fails the whole tick --
+            // no task advances, so one bad row stops every schedule. Failing
+            // is right (a silent skip would drop fires forever), but the bare
+            // validation message names no schedule, and the caller is a
+            // leader loop with no idea which row to fix. Name it.
             let job_id = enqueue(
                 conn,
                 &queue,
@@ -1370,7 +1393,8 @@ pub fn scheduler_tick(conn: &Connection, now_unix: i64) -> rusqlite::Result<Stri
                 priority,
                 max_attempts,
                 expires_s,
-            )?;
+            )
+            .map_err(|e| name_scheduled_payload_error(&name, &queue, e))?;
             out.push(json!({
                 "name": name,
                 "queue": queue,
@@ -2119,6 +2143,117 @@ mod payload_tests {
             )
             .unwrap();
         assert_eq!(stored, payload);
+    }
+
+    /// Existing rows are not validated retroactively, so a schedule
+    /// registered before this contract can still hold text `enqueue` now
+    /// rejects. Firing it fails the whole tick: `scheduler_tick` enqueues
+    /// every due task in one call, so nothing advances and no other
+    /// schedule fires until the bad row is fixed.
+    ///
+    /// Failing is the correct half -- skipping the row would drop its fires
+    /// silently forever. The part that has to hold is the message: a leader
+    /// loop sees only this string, so it must name the schedule to fix.
+    #[test]
+    fn a_legacy_schedule_payload_names_itself_when_it_stops_the_tick() {
+        let conn = db();
+        // 'aaa' sorts first, so the bad row is reached before the healthy one.
+        for (name, payload) in [
+            ("aaa-legacy", "not json"),
+            ("bbb-legacy-undecodable", r#""\ud800""#),
+        ] {
+            conn.execute(
+                "INSERT INTO _honker_scheduler_tasks
+                   (name, queue, cron_expr, payload, priority, next_fire_at,
+                    enabled, max_attempts)
+                 VALUES (?1, 'backups', '@every 1m', ?2, 0, 1, 1, 3)",
+                params![name, payload],
+            )
+            .unwrap();
+        }
+        conn.query_row(
+            "SELECT honker_scheduler_register('zzz-healthy', 'backups', '@every 1m', '{}', 0, NULL, 3)",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE _honker_scheduler_tasks SET next_fire_at = 1 WHERE name = 'zzz-healthy'",
+            [],
+        )
+        .unwrap();
+
+        let err = conn
+            .query_row("SELECT honker_scheduler_tick(120)", [], |r| {
+                r.get::<_, String>(0)
+            })
+            .expect_err("a legacy non-JSON schedule payload must fail the tick");
+        let text = err.to_string();
+        assert!(
+            text.contains("honker: payload must be valid JSON"),
+            "expected the payload contract error, got: {err}"
+        );
+        assert!(
+            text.contains("\"aaa-legacy\""),
+            "the error must name the schedule the caller has to fix, got: {err}"
+        );
+        assert!(
+            text.contains("\"backups\""),
+            "the error must name the schedule's queue, got: {err}"
+        );
+
+        // The blast radius is the whole tick, not just the bad row. Pin it so
+        // a change to skip-and-continue has to be deliberate.
+        let live: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_live", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(live, 0, "a failed tick must not half-fire other schedules");
+        let unadvanced: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM _honker_scheduler_tasks WHERE next_fire_at = 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(unadvanced, 3, "no schedule advances while the tick fails");
+
+        // Removing the bad rows through the public API frees the scheduler.
+        for name in ["aaa-legacy", "bbb-legacy-undecodable"] {
+            conn.query_row("SELECT honker_scheduler_unregister(?1)", [name], |r| {
+                r.get::<_, i64>(0)
+            })
+            .unwrap();
+        }
+        conn.query_row("SELECT honker_scheduler_tick(120)", [], |r| {
+            r.get::<_, String>(0)
+        })
+        .expect("the healthy schedule fires once the bad rows are gone");
+        let live: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_live", [], |r| r.get(0))
+            .unwrap();
+        assert!(live > 0, "the healthy schedule must fire after the fix");
+    }
+
+    /// A real SQLite failure inside a scheduled fire keeps its own error, so
+    /// callers can still match on the code. Only the payload rejection is
+    /// rewritten to carry the schedule's name.
+    #[test]
+    fn naming_a_scheduled_payload_error_leaves_sqlite_errors_alone() {
+        let sqlite_err = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(5), // SQLITE_BUSY
+            Some("database is locked".into()),
+        );
+        let passed_through = name_scheduled_payload_error("nightly", "backups", sqlite_err);
+        assert!(
+            matches!(passed_through, rusqlite::Error::SqliteFailure(..)),
+            "a SQLite failure must not be flattened into a user-function error"
+        );
+        let payload_err = super::super::validate_json_payload("not json").unwrap_err();
+        let named = name_scheduled_payload_error("nightly", "backups", payload_err);
+        assert!(
+            named.to_string().contains("\"nightly\""),
+            "a payload rejection must gain the schedule name, got: {named}"
+        );
     }
 
     #[test]

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -285,6 +285,19 @@ fn set_journal_mode_wal(conn: &Connection) -> rusqlite::Result<()> {
 // notify() SQL function + notifications schema
 // ---------------------------------------------------------------------
 
+/// Payloads crossing a public Honker write boundary are JSON text.
+/// Parse into `IgnoredAny` so validation does not allocate a JSON tree
+/// that the write path would immediately discard.
+pub(crate) fn validate_json_payload(payload: &str) -> rusqlite::Result<()> {
+    if serde_json::from_str::<serde::de::IgnoredAny>(payload).is_ok() {
+        Ok(())
+    } else {
+        Err(rusqlite::Error::UserFunctionError(Box::new(
+            std::io::Error::other("honker: payload must be valid JSON"),
+        )))
+    }
+}
+
 /// Install the `_honker_notifications` table and the
 /// `notify(channel, payload)` SQL scalar function on `conn`. Idempotent.
 ///
@@ -318,6 +331,7 @@ pub fn attach_notify(conn: &Connection) -> Result<(), Error> {
     conn.create_scalar_function("notify", 2, FunctionFlags::SQLITE_UTF8, |ctx| {
         let channel: String = ctx.get(0)?;
         let payload: String = ctx.get(1)?;
+        validate_json_payload(&payload)?;
         let db = unsafe { ctx.get_connection() }?;
         let mut ins = db.prepare_cached(
             "INSERT INTO _honker_notifications (channel, payload) VALUES (?1, ?2)",
@@ -1403,13 +1417,14 @@ mod tests {
     }
 
     #[test]
-    fn notify_inserts_row() {
+    fn notify_accepts_every_json_payload_shape() {
         let conn = mem();
         attach_notify(&conn).unwrap();
-        conn.execute_batch("BEGIN IMMEDIATE;").unwrap();
-        conn.query_row("SELECT notify('orders', 'new')", [], |_| Ok(()))
-            .unwrap();
-        conn.execute_batch("COMMIT;").unwrap();
+        let payloads = ["{}", "[]", "42", "\"str\"", "true", "null"];
+        for payload in payloads {
+            conn.query_row("SELECT notify('orders', ?1)", [payload], |_| Ok(()))
+                .unwrap();
+        }
 
         let n: i64 = conn
             .query_row(
@@ -1418,7 +1433,27 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(n, 1);
+        assert_eq!(n, payloads.len() as i64);
+    }
+
+    #[test]
+    fn notify_rejects_non_json_payload() {
+        let conn = mem();
+        attach_notify(&conn).unwrap();
+        let err = conn
+            .query_row("SELECT notify('orders', 'not json')", [], |_| Ok(()))
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("honker: payload must be valid JSON"),
+            "expected the JSON payload contract error, got: {err}"
+        );
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_notifications", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(n, 0, "rejected payload must not be written");
     }
 
     #[test]
@@ -1426,7 +1461,7 @@ mod tests {
         let conn = mem();
         attach_notify(&conn).unwrap();
         conn.execute_batch("BEGIN IMMEDIATE;").unwrap();
-        conn.query_row("SELECT notify('x', 'y')", [], |_| Ok(()))
+        conn.query_row("SELECT notify('x', '\"y\"')", [], |_| Ok(()))
             .unwrap();
         conn.execute_batch("ROLLBACK;").unwrap();
 

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -285,17 +285,45 @@ fn set_journal_mode_wal(conn: &Connection) -> rusqlite::Result<()> {
 // notify() SQL function + notifications schema
 // ---------------------------------------------------------------------
 
-/// Payloads crossing a public Honker write boundary are JSON text.
-/// Parse as `IgnoredAny` so validation does not allocate a JSON tree that the
-/// write path would immediately discard.
+/// Payloads crossing a public Honker write boundary are JSON text that a
+/// JSON decoder can actually read back.
+///
+/// Validate by parsing into `serde_json::Value`, which is exactly what the
+/// read side does. A cheaper structural scan (`serde::de::IgnoredAny`) walks
+/// the grammar without unescaping strings or range-checking numbers, so it
+/// accepts text that every decoder then rejects:
+///
+/// | payload        | `IgnoredAny` | `Value` |
+/// |----------------|--------------|---------|
+/// | `"\ud800"`     | ok           | lone leading surrogate |
+/// | `1e999`        | ok           | number out of range |
+///
+/// Both shapes are what `json.dumps` and `JSON.stringify` can emit, so a
+/// Python or Node producer could enqueue a job no Rust consumer could decode.
+/// Rejecting at the producer keeps "payload is JSON, therefore decoding is
+/// safe" true instead of approximate.
+///
+/// The `Value` tree is dropped immediately. It costs a couple of allocations
+/// against a ~24 us enqueue that is dominated by the SQLite insert and
+/// binding marshaling; see `tests/test_performance_floors.py`.
 pub(crate) fn validate_json_payload(payload: &str) -> rusqlite::Result<()> {
-    if serde_json::from_str::<serde::de::IgnoredAny>(payload).is_ok() {
-        Ok(())
+    let err = match serde_json::from_str::<serde_json::Value>(payload) {
+        Ok(_) => return Ok(()),
+        Err(err) => err,
+    };
+    // Rejection only, so the second parse is off the hot path. A lone
+    // surrogate IS valid JSON by the grammar -- telling that caller their
+    // text "must be valid JSON" sends them looking for a syntax error they
+    // do not have. Re-scan structurally to name the real problem, and pass
+    // serde's own message through either way.
+    let message = if serde_json::from_str::<serde::de::IgnoredAny>(payload).is_ok() {
+        format!("honker: payload is valid JSON but cannot be decoded: {err}")
     } else {
-        Err(rusqlite::Error::UserFunctionError(Box::new(
-            std::io::Error::other("honker: payload must be valid JSON"),
-        )))
-    }
+        format!("honker: payload must be valid JSON: {err}")
+    };
+    Err(rusqlite::Error::UserFunctionError(Box::new(
+        std::io::Error::other(message),
+    )))
 }
 
 /// Install the `_honker_notifications` table and the
@@ -1443,11 +1471,51 @@ mod tests {
         let err = conn
             .query_row("SELECT notify('orders', 'not json')", [], |_| Ok(()))
             .unwrap_err();
+        let text = err.to_string();
         assert!(
-            err.to_string()
-                .contains("honker: payload must be valid JSON"),
+            text.contains("honker: payload must be valid JSON"),
             "expected the JSON payload contract error, got: {err}"
         );
+        assert!(
+            text.contains("line 1 column"),
+            "the error must pass serde's own message through, got: {err}"
+        );
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _honker_notifications", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(n, 0, "rejected payload must not be written");
+    }
+
+    /// Valid by the JSON grammar, undecodable by any JSON decoder: a lone
+    /// surrogate is not valid UTF-8 and 1e999 overflows f64. A structural
+    /// scan lets both through; the read side does not.
+    #[test]
+    fn notify_rejects_undecodable_json_payload() {
+        let conn = mem();
+        attach_notify(&conn).unwrap();
+        let payloads = [
+            r#""\ud800""#,
+            r#"{"a":"\ud800"}"#,
+            "1e999",
+            r#"{"a":1e999}"#,
+            "-1e999",
+        ];
+        for payload in payloads {
+            let err = conn
+                .query_row("SELECT notify('orders', ?1)", [payload], |_| Ok(()))
+                .unwrap_err();
+            let text = err.to_string();
+            assert!(
+                text.contains("honker: payload is valid JSON but cannot be decoded"),
+                "expected the undecodable-JSON error for {payload}, got: {err}"
+            );
+            assert!(
+                text.contains("line 1 column"),
+                "the error must pass serde's own message through for {payload}, got: {err}"
+            );
+        }
         let n: i64 = conn
             .query_row("SELECT COUNT(*) FROM _honker_notifications", [], |row| {
                 row.get(0)

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -286,10 +286,10 @@ fn set_journal_mode_wal(conn: &Connection) -> rusqlite::Result<()> {
 // ---------------------------------------------------------------------
 
 /// Payloads crossing a public Honker write boundary are JSON text.
-/// Parse as a borrowed `RawValue` so validation does not allocate a JSON
-/// tree that the write path would immediately discard.
+/// Parse as `IgnoredAny` so validation does not allocate a JSON tree that the
+/// write path would immediately discard.
 pub(crate) fn validate_json_payload(payload: &str) -> rusqlite::Result<()> {
-    if serde_json::from_str::<&serde_json::value::RawValue>(payload).is_ok() {
+    if serde_json::from_str::<serde::de::IgnoredAny>(payload).is_ok() {
         Ok(())
     } else {
         Err(rusqlite::Error::UserFunctionError(Box::new(

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -286,10 +286,10 @@ fn set_journal_mode_wal(conn: &Connection) -> rusqlite::Result<()> {
 // ---------------------------------------------------------------------
 
 /// Payloads crossing a public Honker write boundary are JSON text.
-/// Parse into `IgnoredAny` so validation does not allocate a JSON tree
-/// that the write path would immediately discard.
+/// Parse as a borrowed `RawValue` so validation does not allocate a JSON
+/// tree that the write path would immediately discard.
 pub(crate) fn validate_json_payload(payload: &str) -> rusqlite::Result<()> {
-    if serde_json::from_str::<serde::de::IgnoredAny>(payload).is_ok() {
+    if serde_json::from_str::<&serde_json::value::RawValue>(payload).is_ok() {
         Ok(())
     } else {
         Err(rusqlite::Error::UserFunctionError(Box::new(

--- a/honker-extension/src/lib.rs
+++ b/honker-extension/src/lib.rs
@@ -9,8 +9,7 @@
 //!
 //!     .load ./libhonker_ext
 //!     SELECT honker_bootstrap();
-//!     SELECT honker_enqueue('emails', '{"to": "alice"}',
-//!                           NULL, NULL, 0, 3, NULL);
+//!     SELECT honker_enqueue('emails', '{"to":"alice"}', NULL, NULL, 0, 3, NULL);
 //!     SELECT honker_claim_batch('emails', 'worker-1', 32, 300);
 //!     SELECT honker_ack_batch('[1,2,3]', 'worker-1');
 //!     SELECT notify('orders', '{"id": 42}');

--- a/honker-extension/src/lib.rs
+++ b/honker-extension/src/lib.rs
@@ -9,8 +9,8 @@
 //!
 //!     .load ./libhonker_ext
 //!     SELECT honker_bootstrap();
-//!     INSERT INTO _honker_live (queue, payload)
-//!     VALUES ('emails', '{"to": "alice"}');
+//!     SELECT honker_enqueue('emails', '{"to": "alice"}',
+//!                           NULL, NULL, 0, 3, NULL);
 //!     SELECT honker_claim_batch('emails', 'worker-1', 32, 300);
 //!     SELECT honker_ack_batch('[1,2,3]', 'worker-1');
 //!     SELECT notify('orders', '{"id": 42}');

--- a/packages/honker-bun/test/parity.test.ts
+++ b/packages/honker-bun/test/parity.test.ts
@@ -433,7 +433,7 @@ maybe("honker-bun parity — Results", () => {
   test(
     "sweepResults returns non-negative",
     withDb((db) => {
-      db.saveResult(1, "x", 60);
+      db.saveResult(1, JSON.stringify("x"), 60);
       const n = db.sweepResults();
       expect(n).toBeGreaterThanOrEqual(0);
     }),

--- a/packages/honker-ex/lib/honker.ex
+++ b/packages/honker-ex/lib/honker.ex
@@ -178,8 +178,10 @@ defmodule Honker do
 
   @doc """
   Persist a job result for later retrieval via `get_result/2`. `value`
-  must be a string — encode JSON yourself if you want structure. `ttl_s`
-  is seconds before `sweep_results/1` will delete it.
+  must be a string holding JSON text — honker rejects anything else, so
+  encode it yourself. A bare string needs quoting: pass
+  `Jason.encode!("done")` (`~s("done")`), not `"done"`. `ttl_s` is
+  seconds before `sweep_results/1` will delete it.
   """
   def save_result(%Database{conn: conn}, job_id, value, ttl_s) when is_binary(value) do
     case query_first(conn, "SELECT honker_result_save(?1, ?2, ?3)", [job_id, value, ttl_s]) do

--- a/packages/honker-go/parity_test.go
+++ b/packages/honker-go/parity_test.go
@@ -563,7 +563,7 @@ func TestSweepResultsExpired(t *testing.T) {
 	}
 	defer db.Close()
 
-	if err := db.SaveResult(1, "val", 1); err != nil {
+	if err := db.SaveResult(1, `"val"`, 1); err != nil {
 		t.Fatalf("save result: %v", err)
 	}
 	time.Sleep(2 * time.Second)

--- a/packages/honker-rs/Cargo.lock
+++ b/packages/honker-rs/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "rusqlite",
+ "serde",
  "serde_json",
  "thiserror",
 ]

--- a/packages/honker-ruby/lib/honker.rb
+++ b/packages/honker-ruby/lib/honker.rb
@@ -671,8 +671,9 @@ module Honker
     end
 
     # Persist a job result for later retrieval via `get_result`.
-    # `value` is stored verbatim — JSON-encode it yourself if you want
-    # to round-trip structured data.
+    # `value` is stored verbatim and must already be JSON text — honker
+    # rejects anything else. A bare string needs quoting: pass
+    # `"done".to_json` (`'"done"'`), not `"done"`.
     def save_result(job_id, value, ttl_s:)
       @db.get_first_row(
         "SELECT honker_result_save(?, ?, ?)",

--- a/packages/honker-ruby/spec/parity_spec.rb
+++ b/packages/honker-ruby/spec/parity_spec.rb
@@ -381,7 +381,7 @@ class HonkerParityTest < Minitest::Test
   end
 
   def test_results_sweep_removes_expired
-    @db.save_result(1, "v1", ttl_s: 3600)
+    @db.save_result(1, JSON.dump("v1"), ttl_s: 3600)
     swept = @db.sweep_results
     # Nothing expired yet; sweep is a no-op but returns a count.
     assert_equal 0, swept

--- a/tests/test_extension_interop.py
+++ b/tests/test_extension_interop.py
@@ -186,7 +186,7 @@ def test_extension_registers_notify_function(ext_db_path):
     conn.load_extension(_EXT_PATH)
 
     conn.execute("BEGIN IMMEDIATE")
-    row = conn.execute("SELECT notify('orders', 'hello')").fetchone()
+    row = conn.execute("SELECT notify('orders', '\"hello\"')").fetchone()
     assert row[0] >= 1  # returned inserted id
     conn.execute("COMMIT")
 


### PR DESCRIPTION
Closes #152. Also closes #146 — see below.

## Why this change is needed

Honker stores payloads as text, but its typed job APIs assume that text is JSON.

Most typed enqueue APIs serialize values before writing them. The SQLite extension did not enforce the same rule. A caller using its own SQLite or ORM connection could run `honker_enqueue` with any text, including text that could not be decoded as JSON later.

This change makes JSON a core contract instead of a binding convention.

## What changes

Honker validates payload text at every public write path, before the database write:

- queue enqueue
- stream publish
- notification publish
- result save
- scheduler register
- scheduler update when a new payload is supplied

For example, this still works:

```sql
SELECT honker_enqueue(
  'emails',
  '{"to":"alice@example.com"}',
  NULL, NULL, 0, 3, NULL
);
```

This now fails before a queue row is written:

```sql
SELECT honker_enqueue('emails', 'not json', NULL, NULL, 0, 3, NULL);
-- honker: payload must be valid JSON: expected ident at line 1 column 2
```

JSON is not limited to objects. Arrays and bare scalar values remain valid:

```text
[1, 2]
42
"ready"
true
null
```

A plain string such as `ready` is not JSON. Its serialized JSON form is `"ready"`.

## Validation is as strict as the read side

The validator parses into `serde_json::Value` — exactly what the read side does — rather than scanning the grammar structurally with `serde::de::IgnoredAny`.

A structural scan walks the grammar and discards values. It never unescapes strings, range-checks numbers, or bounds nesting, so it is strictly more permissive than any decoder. Measured on the previous revision of this branch:

| payload | structural scan | `serde_json::Value` |
|---|---|---|
| `"\ud800"` | ok | unexpected end of hex escape |
| `{"a":"\ud800"}` | ok | unexpected end of hex escape |
| `1e999` | ok | number out of range |
| `-1e999` | ok | number out of range |
| `{"a":1e999}` | ok | number out of range |
| 4096 nested arrays | ok | recursion limit exceeded |

`json.dumps` in Python and `JSON.stringify` in Node both emit lone surrogates. So a Python producer could enqueue a job, Node could read it back, and any Rust-side `serde_json` decode — `Job<T>` from #124 — would fail. That is a poison job created by one process and discovered by another.

Validating with `Value` puts the failure on the caller that caused it.

## Breaking change

Wider than first described. Three payload classes that used to enqueue now fail at the producer:

- **Lone surrogates**, such as `"\ud800"` or `{"a":"\ud800"}`. Valid by the JSON grammar, not representable as UTF-8.
- **Numbers outside f64 range**, such as `1e999`, `-1e999`, `{"a":1e999}`.
- **Nesting deeper than 128 levels**, which is `serde_json`'s own recursion limit. Previously there was no depth bound at all; 50,000 nested arrays enqueued fine.

This is the intended behavior, not a regression. A producer emitting any of these was already creating a job a consumer could not decode — the error moved, it did not appear. Callers relying on one of these shapes should encode it: escape a surrogate pair properly, send an out-of-range number as a string, or flatten the nesting.

## Error messages

`honker: payload must be valid JSON` was misleading for the new cases. A lone surrogate *is* valid JSON by the grammar; it just cannot be decoded. Telling that caller their payload is not valid JSON sends them hunting for a syntax error they do not have.

Two messages now, both carrying serde's own text:

```text
honker: payload must be valid JSON: expected ident at line 1 column 2
honker: payload is valid JSON but cannot be decoded: number out of range at line 1 column 5
honker: payload is valid JSON but cannot be decoded: unexpected end of hex escape at line 1 column 8
honker: payload is valid JSON but cannot be decoded: recursion limit exceeded at line 1 column 128
```

The second parse that picks between them runs only on the rejection path, so the accept path is a single parse.

## Performance

The `IgnoredAny` scan was chosen to avoid allocating a `Value` tree. Measured rather than assumed, on `tests/test_performance_floors.py::test_enqueue_throughput_floor_one_tx` (10,000 enqueues in one transaction, release build, M-series laptop, 5 runs each):

| | median | per enqueue |
|---|---|---|
| before (`IgnoredAny`) | 0.235 s | 23.5 µs |
| after (`Value`) | 0.241 s | 24.1 µs |

About +2.3%, or +0.6 µs per enqueue, against a 3.0 s floor. Enqueue cost is dominated by the SQLite insert and binding marshaling; a small `Value` that is dropped immediately does not show up. The full floor suite passes.

## Database and binding behavior

No table `CHECK` constraint and no schema rebuild. Validation stays at the public core entry points. Direct writes to internal tables such as `_honker_live` are still outside the public contract.

`_honker_dead.payload` is not validated again. Core only copies it from an already validated live queue row.

Note for the migration guide: `SELECT id FROM _honker_live WHERE NOT json_valid(payload)` still does not agree with honker exactly. SQLite's `json_valid()` returns 1 for `"\ud800"` and `1e999`, so it will miss legacy rows that honker now rejects. To find every row that will not decode, decode it. In the other direction the disagreement is now closed: honker's depth bound (128) is stricter than `json_valid()`'s (~1000), so the query can no longer flag a row honker itself wrote.

## Tests

All five entry points are covered for both rejection classes, including both arities of `honker_scheduler_register` and `honker_scheduler_update`, and `notify`. Bare scalars (`42`, `"str"`, `true`, `null`) plus `{}` and `[]` are asserted to still enqueue and store byte-identical text — the case a stricter validator is most likely to break by accident. Ordinary nesting (32 levels) still enqueues.
