### PR TITLE
feat(core): queue-scoped honker_cancel + capability probe (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,16 @@
   changes: every current caller keeps hitting `honker_cancel(job_id)`.
 - Tests cover both arities on one connection, the wrong-queue no-op on
   pending and processing rows (asserting the row is still live afterwards),
-  idempotence, the arity error, and the probe with and without the 2-arg
-  form — in honker-core against rusqlite, and again through the real
+  the owning queue cancelling a claimed row at both arities, idempotence,
+  the arity error, and the probe with and without the 2-arg form,
+  including that an unanswerable probe is an error and not a `false` —
+  in honker-core against rusqlite, and again through the real
   `.load libhonker_ext` path in `tests/test_extension_interop.py`.
+- The shared ORM surface (`scripts/proof/orm/surface.json`, replayed by
+  every documented ORM recipe in 11 languages) gains the scoped cancel
+  and the capability probe. That is what proves the new arity and
+  `pragma_function_list` work through each binding's own SQLite build,
+  not just through rusqlite and CPython's.
 
 ## 2026-08-27 — Node 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # CHANGELOG
 
+## Unreleased — queue-scoped cancel in core (issue #134)
+
+- `honker_cancel(queue, job_id)` joins the existing `honker_cancel(job_id)`.
+  The 2-arg form only removes a pending or processing row that is in that
+  queue; a job in another queue is a miss and returns 0, the same answer an
+  already-ack'd id gives. The queue check is part of the DELETE, not a read
+  before it — a `SELECT queue` followed by a `DELETE` leaves a window for a
+  concurrent claim to change the row between the two statements.
+- The 1-arg form is unchanged and stays: it is the global cancel that
+  `Database.cancel(id)` will use. SQLite dispatches on (name, arity), so both
+  forms live on one connection and bindings can move to the scoped form one
+  package at a time instead of in lockstep.
+- New connect-time capability probe, `honker_core::has_queue_scoped_cancel`
+  and the `CANCEL_QUEUE_SCOPED_PROBE_SQL` string behind it. Calling
+  `honker_cancel` at an arity the loaded extension does not have is a hard
+  SQLite error, not a fallback, and there is no `honker_version()` to ask
+  first — so a binding built for the 2-arg form running against an older
+  vendored `libhonker_ext` would fail at cancel time in production.
+  `pragma_function_list` reports each arity as its own row, so one cheap
+  query at startup turns that into a connect-time check. Bindings that talk
+  to the extension over SQL run the string; Rust-side bindings call the
+  helper. The probe propagates errors rather than reporting "absent" for
+  "cannot tell".
+- Core only. No binding calls the new arity yet, so no existing behavior
+  changes: every current caller keeps hitting `honker_cancel(job_id)`.
+- Tests cover both arities on one connection, the wrong-queue no-op on
+  pending and processing rows (asserting the row is still live afterwards),
+  idempotence, the arity error, and the probe with and without the 2-arg
+  form — in honker-core against rusqlite, and again through the real
+  `.load libhonker_ext` path in `tests/test_extension_interop.py`.
+
 ## 2026-08-27 — Node 0.5.1
 
 - Node `@russellthehippo/honker-node`: 0.5.1, with the four

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -1022,6 +1022,12 @@ pub fn cancel_in_queue(conn: &Connection, queue: &str, job_id: i64) -> rusqlite:
 /// Bindings that talk to the extension over SQL (Go, Ruby, .NET, C++,
 /// Elixir, Bun) run this string verbatim; Rust-side bindings can call
 /// [`has_queue_scoped_cancel`] instead.
+///
+/// If the query itself raises, that is "cannot tell", not "absent" —
+/// a SQLite built with SQLITE_OMIT_INTROSPECTION_PRAGMAS has no
+/// `pragma_function_list` to read. Surface the error. A binding that
+/// rescues it into `false` reports an old extension while running a
+/// new one, which is the exact failure this probe exists to prevent.
 pub const CANCEL_QUEUE_SCOPED_PROBE_SQL: &str =
     "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name = 'honker_cancel' AND narg = 2)";
 
@@ -2067,6 +2073,22 @@ mod cancel_scoping {
             Some("sms"),
             "the processing sms row must still be live"
         );
+
+        // The owning queue does reach the claimed row. This half is
+        // what pins the 2-arg form to the same states as the 1-arg
+        // form: without it, narrowing the scoped DELETE to
+        // `state = 'pending'` leaves every other test in this module
+        // passing, and the two arities silently disagree about
+        // processing rows.
+        let n: i64 = conn
+            .query_row("SELECT honker_cancel('sms', ?1)", [sms_id], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 1, "the owning queue cancels a processing row");
+        assert_eq!(
+            live_queue(&conn, sms_id),
+            None,
+            "the processing row is gone after its own queue cancels it"
+        );
     }
 
     /// The 1-arg form keeps its shipped meaning: global, ignores the
@@ -2081,6 +2103,35 @@ mod cancel_scoping {
             .unwrap();
         assert_eq!(n, 1, "1-arg cancel reaches a job in any queue");
         assert_eq!(live_queue(&conn, sms_id), None);
+    }
+
+    /// The 1-arg form's other shipped promise, the one its own doc
+    /// comment makes: it removes a claimed (processing) row, not just a
+    /// pending one. Nothing else in honker-core covered that, so the
+    /// two arities could have drifted apart on state — one keeping
+    /// 'processing' in its IN-list, the other losing it — with every
+    /// other test here still green.
+    #[test]
+    fn one_arg_form_cancels_a_processing_row() {
+        let conn = db();
+        let id = enqueue(&conn, "sms");
+        let _: String = conn
+            .query_row("SELECT honker_claim_batch('sms', 'w1', 8, 300)", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let state: String = conn
+            .query_row("SELECT state FROM _honker_live WHERE id = ?1", [id], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(state, "processing");
+
+        let n: i64 = conn
+            .query_row("SELECT honker_cancel(?1)", [id], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 1, "1-arg cancel still reaches a claimed row");
+        assert_eq!(live_queue(&conn, id), None);
     }
 
     /// Idempotence and the missing-id case at the new arity: a second
@@ -2165,5 +2216,36 @@ mod cancel_scoping {
             .query_row(CANCEL_QUEUE_SCOPED_PROBE_SQL, [], |r| r.get(0))
             .unwrap();
         assert_eq!(raw, 0, "the exported probe SQL must return 0");
+    }
+
+    /// "Cannot tell" must not collapse into "absent". A real table
+    /// named `pragma_function_list` shadows the eponymous pragma table
+    /// on this connection, so the probe query no longer resolves —
+    /// the same shape a SQLite built with
+    /// SQLITE_OMIT_INTROSPECTION_PRAGMAS presents, where the pragma
+    /// table is not there at all.
+    ///
+    /// This is the test for the claim the doc comment makes. Without
+    /// it, `has_queue_scoped_cancel` could be rewritten to end in
+    /// `.unwrap_or(false)` and every other test in this module would
+    /// still pass — while a binding on a new extension got told the
+    /// extension was old and took the wrong migration path.
+    #[test]
+    fn probe_error_is_not_flattened_to_false() {
+        let conn = db();
+        assert!(
+            has_queue_scoped_cancel(&conn).unwrap(),
+            "precondition: this connection answers the probe with true"
+        );
+
+        conn.execute_batch("CREATE TABLE pragma_function_list (x)")
+            .unwrap();
+
+        let err = has_queue_scoped_cancel(&conn)
+            .expect_err("an unanswerable probe must be an Err, never Ok(false)");
+        assert!(
+            err.to_string().contains("no such column"),
+            "expected the probe query itself to fail, got: {err}"
+        );
     }
 }

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -1970,6 +1970,7 @@ mod cancel_scoping {
         has_queue_scoped_cancel,
     };
     use rusqlite::Connection;
+    use rusqlite::OptionalExtension;
     use rusqlite::functions::FunctionFlags;
 
     fn db() -> Connection {
@@ -1993,10 +1994,15 @@ mod cancel_scoping {
     /// the wrong-queue tests, so they assert on this, not just on the
     /// return count.
     fn live_queue(conn: &Connection, id: i64) -> Option<String> {
+        // `.optional()` and not `.ok()`: `.ok()` turns EVERY error into
+        // None, so a typo'd table name or a schema change would make
+        // "the row is gone" assertions below pass without the cancel
+        // having done anything. Only QueryReturnedNoRows means gone.
         conn.query_row("SELECT queue FROM _honker_live WHERE id = ?1", [id], |r| {
             r.get(0)
         })
-        .ok()
+        .optional()
+        .unwrap()
     }
 
     /// Both arities are callable on the SAME connection, under the SAME

--- a/honker-core/src/honker_ops.rs
+++ b/honker-core/src/honker_ops.rs
@@ -502,6 +502,20 @@ pub fn attach_honker_functions(conn: &Connection) -> rusqlite::Result<()> {
         cancel(&db, job_id).map_err(to_sql_err)
     })?;
 
+    // honker_cancel(queue, job_id) -> 1 if a pending/processing row in
+    // THAT queue was removed, 0 otherwise. Registered under the same
+    // name at a different arity: SQLite dispatches on (name, nArg), so
+    // this queue-scoped form and the global 1-arg form above coexist on
+    // one connection. Bindings move to this form per-package without a
+    // lockstep release; see `has_queue_scoped_cancel` for the
+    // connect-time probe that tells them which forms are loaded.
+    conn.create_scalar_function("honker_cancel", 2, FunctionFlags::SQLITE_UTF8, |ctx| {
+        let queue: String = ctx.get(0)?;
+        let job_id: i64 = arg_i64(ctx, 1)?;
+        let db = unsafe { ctx.get_connection() }?;
+        cancel_in_queue(&db, &queue, job_id).map_err(to_sql_err)
+    })?;
+
     // honker_get_job(job_id) -> JSON object on hit, empty string on miss.
     conn.create_scalar_function("honker_get_job", 1, FunctionFlags::SQLITE_UTF8, |ctx| {
         let job_id: i64 = arg_i64(ctx, 0)?;
@@ -971,6 +985,54 @@ pub fn cancel(conn: &Connection, job_id: i64) -> rusqlite::Result<i64> {
         rusqlite::params![job_id],
     )?;
     Ok(n as i64)
+}
+
+/// Cancel a job by id, but only if it belongs to `queue`. Same
+/// semantics as [`cancel`] otherwise: 1 if a pending or processing row
+/// was removed, 0 otherwise, idempotent.
+///
+/// A job in another queue is a miss, not an error — the caller gets 0,
+/// the same answer it gets for an id that was already ack'd. That
+/// matches how a queue handle treats a foreign id everywhere else.
+///
+/// The queue check is part of the DELETE, not a read before it. A
+/// `SELECT queue` followed by a `DELETE` leaves a window where a
+/// concurrent claim can change the row between the two statements; one
+/// statement has no such window.
+pub fn cancel_in_queue(conn: &Connection, queue: &str, job_id: i64) -> rusqlite::Result<i64> {
+    let n = conn.execute(
+        "DELETE FROM _honker_live
+          WHERE queue = ?1 AND id = ?2 AND state IN ('pending', 'processing')",
+        rusqlite::params![queue, job_id],
+    )?;
+    Ok(n as i64)
+}
+
+/// SQL that answers "does the loaded honker extension have the
+/// queue-scoped `honker_cancel(queue, job_id)`?" — returns 1 or 0.
+///
+/// Calling `honker_cancel` at an arity the loaded extension does not
+/// have is a hard SQLite error ("wrong number of arguments"), not a
+/// fallback, and there is no `honker_version()` to ask first. A binding
+/// built for the 2-arg form and running against an older vendored
+/// `libhonker_ext` would therefore fail at cancel time in production.
+/// `pragma_function_list` reports each arity as its own row, so this
+/// one cheap query at connect time turns that into a startup check.
+///
+/// Bindings that talk to the extension over SQL (Go, Ruby, .NET, C++,
+/// Elixir, Bun) run this string verbatim; Rust-side bindings can call
+/// [`has_queue_scoped_cancel`] instead.
+pub const CANCEL_QUEUE_SCOPED_PROBE_SQL: &str =
+    "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name = 'honker_cancel' AND narg = 2)";
+
+/// Run [`CANCEL_QUEUE_SCOPED_PROBE_SQL`] on `conn`.
+///
+/// Errors are propagated, not flattened into `false`: a SQLite build
+/// compiled without the introspection pragmas cannot answer this
+/// question, and reporting "no queue-scoped cancel" for "cannot tell"
+/// would send a binding down the wrong migration path silently.
+pub fn has_queue_scoped_cancel(conn: &Connection) -> rusqlite::Result<bool> {
+    conn.query_row(CANCEL_QUEUE_SCOPED_PROBE_SQL, [], |r| r.get(0))
 }
 
 /// Read a single job row by id. Returns a JSON object on success or
@@ -1887,5 +1949,221 @@ mod real_arg_tests {
         assert!(probe(f64::NAN).is_err(), "NaN must reject");
         // Negative zero is whole and must coerce to 0, not error.
         assert!(probe(-0.0).is_ok(), "-0.0 must pass");
+    }
+}
+
+// Queue-scoped cancel (issue #134). `honker_cancel` carries a global
+// 1-arg form and a queue-scoped 2-arg form on the same connection while
+// bindings migrate, so these tests cover both arities together: the
+// scoped form must refuse a foreign queue without touching the row, and
+// the global form must keep its current meaning exactly.
+#[cfg(test)]
+mod cancel_scoping {
+    use crate::{
+        CANCEL_QUEUE_SCOPED_PROBE_SQL, attach_honker_functions, bootstrap_honker_schema,
+        has_queue_scoped_cancel,
+    };
+    use rusqlite::Connection;
+    use rusqlite::functions::FunctionFlags;
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        attach_honker_functions(&conn).unwrap();
+        bootstrap_honker_schema(&conn).unwrap();
+        conn
+    }
+
+    fn enqueue(conn: &Connection, queue: &str) -> i64 {
+        conn.query_row(
+            "SELECT honker_enqueue(?1, '{}', NULL, NULL, 0, 3, NULL)",
+            [queue],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    /// The queue a live row sits in, or `None` if the row is gone.
+    /// Distinguishing "still there" from "deleted" is the whole point of
+    /// the wrong-queue tests, so they assert on this, not just on the
+    /// return count.
+    fn live_queue(conn: &Connection, id: i64) -> Option<String> {
+        conn.query_row("SELECT queue FROM _honker_live WHERE id = ?1", [id], |r| {
+            r.get(0)
+        })
+        .ok()
+    }
+
+    /// Both arities are callable on the SAME connection, under the SAME
+    /// name. This is the migration story: 1-arg callers keep working
+    /// while bindings move to the 2-arg form one release at a time.
+    #[test]
+    fn both_arities_coexist_on_one_connection() {
+        let conn = db();
+        let a = enqueue(&conn, "emails");
+        let b = enqueue(&conn, "sms");
+
+        let one_arg: i64 = conn
+            .query_row("SELECT honker_cancel(?1)", [a], |r| r.get(0))
+            .unwrap();
+        assert_eq!(one_arg, 1, "1-arg global cancel still resolves");
+
+        let two_arg: i64 = conn
+            .query_row("SELECT honker_cancel('sms', ?1)", [b], |r| r.get(0))
+            .unwrap();
+        assert_eq!(two_arg, 1, "2-arg scoped cancel resolves on the same conn");
+    }
+
+    /// The defect this closes: a handle for one queue must not delete
+    /// another queue's row, and the row must survive the attempt.
+    #[test]
+    fn wrong_queue_cancels_nothing_and_leaves_the_row() {
+        let conn = db();
+        let sms_id = enqueue(&conn, "sms");
+
+        let n: i64 = conn
+            .query_row("SELECT honker_cancel('emails', ?1)", [sms_id], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "emails handle must not cancel an sms job");
+        assert_eq!(
+            live_queue(&conn, sms_id).as_deref(),
+            Some("sms"),
+            "the sms row must still be live after a foreign-queue cancel"
+        );
+
+        let n: i64 = conn
+            .query_row("SELECT honker_cancel('sms', ?1)", [sms_id], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 1, "the owning queue can cancel it");
+        assert_eq!(live_queue(&conn, sms_id), None, "the row is gone");
+    }
+
+    /// Scoping must hold for a claimed (processing) row too, not just a
+    /// pending one — that is the row a racing worker is holding, and the
+    /// reason the queue check is inside the DELETE.
+    #[test]
+    fn scoping_holds_for_processing_rows() {
+        let conn = db();
+        let sms_id = enqueue(&conn, "sms");
+        let _: String = conn
+            .query_row("SELECT honker_claim_batch('sms', 'w1', 8, 300)", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM _honker_live WHERE id = ?1",
+                [sms_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "processing");
+
+        let n: i64 = conn
+            .query_row("SELECT honker_cancel('emails', ?1)", [sms_id], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "wrong queue must not cancel a processing row");
+        assert_eq!(
+            live_queue(&conn, sms_id).as_deref(),
+            Some("sms"),
+            "the processing sms row must still be live"
+        );
+    }
+
+    /// The 1-arg form keeps its shipped meaning: global, ignores the
+    /// queue. It becomes the documented `Database.cancel(id)` form. If
+    /// this ever fails, the migration broke every existing caller.
+    #[test]
+    fn one_arg_form_is_still_global() {
+        let conn = db();
+        let sms_id = enqueue(&conn, "sms");
+        let n: i64 = conn
+            .query_row("SELECT honker_cancel(?1)", [sms_id], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 1, "1-arg cancel reaches a job in any queue");
+        assert_eq!(live_queue(&conn, sms_id), None);
+    }
+
+    /// Idempotence and the missing-id case at the new arity: a second
+    /// cancel and an unknown id both return 0, same as the 1-arg form.
+    #[test]
+    fn repeat_and_missing_return_zero() {
+        let conn = db();
+        let id = enqueue(&conn, "emails");
+        let first: i64 = conn
+            .query_row("SELECT honker_cancel('emails', ?1)", [id], |r| r.get(0))
+            .unwrap();
+        let second: i64 = conn
+            .query_row("SELECT honker_cancel('emails', ?1)", [id], |r| r.get(0))
+            .unwrap();
+        let missing: i64 = conn
+            .query_row("SELECT honker_cancel('emails', 987654)", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!((first, second, missing), (1, 0, 0));
+    }
+
+    /// SQLite dispatches on (name, arity), so a wrong argument count is
+    /// a hard error rather than a silent fallback to the other form.
+    /// That is exactly why the capability probe below has to exist.
+    #[test]
+    fn unregistered_arity_is_an_error() {
+        let conn = db();
+        let err = conn
+            .query_row("SELECT honker_cancel('emails', 1, 2)", [], |r| {
+                r.get::<_, i64>(0)
+            })
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("wrong number of arguments"),
+            "expected an arity error, got: {err}"
+        );
+    }
+
+    /// A connection with the current functions attached reports the
+    /// queue-scoped form as present, through both the exported SQL
+    /// string and the Rust helper.
+    #[test]
+    fn probe_reports_true_with_the_two_arg_form() {
+        let conn = db();
+        assert!(
+            has_queue_scoped_cancel(&conn).unwrap(),
+            "helper must see honker_cancel/2 on a fully attached connection"
+        );
+        let raw: i64 = conn
+            .query_row(CANCEL_QUEUE_SCOPED_PROBE_SQL, [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(raw, 1, "the exported probe SQL must return 1");
+    }
+
+    /// The case the probe exists for: an older vendored extension that
+    /// registered only the global 1-arg `honker_cancel`. Registering
+    /// arity 1 by hand reproduces that connection exactly — the name is
+    /// present, the arity is not — and the probe must say false rather
+    /// than being fooled by the name.
+    #[test]
+    fn probe_reports_false_without_the_two_arg_form() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.create_scalar_function("honker_cancel", 1, FunctionFlags::SQLITE_UTF8, |_ctx| {
+            Ok(0i64)
+        })
+        .unwrap();
+
+        let present: i64 = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM pragma_function_list \
+                 WHERE name = 'honker_cancel' AND narg = 1)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(present, 1, "precondition: the 1-arg form is registered");
+
+        assert!(
+            !has_queue_scoped_cancel(&conn).unwrap(),
+            "helper must not report a queue-scoped cancel on an old extension"
+        );
+        let raw: i64 = conn
+            .query_row(CANCEL_QUEUE_SCOPED_PROBE_SQL, [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(raw, 0, "the exported probe SQL must return 0");
     }
 }

--- a/honker-core/src/lib.rs
+++ b/honker-core/src/lib.rs
@@ -42,6 +42,11 @@ mod kernel_watcher;
 mod shm_watcher;
 
 pub use honker_ops::attach_honker_functions;
+// Connect-time capability probe for the queue-scoped
+// `honker_cancel(queue, job_id)`. Bindings call this (or run the SQL
+// string themselves) to detect a vendored extension that only has the
+// older global 1-arg form.
+pub use honker_ops::{CANCEL_QUEUE_SCOPED_PROBE_SQL, has_queue_scoped_cancel};
 // Shared by the loadable extension's own watcher SQL functions so every
 // honker_* function coerces integer arguments the same way.
 pub use honker_ops::{arg_i64, arg_opt_i64};

--- a/scripts/proof/orm/surface.json
+++ b/scripts/proof/orm/surface.json
@@ -154,6 +154,49 @@
       "expect": {"kind": "json_len", "n": 0}
     },
     {
+      "id": "enqueue_cancel_scoped",
+      "sql": "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
+      "args": ["$ns:qcs", "{\"n\":2}", 0, 3],
+      "store": "job_cs",
+      "expect": {"kind": "int_gt", "n": 0}
+    },
+    {
+      "id": "cancel_scoped_wrong_queue",
+      "sql": "SELECT honker_cancel(?, ?)",
+      "args": ["$ns:qc", "$job_cs"],
+      "expect": {"kind": "int_eq", "n": 0}
+    },
+    {
+      "id": "get_after_wrong_queue_cancel",
+      "sql": "SELECT honker_get_job(?)",
+      "args": ["$job_cs"],
+      "expect": {"kind": "contains", "s": "$ns:qcs"}
+    },
+    {
+      "id": "cancel_scoped",
+      "sql": "SELECT honker_cancel(?, ?)",
+      "args": ["$ns:qcs", "$job_cs"],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
+      "id": "cancel_scoped_idempotent",
+      "sql": "SELECT honker_cancel(?, ?)",
+      "args": ["$ns:qcs", "$job_cs"],
+      "expect": {"kind": "int_eq", "n": 0}
+    },
+    {
+      "id": "get_cancelled_scoped",
+      "sql": "SELECT honker_get_job(?)",
+      "args": ["$job_cs"],
+      "expect": {"kind": "empty_string"}
+    },
+    {
+      "id": "cancel_capability_probe",
+      "sql": "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name = 'honker_cancel' AND narg = 2)",
+      "args": [],
+      "expect": {"kind": "int_eq", "n": 1}
+    },
+    {
       "id": "enqueue_b1",
       "sql": "SELECT honker_enqueue(?, ?, NULL, NULL, ?, ?, NULL)",
       "args": ["$ns:qb", "{\"i\":1}", 0, 3],

--- a/tests/test_extension_interop.py
+++ b/tests/test_extension_interop.py
@@ -885,3 +885,85 @@ def test_load_extension_names_the_real_problem_when_unsupported():
     message = str(excinfo.value)
     assert "SQLITE_ENABLE_LOAD_EXTENSION" in message
     assert "honker.open()" in message
+
+
+# --- queue-scoped cancel (issue #134) -------------------------------
+#
+# `honker_cancel` carries a global 1-arg form and a queue-scoped 2-arg
+# form. honker-core proves the semantics against rusqlite directly;
+# these two prove the same functions are really there over the
+# `.load libhonker_ext` path, which is how Go, Ruby, .NET, C++, Elixir
+# and Bun get them.
+
+
+@pytest.mark.skipif(_SKIP, reason=_SKIP_REASON)
+def test_extension_cancel_carries_both_arities(ext_db_path):
+    """Through the loaded extension: the 2-arg form refuses a job in
+    another queue and leaves the row alone, cancels one in its own
+    queue, and the 1-arg form still reaches any queue."""
+    conn = _open_ext(ext_db_path)
+    sms_id = conn.execute(
+        "SELECT honker_enqueue('sms', '{}', NULL, NULL, 0, 3, NULL)"
+    ).fetchone()[0]
+    email_id = conn.execute(
+        "SELECT honker_enqueue('emails', '{}', NULL, NULL, 0, 3, NULL)"
+    ).fetchone()[0]
+    conn.commit()
+
+    # Wrong queue: no-op, and the row is still live afterwards.
+    assert conn.execute(
+        "SELECT honker_cancel('emails', ?)", [sms_id]
+    ).fetchone()[0] == 0
+    assert conn.execute(
+        "SELECT queue FROM _honker_live WHERE id=?", [sms_id]
+    ).fetchone() == ("sms",)
+
+    # Own queue: cancels, and the row is gone.
+    assert conn.execute(
+        "SELECT honker_cancel('sms', ?)", [sms_id]
+    ).fetchone()[0] == 1
+    assert conn.execute(
+        "SELECT queue FROM _honker_live WHERE id=?", [sms_id]
+    ).fetchone() is None
+
+    # The 1-arg form is unchanged: global, no queue argument.
+    assert conn.execute(
+        "SELECT honker_cancel(?)", [email_id]
+    ).fetchone()[0] == 1
+    assert conn.execute(
+        "SELECT queue FROM _honker_live WHERE id=?", [email_id]
+    ).fetchone() is None
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.skipif(_SKIP, reason=_SKIP_REASON)
+def test_extension_capability_probe_detects_the_two_arg_cancel(ext_db_path):
+    """The connect-time probe a binding runs before trusting the 2-arg
+    form. Calling `honker_cancel` at an arity the loaded extension does
+    not have is a hard error, so a binding vendoring an older
+    libhonker_ext needs to find out at connect time, not at cancel time.
+
+    `pragma_function_list` reports each arity as its own row. The
+    negative case registers a 1-arg `honker_cancel` and nothing else,
+    standing in for that older extension: same name, missing arity."""
+    probe = (
+        "SELECT EXISTS(SELECT 1 FROM pragma_function_list "
+        "WHERE name = 'honker_cancel' AND narg = 2)"
+    )
+
+    conn = _open_ext(ext_db_path)
+    assert conn.execute(probe).fetchone()[0] == 1
+    conn.close()
+
+    old = sqlite3.connect(":memory:")
+    old.create_function("honker_cancel", 1, lambda job_id: 0)
+    assert old.execute(
+        "SELECT EXISTS(SELECT 1 FROM pragma_function_list "
+        "WHERE name = 'honker_cancel' AND narg = 1)"
+    ).fetchone()[0] == 1, "precondition: the 1-arg form is registered"
+    assert old.execute(probe).fetchone()[0] == 0
+    # And the arity mismatch it protects against is a hard error.
+    with pytest.raises(sqlite3.OperationalError, match="wrong number of arguments"):
+        old.execute("SELECT honker_cancel('emails', 1)")
+    old.close()


### PR DESCRIPTION
Core half of #134. No binding touched — the nine binding PRs wire this up in a second pass.

## What lands

- `honker_cancel(queue, job_id)` registered next to the existing `honker_cancel(job_id)`.
  The scoped form removes a pending or processing row only if it is in that queue; a job
  in another queue returns 0, the same answer an already-ack'd id gives.
- The queue check is inside the DELETE: `WHERE queue = ?1 AND id = ?2 AND state IN (...)`.
  Not a `SELECT` then a `DELETE` — that leaves a window for a concurrent claim to change
  the row between the two statements.
- `honker_cancel/1` is unchanged. SQLite dispatches on (name, arity), so both forms live
  on one connection; the 1-arg form becomes the global `Database.cancel(id)` and bindings
  migrate one package at a time instead of in lockstep.
- Connect-time capability probe: `honker_core::has_queue_scoped_cancel(&conn)` and the
  `CANCEL_QUEUE_SCOPED_PROBE_SQL` string behind it. A wrong arity is a hard SQLite error,
  not a fallback, and there is no `honker_version()`, so a binding built for the 2-arg
  form against an older vendored `libhonker_ext` would fail at cancel time in production.
  `pragma_function_list` reports each arity as its own row. SQL-over-extension bindings
  (Go, Ruby, .NET, C++, Elixir, Bun) run the string verbatim; Rust-side bindings call the
  helper. Errors propagate rather than being flattened to "absent".
- CHANGELOG entry. No version bumped.

Nothing existing changes behavior: every current caller still hits `honker_cancel(job_id)`.

## Tests

8 in `honker-core` against rusqlite, 2 in `tests/test_extension_interop.py` through the
real `.load libhonker_ext` path — the path Go, Ruby, .NET, C++, Elixir and Bun use.
`honker-core --lib`: 63 passed, 0 failed. `test_extension_interop.py`: 33 passed.

## Load-bearing proof

Each behavior broken, its test watched fail, then restored.

**1. Queue check removed** (`queue = ?1` → `?1 IS NOT NULL`)

```
wrong_queue_cancels_nothing_and_leaves_the_row FAILED
  assertion `left == right` failed: emails handle must not cancel an sms job
    left: 1
   right: 0
scoping_holds_for_processing_rows FAILED
  assertion `left == right` failed: wrong queue must not cancel a processing row
    left: 1
   right: 0
```
Through the loaded extension: `assert conn.execute("SELECT honker_cancel('emails', ?)", [sms_id]).fetchone()[0] == 0` → `assert 1 == 0`.

**2. `honker_cancel/1` unregistered**

```
one_arg_form_is_still_global FAILED
  called `Result::unwrap()` on an `Err` value: SqliteFailure(...,
  Some("wrong number of arguments to function honker_cancel()"))
both_arities_coexist_on_one_connection FAILED   (same error)
```
Through the loaded extension: `sqlite3.OperationalError: wrong number of arguments to function honker_cancel()`.

**3. `honker_cancel/2` unregistered** — 5 of 8 fail:

```
both_arities_coexist_on_one_connection FAILED
wrong_queue_cancels_nothing_and_leaves_the_row FAILED
scoping_holds_for_processing_rows FAILED
repeat_and_missing_return_zero FAILED
  ... Some("wrong number of arguments to function honker_cancel()")
probe_reports_true_with_the_two_arg_form FAILED
  helper must see honker_cancel/2 on a fully attached connection
```
Through the loaded extension: `assert conn.execute(probe).fetchone()[0] == 1` → `assert 0 == 1`.

**4. Probe queries the wrong arity** (`narg = 2` → `narg = 1`)

```
probe_reports_false_without_the_two_arg_form FAILED
  helper must not report a queue-scoped cancel on an old extension
```
Through the loaded extension: `assert old.execute(probe).fetchone()[0] == 0` → `assert 1 == 0`.
Note that `probe_reports_true_with_the_two_arg_form` still passed under this mutation —
the positive case alone cannot catch a probe that matches on name and ignores arity. That
is why the negative test registers a 1-arg-only `honker_cancel` (standing in for an older
extension: right name, missing arity) instead of using a bare connection.

Closes #134's core half.

https://claude.ai/code/session_01YMCFasvKC52r37DDKSTeMC